### PR TITLE
[PB-1197](fix): Thumbnails generation correctly before completing the upload

### DIFF
--- a/InternxtDesktop.xcodeproj/project.pbxproj
+++ b/InternxtDesktop.xcodeproj/project.pbxproj
@@ -1090,7 +1090,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 31;
+				CURRENT_PROJECT_VERSION = 32;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"InternxtDesktop/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
@@ -1290,7 +1290,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 31;
+				CURRENT_PROJECT_VERSION = 32;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"InternxtDesktop/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
@@ -1331,7 +1331,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 31;
+				CURRENT_PROJECT_VERSION = 32;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"InternxtDesktop/Preview Content\"";
 				DEVELOPMENT_TEAM = "";

--- a/InternxtDesktop/Views/Auth/SignInWithBrowserView.swift
+++ b/InternxtDesktop/Views/Auth/SignInWithBrowserView.swift
@@ -8,11 +8,10 @@
 import SwiftUI
 
 struct SignInWithBrowserView: View {
-
- 
+    
+    
     var body: some View {
-        AppSettingsManagerView {
-            Color.Surface
+        Color.Surface
             .ignoresSafeArea(.all)
             .overlay(
                 VStack(alignment: .center, spacing: 0) {
@@ -37,9 +36,8 @@ struct SignInWithBrowserView: View {
                         
                     }.padding(.top, 24)
                 }
-                .frame(width: 300)
+                    .frame(width: 300)
             )
-        }
     }
     
     func openSignUpUrl() {

--- a/InternxtDesktop/Views/Onboarding/OnboardingView.swift
+++ b/InternxtDesktop/Views/Onboarding/OnboardingView.swift
@@ -12,29 +12,28 @@ struct OnboardingView: View {
     public let totalSlides = 5
     @State var currentSlideIndex = 0
     var body: some View {
-        AppSettingsManagerView {
-            HStack(alignment: .top,spacing: 0){
-                VStack(alignment: .leading,spacing:0) {
-                    CurrentSlideView.transition(.onboardingText)
-                }
-                .padding(.top, 64)
-                .padding(.horizontal, 32)
-                .padding(.bottom, 32)
-                .frame(minWidth: 0, maxWidth: .infinity,minHeight: 0, maxHeight: .infinity)
-                .background(Color.Gray1)
-                
-                Divider()
-                    .frame(maxWidth: 1, maxHeight: .infinity)
-                    .overlay(Color.Gray10)
-                    .zIndex(5)
-                HStack(alignment: .top) {
-                    CurrentSlideImage
-                        .transition(.onboardingImage)
-                }
-                .frame(maxWidth: 400, maxHeight: .infinity, alignment: .topLeading)
-                .background(Color.Gray5)
+        HStack(alignment: .top,spacing: 0){
+            VStack(alignment: .leading,spacing:0) {
+                CurrentSlideView.transition(.onboardingText)
             }
+            .padding(.top, 64)
+            .padding(.horizontal, 32)
+            .padding(.bottom, 32)
+            .frame(minWidth: 0, maxWidth: .infinity,minHeight: 0, maxHeight: .infinity)
+            .background(Color.Gray1)
+            
+            Divider()
+                .frame(maxWidth: 1, maxHeight: .infinity)
+                .overlay(Color.Gray10)
+                .zIndex(5)
+            HStack(alignment: .top) {
+                CurrentSlideImage
+                    .transition(.onboardingImage)
+            }
+            .frame(maxWidth: 400, maxHeight: .infinity, alignment: .topLeading)
+            .background(Color.Gray5)
         }
+        
     }
     
     @ViewBuilder
@@ -95,7 +94,7 @@ struct OnboardingView: View {
                     .scaledToFit().frame(width: 204)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-
+            
         default:
             EmptyView()
         }

--- a/InternxtDesktop/Views/SendFeedback/SendFeedbackView.swift
+++ b/InternxtDesktop/Views/SendFeedback/SendFeedbackView.swift
@@ -18,7 +18,6 @@ struct SendFeedbackView: View {
         self.closeWindow = closeWindow
     }
     var body: some View {
-        AppSettingsManagerView{
             VStack(alignment: .leading, spacing: 0){
                 if feedbackSent {
                     VStack(alignment: .center, spacing: 0){
@@ -56,7 +55,6 @@ struct SendFeedbackView: View {
                 
                 charactersCount = feedback.count
             })
-        }
     }
     
     func handleSendFeedback() {

--- a/InternxtDesktop/Views/Settings/SettingsView.swift
+++ b/InternxtDesktop/Views/Settings/SettingsView.swift
@@ -19,23 +19,21 @@ struct SettingsView: View {
     @State var focusedTab: TabView = .General
     public var updater: SPUUpdater? = nil
     var body: some View {
-        AppSettingsManagerView {
-            VStack(alignment: .leading, spacing: 0) {
-                VStack(spacing: 0) {
-                    HStack(spacing: 4) {
-                        TabItem(iconName: .Gear, label: "SETTINGS_TAB_GENERAL_TITLE", id: .General)
-                        TabItem(iconName: .At, label: "SETTINGS_TAB_ACCOUNT_TITLE", id: .Account)
-                    }
-                    .frame(maxWidth: .infinity)
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 6)
-                    .background(colorScheme == .dark ? Color.Gray5 :  Color.Surface)
-                    Divider().frame(maxWidth: .infinity, maxHeight: 1).overlay(Color.Gray10).zIndex(5)
+        VStack(alignment: .leading, spacing: 0) {
+            VStack(spacing: 0) {
+                HStack(spacing: 4) {
+                    TabItem(iconName: .Gear, label: "SETTINGS_TAB_GENERAL_TITLE", id: .General)
+                    TabItem(iconName: .At, label: "SETTINGS_TAB_ACCOUNT_TITLE", id: .Account)
                 }
-                
-                Tabcontent.background(Color.Gray1)
-            }.frame(width: 440, alignment: .topLeading)
-        }
+                .frame(maxWidth: .infinity)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                .background(colorScheme == .dark ? Color.Gray5 :  Color.Surface)
+                Divider().frame(maxWidth: .infinity, maxHeight: 1).overlay(Color.Gray10).zIndex(5)
+            }
+            
+            Tabcontent.background(Color.Gray1)
+        }.frame(width: 440, alignment: .topLeading)
     }
     
     @ViewBuilder
@@ -65,7 +63,7 @@ struct SettingsView: View {
         .cornerRadius(8)
         .contentShape(Rectangle())
         .onTapGesture {
-                focusedTab = id
+            focusedTab = id
         }
     }
 }

--- a/InternxtDesktop/Windows.swift
+++ b/InternxtDesktop/Windows.swift
@@ -16,7 +16,7 @@ import Sparkle
 func defaultWindows(authManager: AuthManager, usageManager: UsageManager, updater: SPUUpdater, closeSendFeedbackWindow: @escaping () -> Void, finishOrSkipOnboarding: @escaping () -> Void) -> [WindowConfig] {
     let windows = [
         WindowConfig(
-            view: AnyView(SignInWithBrowserView().environmentObject(authManager)),
+            view: AnyView(AppSettingsManagerView{SignInWithBrowserView().environmentObject(authManager)}),
             title: nil,
             id: "auth",
             width: 480,
@@ -24,10 +24,10 @@ func defaultWindows(authManager: AuthManager, usageManager: UsageManager, update
             fixedToFront: false
         ),
         WindowConfig(
-            view:  AnyView(SettingsView(updater: updater)
-                .environmentObject(authManager)
-                .environmentObject(usageManager)
-            ),
+            view:  AnyView(AppSettingsManagerView{ SettingsView(updater: updater)
+                    .environmentObject(authManager)
+                    .environmentObject(usageManager)
+            }),
             title: "Internxt Drive",
             id: "settings",
             width: 400,
@@ -35,13 +35,13 @@ func defaultWindows(authManager: AuthManager, usageManager: UsageManager, update
             backgroundColor: Color.Gray5
         ),
         WindowConfig(
-            view: AnyView(OnboardingView(finishOrSkipOnboarding: finishOrSkipOnboarding)),
+            view: AnyView(AppSettingsManagerView { OnboardingView(finishOrSkipOnboarding: finishOrSkipOnboarding) }),
             id: "onboarding",
             width: 800,
             height: 470
         ),
         WindowConfig(
-            view: AnyView(SendFeedbackView(closeWindow: closeSendFeedbackWindow )),
+            view: AnyView(AppSettingsManagerView { SendFeedbackView(closeWindow: closeSendFeedbackWindow ) }),
             title: "Internxt Desktop Feedback",
             id: "send-feedback",
             width: 380,

--- a/SyncExtension/FileProviderExtension.swift
+++ b/SyncExtension/FileProviderExtension.swift
@@ -265,15 +265,6 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension, NSFile
                 do {
                     try FileManager.default.removeItem(at: fileCopy)
                     try FileManager.default.removeItem(at: encryptedFileDestination)
-                } catch {
-                    error.reportToSentry()
-                }
-                
-            }
-            
-            func thumbnailCompletionHandler(_ error:Error?) -> Void {
-                
-                do {
                     try FileManager.default.removeItem(at: encryptedThumbnailFileDestination)
                     try FileManager.default.removeItem(at: thumbnailFileDestination)
                 } catch {
@@ -281,6 +272,8 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension, NSFile
                 }
                 
             }
+            
+           
             return UploadFileUseCase(
                 networkFacade: networkFacade,
                 user: user,
@@ -290,8 +283,7 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension, NSFile
                 encryptedFileDestination: encryptedFileDestination,
                 thumbnailFileDestination: thumbnailFileDestination,
                 encryptedThumbnailFileDestination: encryptedThumbnailFileDestination,
-                completionHandler: completionHandlerInternal,
-                thumbnailGenerationCompletionHandler: thumbnailCompletionHandler
+                completionHandler: completionHandlerInternal
             ).run()
         }
         

--- a/SyncExtension/UseCases/Files/UploadFileUseCase.swift
+++ b/SyncExtension/UseCases/Files/UploadFileUseCase.swift
@@ -29,7 +29,6 @@ struct UploadFileUseCase {
     private let fileContent: URL
     private let networkFacade: NetworkFacade
     private let completionHandler: (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void
-    private let thumbnailGenerationCompletionHandler: (Error?) -> Void
     private let driveAPI = APIFactory.Drive
     private let config = ConfigLoader().get()
     private let user: DriveUser
@@ -44,8 +43,7 @@ struct UploadFileUseCase {
         encryptedFileDestination: URL,
         thumbnailFileDestination:URL,
         encryptedThumbnailFileDestination: URL,
-        completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void,
-        thumbnailGenerationCompletionHandler: @escaping (Error?) -> Void
+        completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void
     ) {
         self.item = item
         self.activityManager = activityManager
@@ -56,7 +54,6 @@ struct UploadFileUseCase {
         self.completionHandler = completionHandler
         self.networkFacade = networkFacade
         self.user = user
-        self.thumbnailGenerationCompletionHandler = thumbnailGenerationCompletionHandler
     }
     
    
@@ -205,10 +202,8 @@ struct UploadFileUseCase {
                 
                 if let thumbnailUploadUnwrapped = thumbnailUpload {
                     self.logger.info("✅ Thumbnail uploaded with fileId \(thumbnailUploadUnwrapped.fileId)...")
-                    self.thumbnailGenerationCompletionHandler(nil)
                 } else {
                     self.logger.info("❌ Thumbnail uploaded failed")
-                    self.thumbnailGenerationCompletionHandler(nil)
                 }
                 
                 completionHandler(fileProviderItem, [], false, nil )
@@ -220,7 +215,6 @@ struct UploadFileUseCase {
                 
                 self.logger.error("❌ Failed to create file: \(error.localizedDescription)")
                 completionHandler(nil, [], false, NSError(domain: NSFileProviderErrorDomain, code: NSFileProviderError.serverUnreachable.rawValue))
-                self.thumbnailGenerationCompletionHandler(error)
             }
         }
         

--- a/SyncExtension/UseCases/Files/UploadFileUseCase.swift
+++ b/SyncExtension/UseCases/Files/UploadFileUseCase.swift
@@ -191,8 +191,6 @@ struct UploadFileUseCase {
                 
                 self.trackEnd(processIdentifier: trackId, startedAt: startedAt)
                 
-                completionHandler(fileProviderItem, [], false, nil )
-                activityManager.saveActivityEntry(entry: ActivityEntry(filename: FileProviderItem.getFilename(name: createdFile.plain_name ?? createdFile.name, itemExtension: createdFile.type), kind: .upload, status: .finished))
                 self.logger.info("✅ Created file correctly with identifier \(fileProviderItem.itemIdentifier.rawValue)")
                 
                 self.logger.info("🖼️ Processing thumbnail...")
@@ -213,9 +211,13 @@ struct UploadFileUseCase {
                     self.thumbnailGenerationCompletionHandler(nil)
                 }
                 
+                completionHandler(fileProviderItem, [], false, nil )
+                activityManager.saveActivityEntry(entry: ActivityEntry(filename: FileProviderItem.getFilename(name: createdFile.plain_name ?? createdFile.name, itemExtension: createdFile.type), kind: .upload, status: .finished))
+                
             } catch {
                 self.trackError(processIdentifier: trackId, error: error)
                 error.reportToSentry()
+                
                 self.logger.error("❌ Failed to create file: \(error.localizedDescription)")
                 completionHandler(nil, [], false, NSError(domain: NSFileProviderErrorDomain, code: NSFileProviderError.serverUnreachable.rawValue))
                 self.thumbnailGenerationCompletionHandler(error)
@@ -223,6 +225,10 @@ struct UploadFileUseCase {
         }
         
         return progress
+    }
+    
+    func patchFileContent() -> Void {
+        
     }
     
     func generateAndUploadThumbnail(driveItemId: Int, fileURL: URL, destinationURL: URL, encryptedThumbnailDestination: URL) async -> CreateThumbnailResponse? {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -97,9 +97,9 @@ platform :mac do
 
 
     # Send an slack message with the new DMG ready
-
+    # TODO: Add changelog and latest changes from previous release
     slack(
-      pretext: "Drive Desktop MacOS v#{version} is ready for QA\n<#{dmg_download_url}|Download DMG Installer>",
+      pretext: "Drive Desktop MacOS v#{version} is ready for QA\n<#{dmg_download_url}|Download DMG Installer>\n\nInstructions:\nLogout and then uninstall totally the previous app version to prevent unpredictable effects",
       slack_url: ENV["SLACK_WEBHOOK_MAC_TEAM"]
     )
 


### PR DESCRIPTION
This PR modifies how we generate the thumbails for uploaded files, instead of completing the upload and then generate the thumbnail, now we wait until the thumbnail is generated before completing the upload so the OS does not finish the process that is running the operation