### PR TITLE
[PB-1075]: Properly cleanup tmp files after upload/download

### DIFF
--- a/InternxtDesktop.xcodeproj/project.pbxproj
+++ b/InternxtDesktop.xcodeproj/project.pbxproj
@@ -149,6 +149,7 @@
 		E1ADD04F2AA8D54E00D95694 /* RealtimeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1ADD04E2AA8D54E00D95694 /* RealtimeService.swift */; };
 		E1ADD0522AA8D68D00D95694 /* SocketIO in Frameworks */ = {isa = PBXBuildFile; productRef = E1ADD0512AA8D68D00D95694 /* SocketIO */; };
 		E1BE23612AB0A06A00EAB152 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E1FB2D2B2A76BF0300473AE1 /* Assets.xcassets */; };
+		E1C56E232AE19A5100C0EC06 /* URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = E106D4612AB9FD6300E3BF7A /* URL.swift */; };
 		E1CC520A2A97DE85009DEEAA /* DeleteFileOrFolderUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1CC52092A97DE85009DEEAA /* DeleteFileOrFolderUseCase.swift */; };
 		E1CC520C2A98B460009DEEAA /* Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1CC520B2A98B460009DEEAA /* Bundle.swift */; };
 		E1CC520D2A98B460009DEEAA /* Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1CC520B2A98B460009DEEAA /* Bundle.swift */; };
@@ -1119,6 +1120,7 @@
 				E145E17C2A83A1DA00B07E0B /* RenameFolderUseCase.swift in Sources */,
 				E190AC4B2AB0BDEC00F7B69C /* FileProviderItemActionsManager.swift in Sources */,
 				E145E16F2A82ABEB00B07E0B /* TrashFolderUseCase.swift in Sources */,
+				E1C56E232AE19A5100C0EC06 /* URL.swift in Sources */,
 				E10B0FDA2A9411C900B97874 /* AuthManager.swift in Sources */,
 				E109717F2A81143A00ABED41 /* APIFactory.swift in Sources */,
 				E1CC520A2A97DE85009DEEAA /* DeleteFileOrFolderUseCase.swift in Sources */,
@@ -1249,7 +1251,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 28;
+				CURRENT_PROJECT_VERSION = 29;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"InternxtDesktop/Preview Content\"";
 				DEVELOPMENT_TEAM = JR4S3SY396;
@@ -1266,7 +1268,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 2.0.1;
+				MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = internxt.InternxtDesktop;
 				PRODUCT_MODULE_NAME = Internxt;
 				PRODUCT_NAME = "Internxt Drive";
@@ -1319,7 +1321,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = SyncExtension/SyncExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 28;
+				CURRENT_PROJECT_VERSION = 29;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = JR4S3SY396;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -1333,7 +1335,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 2.0.1;
+				MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = internxt.InternxtDesktop.sync;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1477,7 +1479,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 28;
+				CURRENT_PROJECT_VERSION = 29;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"InternxtDesktop/Preview Content\"";
 				DEVELOPMENT_TEAM = JR4S3SY396;
@@ -1494,7 +1496,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 2.0.1;
+				MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = internxt.InternxtDesktop;
 				PRODUCT_MODULE_NAME = Internxt;
 				PRODUCT_NAME = "Internxt Drive";
@@ -1514,7 +1516,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 28;
+				CURRENT_PROJECT_VERSION = 29;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"InternxtDesktop/Preview Content\"";
 				DEVELOPMENT_TEAM = JR4S3SY396;
@@ -1531,7 +1533,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 2.0.1;
+				MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = internxt.InternxtDesktop;
 				PRODUCT_MODULE_NAME = Internxt;
 				PRODUCT_NAME = "Internxt Drive";
@@ -1622,7 +1624,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = SyncExtension/SyncExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 28;
+				CURRENT_PROJECT_VERSION = 29;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = JR4S3SY396;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -1636,7 +1638,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 2.0.1;
+				MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = internxt.InternxtDesktop.sync;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1650,7 +1652,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = SyncExtension/SyncExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 28;
+				CURRENT_PROJECT_VERSION = 29;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = JR4S3SY396;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -1664,7 +1666,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 2.0.1;
+				MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = internxt.InternxtDesktop.sync;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/InternxtDesktop.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/InternxtDesktop.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -96,7 +96,7 @@
       "location" : "https://github.com/internxt/swift-core",
       "state" : {
         "branch" : "main",
-        "revision" : "3989f687959a2d07e569e6552c03cc1c33a665fb"
+        "revision" : "78552916a01fa69e70ba1ddf1b444d885e1212b7"
       }
     }
   ],

--- a/InternxtDesktop.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/InternxtDesktop.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,7 +15,7 @@
       "location" : "https://github.com/sindresorhus/LaunchAtLogin",
       "state" : {
         "branch" : "main",
-        "revision" : "8e28b5e5a9561ace33a26c55d78f74963fbce6f9"
+        "revision" : "d811817ce35d74872a1170c851cab243a2b8b559"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/realm/realm-core.git",
       "state" : {
-        "revision" : "1eb93c9619f6a05b5a91c2719690606016802e0b",
-        "version" : "13.20.1"
+        "revision" : "c569bec4d04da84030d94f376437bc4efda3686b",
+        "version" : "13.23.1"
       }
     },
     {
@@ -33,7 +33,7 @@
       "location" : "https://github.com/realm/realm-swift.git",
       "state" : {
         "branch" : "master",
-        "revision" : "987523254e28254652cab86b4e558a96231bbfe3"
+        "revision" : "f485d2a3bbfaf92186c52ff6d7fa32c924338cf2"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa",
       "state" : {
-        "revision" : "12998398eb51e2e8ff7098163fa97d305eee6d87",
-        "version" : "8.11.0"
+        "revision" : "2889f06002ef4f4cb3ec983da42a706e1d0124e5",
+        "version" : "8.14.1"
       }
     },
     {
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle",
       "state" : {
-        "revision" : "f0ceaf5cc9f3f23daa0ccb6dcebd79fc96ccc7d9",
-        "version" : "2.5.0"
+        "revision" : "1f07f4096e52f19b5e7abaa697b7fc592b7ff57c",
+        "version" : "2.5.1"
       }
     },
     {
@@ -96,7 +96,7 @@
       "location" : "https://github.com/internxt/swift-core",
       "state" : {
         "branch" : "main",
-        "revision" : "5605887b7f30b3473f2a5eea00a3122ccfdfb2d5"
+        "revision" : "3989f687959a2d07e569e6552c03cc1c33a665fb"
       }
     }
   ],

--- a/InternxtDesktop/AppDelegate.swift
+++ b/InternxtDesktop/AppDelegate.swift
@@ -101,7 +101,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
            
         })
-        if self.updaterController.updater.canCheckForUpdates == true {
+        if ConfigLoader.isDevMode == false && self.updaterController.updater.canCheckForUpdates == true {
             self.updaterController.updater.checkForUpdatesInBackground()
         }
         

--- a/InternxtDesktop/Services/UsageManager.swift
+++ b/InternxtDesktop/Services/UsageManager.swift
@@ -10,6 +10,7 @@ import Foundation
 
 class UsageManager: ObservableObject {
     
+    @Published var loadingUsage: Bool = true
     @Published var usageError: Error? = nil
     // Just to avoid accidentally dividing by 0
     @Published var limit: Int64 = 1
@@ -27,6 +28,9 @@ class UsageManager: ObservableObject {
     
     public func updateUsage() async {
         do {
+            DispatchQueue.main.sync {
+                self.loadingUsage = true
+            }
             let limit = try await APIFactory.Drive.getLimit()
             
             let driveUsage = try await APIFactory.Drive.getUsage()
@@ -37,6 +41,7 @@ class UsageManager: ObservableObject {
                 self.driveUsage = driveUsage.drive
                 self.backupsUsage = driveUsage.backups
                 self.photosUsage = photosUsage.usage
+                self.loadingUsage = false
             }
             
             
@@ -44,6 +49,7 @@ class UsageManager: ObservableObject {
             error.reportToSentry()
             DispatchQueue.main.async {
                 self.usageError = error
+                self.loadingUsage = false
             }
         }
     }

--- a/InternxtDesktop/Views/Settings/AccountUsageView.swift
+++ b/InternxtDesktop/Views/Settings/AccountUsageView.swift
@@ -13,27 +13,36 @@ struct AccountUsageView: View {
     @EnvironmentObject var usageManager: UsageManager
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            HStack(alignment: .center, spacing: 0) {
-                CurrentPlanSpace()
-                Spacer()
-                AppButton(title: "COMMON_UPGRADE", onClick: handleOpenUpgradePlan)
-            }.padding(.bottom, 20)
-            HStack {
-                Text("COMMON_USAGE_\(usageManager.getFormattedTotalUsage())_OF_\(usageManager.format(bytes: usageManager.limit))").font(.BaseRegular)
-                    .foregroundColor(.Gray100)
-                Spacer()
-                AppText("\(usageManager.getUsedPercentage())")
-                    .font(.BaseRegular)
-                    .foregroundColor(.Gray50)
+            if(usageManager.loadingUsage == true && usageManager.limit == 1) {
+                HStack(alignment: .center,spacing: 8) {
+                    ProgressView().progressViewStyle(.circular).controlSize(.small)
+                    AppText("USAGE_LOADING").font(.BaseMedium)
+                       .foregroundColor(.Gray50)
+                }.frame(height: 140)
+            } else {
+                HStack(alignment: .center, spacing: 0) {
+                    CurrentPlanSpace()
+                    Spacer()
+                    AppButton(title: "COMMON_UPGRADE", onClick: handleOpenUpgradePlan)
+                }.padding(.bottom, 20)
+                HStack {
+                    Text("COMMON_USAGE_\(usageManager.getFormattedTotalUsage())_OF_\(usageManager.format(bytes: usageManager.limit))").font(.BaseRegular)
+                        .foregroundColor(.Gray100)
+                    Spacer()
+                    AppText("\(usageManager.getUsedPercentage())")
+                        .font(.BaseRegular)
+                        .foregroundColor(.Gray50)
+                }
+                
+                
+                UsageBar().cornerRadius(6).padding(.vertical, 8)
+                HStack(alignment: .center, spacing: 16) {
+                    UsageLegendItem(label: "Drive", color: .Primary)
+                    UsageLegendItem(label: "Backups", color: .Indigo)
+                    UsageLegendItem(label: "Photos", color: .Orange)
+                }
             }
             
-            
-            UsageBar().cornerRadius(6).padding(.vertical, 8)
-            HStack(alignment: .center, spacing: 16) {
-                UsageLegendItem(label: "Drive", color: .Primary)
-                UsageLegendItem(label: "Backups", color: .Indigo)
-                UsageLegendItem(label: "Photos", color: .Orange)
-            }
         }
         
         .padding(20)

--- a/InternxtDesktop/Views/Widget/WidgetHeaderView.swift
+++ b/InternxtDesktop/Views/Widget/WidgetHeaderView.swift
@@ -64,8 +64,18 @@ struct WidgetHeaderView: View {
                 .foregroundColor(.Gray100)
                 .lineLimit(1)
                 .help(user?.email ?? "No user found")
-            Text("COMMON_USAGE_\(usageManager.getFormattedTotalUsage())_OF_\(usageManager.format(bytes: usageManager.limit))").font(.XSMedium)
-                .foregroundColor(.Gray50)
+            if(self.usageManager.loadingUsage == true && usageManager.limit == 1) {
+                HStack(alignment: .center,spacing: 4) {
+                    ProgressView().progressViewStyle(.circular).controlSize(.mini)
+                    AppText("USAGE_LOADING").font(.XSMedium)
+                       .foregroundColor(.Gray50)
+                }
+            } else {
+                Text("COMMON_USAGE_\(usageManager.getFormattedTotalUsage())_OF_\(usageManager.format(bytes: usageManager.limit))").font(.XSMedium)
+                   .foregroundColor(.Gray50)
+                
+                
+            }
         }
         
     }

--- a/InternxtDesktop/Windows.swift
+++ b/InternxtDesktop/Windows.swift
@@ -31,7 +31,8 @@ func defaultWindows(authManager: AuthManager, usageManager: UsageManager, update
             title: "Internxt Drive",
             id: "settings",
             width: 400,
-            height: 290
+            height: 290,
+            backgroundColor: Color.Gray5
         ),
         WindowConfig(
             view: AnyView(OnboardingView(finishOrSkipOnboarding: finishOrSkipOnboarding)),

--- a/Shared/Extensions/URL.swift
+++ b/Shared/Extensions/URL.swift
@@ -8,8 +8,62 @@
 import Foundation
 import SwiftUI
 
+struct URLFileAttribute {
+    private(set) var fileSize: UInt? = nil
+    private(set) var creationDate: Date? = nil
+    private(set) var modificationDate: Date? = nil
+
+    init(url: URL) {
+        let path = url.path
+        guard let dictionary: [FileAttributeKey: Any] = try? FileManager.default
+                .attributesOfItem(atPath: path) else {
+            return
+        }
+
+        if dictionary.keys.contains(FileAttributeKey.size),
+            let value = dictionary[FileAttributeKey.size] as? UInt {
+            self.fileSize = value
+        }
+
+        if dictionary.keys.contains(FileAttributeKey.creationDate),
+            let value = dictionary[FileAttributeKey.creationDate] as? Date {
+            self.creationDate = value
+        }
+
+        if dictionary.keys.contains(FileAttributeKey.modificationDate),
+            let value = dictionary[FileAttributeKey.modificationDate] as? Date {
+            self.modificationDate = value
+        }
+    }
+}
+
 extension URL {
     func open() {
         NSWorkspace.shared.open(self)
     }
+    
+    public func directoryContents() -> [URL] {
+            do {
+                let directoryContents = try FileManager.default.contentsOfDirectory(at: self, includingPropertiesForKeys: nil)
+                return directoryContents
+            } catch let error {
+                print("Error while getting directory content: \(error)")
+                return []
+            }
+        }
+
+      public func getFolderSize() -> UInt {
+            let contents = self.directoryContents()
+            var totalSize: UInt = 0
+            contents.forEach { url in
+                let size = url.getFileSize()
+                totalSize += size
+            }
+            return totalSize
+        }
+
+        public func getFileSize() -> UInt {
+            let attributes = URLFileAttribute(url: self)
+            return attributes.fileSize ?? 0
+        }
 }

--- a/Shared/en.lproj/Localizable.strings
+++ b/Shared/en.lproj/Localizable.strings
@@ -51,6 +51,9 @@
 "COMMON_USAGE_%@_OF_%@" = "Using %@ of %@";
 "COMMON_CLOSE" = "Close";
 
+// Usage
+"USAGE_LOADING" = "Loading your usage";
+
 // Context menu actions
 "CONTEXT_MENU_AVAILABLE_OFFLINE" = "Make Available Offline";
 "CONTEXT_MENU_AVAILABLE_ONLINE_ONLY" = "Make Online Only";

--- a/Shared/es.lproj/Localizable.strings
+++ b/Shared/es.lproj/Localizable.strings
@@ -51,6 +51,9 @@
 "COMMON_USAGE_%@_OF_%@" = "Usado %@ de %@";
 "COMMON_CLOSE" = "Cerrar";
 
+// Usage
+"USAGE_LOADING" = "Cargando espacio usado";
+
 // Context menu actions
 "CONTEXT_MENU_AVAILABLE_OFFLINE" = "Cambiar a disponible offline";
 "CONTEXT_MENU_AVAILABLE_ONLINE_ONLY" = "Cambiar a disponible sólo online";

--- a/Shared/fr.lproj/Localizable.strings
+++ b/Shared/fr.lproj/Localizable.strings
@@ -51,6 +51,9 @@
 "COMMON_USAGE_%@_OF_%@" = "Utilisation de %@ de %@";
 "COMMON_CLOSE" = "Fermer" ;
 
+// Usage
+"USAGE_LOADING" = "Chargement de l'espace";
+
 // Context menu actions
 "CONTEXT_MENU_AVAILABLE_OFFLINE" = "Rendre disponible hors ligne";
 "CONTEXT_MENU_AVAILABLE_ONLINE_ONLY" = "Rendre disponible en ligne uniquement";

--- a/SyncExtension/UseCases/Files/FetchFileContentUseCase.swift
+++ b/SyncExtension/UseCases/Files/FetchFileContentUseCase.swift
@@ -79,7 +79,6 @@ struct FetchFileContentUseCase {
                 self.logger.info("Fetching file \(fileProviderItem.itemIdentifier.rawValue) inside of \(fileProviderItem.parentItemIdentifier.rawValue)")
                 
                 completionHandler(decryptedFileURL, fileProviderItem , nil)
-                throw FileProviderError.DomainNotLoaded
                 // Finish
                 progressHandler(completedProgress: 1)
                 activityManager.saveActivityEntry(entry: ActivityEntry(filename: filename, kind: .download, status: .finished))

--- a/SyncExtension/UseCases/Files/FetchFileContentUseCase.swift
+++ b/SyncExtension/UseCases/Files/FetchFileContentUseCase.swift
@@ -79,6 +79,7 @@ struct FetchFileContentUseCase {
                 self.logger.info("Fetching file \(fileProviderItem.itemIdentifier.rawValue) inside of \(fileProviderItem.parentItemIdentifier.rawValue)")
                 
                 completionHandler(decryptedFileURL, fileProviderItem , nil)
+                throw FileProviderError.DomainNotLoaded
                 // Finish
                 progressHandler(completedProgress: 1)
                 activityManager.saveActivityEntry(entry: ActivityEntry(filename: filename, kind: .download, status: .finished))


### PR DESCRIPTION
This PR adds a system to cleanup TMP files when:

- An upload finishes (either successfully or not)
- A download finishes (either successfully or not)
- The sync extension launches, it deletes all the tmp files in the directory (this happens before any other operation)