### PR TITLE
[PB-1027]: (feature) Detect file replacements and update content

### DIFF
--- a/InternxtDesktop.xcodeproj/project.pbxproj
+++ b/InternxtDesktop.xcodeproj/project.pbxproj
@@ -1090,7 +1090,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 32;
+				CURRENT_PROJECT_VERSION = 33;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"InternxtDesktop/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
@@ -1290,7 +1290,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 32;
+				CURRENT_PROJECT_VERSION = 33;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"InternxtDesktop/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
@@ -1331,7 +1331,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 32;
+				CURRENT_PROJECT_VERSION = 33;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"InternxtDesktop/Preview Content\"";
 				DEVELOPMENT_TEAM = "";

--- a/InternxtDesktop.xcodeproj/project.pbxproj
+++ b/InternxtDesktop.xcodeproj/project.pbxproj
@@ -98,6 +98,7 @@
 		E19136942AA101DE00CAF0FA /* WidgetIconButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E19136932AA101DE00CAF0FA /* WidgetIconButtonView.swift */; };
 		E19136962AA108D200CAF0FA /* View.swift in Sources */ = {isa = PBXBuildFile; fileRef = E19136952AA108D200CAF0FA /* View.swift */; };
 		E19136992AA108D200CAF0FA /* View.swift in Sources */ = {isa = PBXBuildFile; fileRef = E19136952AA108D200CAF0FA /* View.swift */; };
+		E198B3972B0B696000598C16 /* UploadFileOrUpdateContentUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E198B3962B0B696000598C16 /* UploadFileOrUpdateContentUseCase.swift */; };
 		E198D7DC2AA9E76900107753 /* GetRemoteChangesUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E198D7DB2AA9E76900107753 /* GetRemoteChangesUseCase.swift */; };
 		E198D7DE2AA9EA0A00107753 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E198D7DD2AA9EA0A00107753 /* Utils.swift */; };
 		E198D7DF2AAA38A500107753 /* RealtimeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1ADD04E2AA8D54E00D95694 /* RealtimeService.swift */; };
@@ -253,6 +254,7 @@
 		E19136902AA0FB4C00CAF0FA /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		E19136932AA101DE00CAF0FA /* WidgetIconButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetIconButtonView.swift; sourceTree = "<group>"; };
 		E19136952AA108D200CAF0FA /* View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = View.swift; sourceTree = "<group>"; };
+		E198B3962B0B696000598C16 /* UploadFileOrUpdateContentUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadFileOrUpdateContentUseCase.swift; sourceTree = "<group>"; };
 		E198D7DB2AA9E76900107753 /* GetRemoteChangesUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetRemoteChangesUseCase.swift; sourceTree = "<group>"; };
 		E198D7DD2AA9EA0A00107753 /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
 		E1A0AC4A2AB3590E005E71D6 /* AppCachedAsyncImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCachedAsyncImage.swift; sourceTree = "<group>"; };
@@ -440,6 +442,7 @@
 				E1581DDF2A96835F0051DD46 /* DownloadFileUseCase.swift */,
 				E140C3352AC37E5500A88B9F /* DeleteFileUseCase.swift */,
 				E1B1C9262B0394C30003F001 /* UpdateFileContentUseCase.swift */,
+				E198B3962B0B696000598C16 /* UploadFileOrUpdateContentUseCase.swift */,
 			);
 			path = Files;
 			sourceTree = "<group>";
@@ -952,6 +955,7 @@
 				E1FB2D872A76C48600473AE1 /* FileProviderItem.swift in Sources */,
 				E198D7DF2AAA38A500107753 /* RealtimeService.swift in Sources */,
 				E198D7DC2AA9E76900107753 /* GetRemoteChangesUseCase.swift in Sources */,
+				E198B3972B0B696000598C16 /* UploadFileOrUpdateContentUseCase.swift in Sources */,
 				E16ECC152A9508B10093D3ED /* ErrorUtils.swift in Sources */,
 				E140C32D2AC376AE00A88B9F /* Drive.swift in Sources */,
 				E1581DDE2A9678000051DD46 /* MoveFolderUseCase.swift in Sources */,
@@ -1090,7 +1094,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 33;
+				CURRENT_PROJECT_VERSION = 34;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"InternxtDesktop/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
@@ -1290,7 +1294,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 33;
+				CURRENT_PROJECT_VERSION = 34;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"InternxtDesktop/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
@@ -1331,7 +1335,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 33;
+				CURRENT_PROJECT_VERSION = 34;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"InternxtDesktop/Preview Content\"";
 				DEVELOPMENT_TEAM = "";

--- a/InternxtDesktop.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/InternxtDesktop.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -96,7 +96,7 @@
       "location" : "https://github.com/internxt/swift-core",
       "state" : {
         "branch" : "main",
-        "revision" : "20bb0d39da00adad326b5faaf7363eaf8791543f"
+        "revision" : "ac5ddcd74d63deec7959df48431f68859eec9506"
       }
     }
   ],

--- a/Shared/Services/ThumbnailGenerator.swift
+++ b/Shared/Services/ThumbnailGenerator.swift
@@ -15,7 +15,7 @@ struct GeneratedThumbnailResult {
     public let url: URL
 }
 
-var DEFAULT_THUMBNAIL_SIZE: CGFloat = 256
+var DEFAULT_THUMBNAIL_SIZE: CGFloat = 512
 class ThumbnailGenerator {
     static var shared = ThumbnailGenerator()
     

--- a/SyncExtension/FileProviderExtension.swift
+++ b/SyncExtension/FileProviderExtension.swift
@@ -248,6 +248,7 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension, NSFile
                 return Progress()
             }
             
+           
             let filename = NSString(string:itemTemplate.filename)
             let fileCopy = makeTemporaryURL("plain", filename.pathExtension)
             try! FileManager.default.copyItem(at: contentUrl, to: fileCopy)
@@ -273,7 +274,7 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension, NSFile
             }
             
            
-            return UploadFileUseCase(
+            return UploadFileOrUpdateContentUseCase(
                 networkFacade: networkFacade,
                 user: user,
                 activityManager: activityManager,
@@ -374,9 +375,11 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension, NSFile
                 networkFacade: self.networkFacade,
                 user: self.user,
                 item: item,
+                fileUuid: item.itemIdentifier.rawValue,
                 url: newContents!,
                 encryptedFileDestination: encryptedFileDestination,
-                completionHandler: completionHandlerInternal
+                completionHandler: completionHandlerInternal,
+                progress: Progress(totalUnitCount: 100)
             ).run()
         }
         

--- a/SyncExtension/UseCases/Files/UploadFileOrUpdateContentUseCase.swift
+++ b/SyncExtension/UseCases/Files/UploadFileOrUpdateContentUseCase.swift
@@ -1,0 +1,108 @@
+//
+//  UploadFileOrUpdateContentUseCase.swift
+//  SyncExtension
+//
+//  Created by Robert Garcia on 20/11/23.
+//
+
+import Foundation
+import os.log
+import InternxtSwiftCore
+import FileProvider
+
+struct UploadFileOrUpdateContentUseCase {
+    let logger = Logger(subsystem: "com.internxt", category: "UploadFileOrUpdateContent")
+    
+    private let cryptoUtils = CryptoUtils()
+    private let encrypt: Encrypt = Encrypt()
+    private let trashAPI: TrashAPI = APIFactory.Trash
+    private let item: NSFileProviderItem
+    private let encryptedFileDestination: URL
+    private let encryptedThumbnailFileDestination: URL
+    private let thumbnailFileDestination: URL
+    private let fileContent: URL
+    private let networkFacade: NetworkFacade
+    private let completionHandler: (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void
+    private let driveAPI = APIFactory.Drive
+    private let driveNewAPI = APIFactory.DriveNew
+    private let config = ConfigLoader().get()
+    private let user: DriveUser
+    private let activityManager: ActivityManager
+    private let trackId = UUID().uuidString
+    init(
+        networkFacade: NetworkFacade,
+        user: DriveUser,
+        activityManager: ActivityManager,
+        item: NSFileProviderItem,
+        url: URL,
+        encryptedFileDestination: URL,
+        thumbnailFileDestination:URL,
+        encryptedThumbnailFileDestination: URL,
+        completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void
+    ) {
+        self.item = item
+        self.activityManager = activityManager
+        self.fileContent = url
+        self.encryptedFileDestination = encryptedFileDestination
+        self.encryptedThumbnailFileDestination = encryptedThumbnailFileDestination
+        self.thumbnailFileDestination = thumbnailFileDestination
+        self.completionHandler = completionHandler
+        self.networkFacade = networkFacade
+        self.user = user
+    }
+    
+    private func fileAlreadyExistsByName() async -> GetFileInFolderByPlainNameResponse? {
+        do {
+            guard let folderIdInt = Int(getParentId(item: self.item, user: self.user)) else {
+                return nil
+            }
+            
+            let filename = (item.filename as NSString)
+            return try await self.driveNewAPI.getFileInFolderByPlainName(folderId: folderIdInt, plainName: filename.deletingPathExtension, type:filename.pathExtension)
+            
+        } catch {
+            return nil
+        }
+        
+    }
+    
+    func run() -> Progress {
+        let progress = Progress(totalUnitCount: 100)
+        Task {
+            self.logger.info("Checking if file already exists...")
+            guard let fileByName = await self.fileAlreadyExistsByName() else {
+                self.logger.info("File doesn't exists in this folder, uploading")
+                return UploadFileUseCase(
+                    networkFacade: self.networkFacade,
+                    user: self.user,
+                    activityManager: self.activityManager,
+                    item: self.item,
+                    url: self.fileContent,
+                    encryptedFileDestination: self.encryptedFileDestination,
+                    thumbnailFileDestination: self.thumbnailFileDestination,
+                    encryptedThumbnailFileDestination: self.encryptedThumbnailFileDestination,
+                    completionHandler: self.completionHandler,
+                    progress: progress
+                ).run()
+            }
+            
+            
+            self.logger.info("File already exists in this folder, replacing content")
+            
+            
+            return UpdateFileContentUseCase(
+                networkFacade: self.networkFacade,
+                user: self.user,
+                item: self.item,
+                fileUuid: fileByName.uuid,
+                url: self.fileContent,
+                encryptedFileDestination: self.encryptedFileDestination,
+                completionHandler: self.completionHandler,
+                progress: progress
+            ).run()
+            
+        }
+        
+        return progress
+    }
+}

--- a/SyncExtension/Utils.swift
+++ b/SyncExtension/Utils.swift
@@ -6,6 +6,8 @@
 //
 
 import Foundation
+import InternxtSwiftCore
+import FileProvider
 
 func dateToAnchor(_ date: Date) -> String {
     let formatter = DateFormatter()
@@ -20,4 +22,9 @@ func anchorToDate(_ string: String) -> Date? {
     formatter.dateStyle = .long
     formatter.timeStyle = .short
     return formatter.date(from: string)
+}
+
+
+func getParentId(item: NSFileProviderItem, user: DriveUser) -> String {
+    return item.parentItemIdentifier == .rootContainer ? String(user.root_folder_id) : item.parentItemIdentifier.rawValue
 }


### PR DESCRIPTION
This PR allows the Desktop app to:

- Detect when an user is replacing a file using the OS dialog by checking if the file with name and type already exists in the folder see:
![image](https://github.com/internxt/drive-desktop-macos/assets/42890253/d8584b1b-9e57-4f69-be8f-7f74850c85b4)

- If the file exists, it performs a content replacement rather than a upload
- If the file does not exists, it performs a normal upload