### PR TITLE
fix: backups UI

### DIFF
--- a/InternxtDesktop.xcodeproj/project.pbxproj
+++ b/InternxtDesktop.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		316DC7EB2B597BD000FDC746 /* DeviceService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 316DC7EA2B597BD000FDC746 /* DeviceService.swift */; };
 		316DC7EC2B59837D00FDC746 /* DeviceService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 316DC7EA2B597BD000FDC746 /* DeviceService.swift */; };
 		317B70BB2B583F6600CEBC08 /* BackupSetupComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317B70BA2B583F6600CEBC08 /* BackupSetupComponent.swift */; };
+		317EE5C92BABC221008CDBD1 /* SettingsTabManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317EE5C82BABC221008CDBD1 /* SettingsTabManager.swift */; };
 		3185496F2B698AAC00D559E1 /* Device.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3185496E2B698AAC00D559E1 /* Device.swift */; };
 		318549702B698AAC00D559E1 /* Device.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3185496E2B698AAC00D559E1 /* Device.swift */; };
 		319436902B9B81BD006F4600 /* BackupTreeNodeSyncResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3194368F2B9B81BD006F4600 /* BackupTreeNodeSyncResult.swift */; };
@@ -309,6 +310,7 @@
 		316D24792B4D9997007DE91A /* BackupsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupsService.swift; sourceTree = "<group>"; };
 		316DC7EA2B597BD000FDC746 /* DeviceService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceService.swift; sourceTree = "<group>"; };
 		317B70BA2B583F6600CEBC08 /* BackupSetupComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupSetupComponent.swift; sourceTree = "<group>"; };
+		317EE5C82BABC221008CDBD1 /* SettingsTabManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTabManager.swift; sourceTree = "<group>"; };
 		3185496E2B698AAC00D559E1 /* Device.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Device.swift; sourceTree = "<group>"; };
 		3194368F2B9B81BD006F4600 /* BackupTreeNodeSyncResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupTreeNodeSyncResult.swift; sourceTree = "<group>"; };
 		319436912B9B8293006F4600 /* BackupRealm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupRealm.swift; sourceTree = "<group>"; };
@@ -898,6 +900,7 @@
 				E1880BA32AA6973C001FC171 /* GlobalUIManager.swift */,
 				E1ADD0432AA7367800D95694 /* UsageManager.swift */,
 				E1A0AC552AB48B7F005E71D6 /* WindowsManager.swift */,
+				317EE5C82BABC221008CDBD1 /* SettingsTabManager.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -1303,6 +1306,7 @@
 				E18300A42AA1FC7700AD023C /* SettingsMenuView.swift in Sources */,
 				E1DB29592A7D5D86009036B8 /* ConfigLoader.swift in Sources */,
 				E1880B992AA611D3001FC171 /* GeneralTabView.swift in Sources */,
+				317EE5C92BABC221008CDBD1 /* SettingsTabManager.swift in Sources */,
 				E1A0AC722AB89B1B005E71D6 /* AnyTransition.swift in Sources */,
 				3104526E2B4B1C5C00984716 /* StopBackupDialog.swift in Sources */,
 				E1DB29612A7D6B80009036B8 /* WidgetContentView.swift in Sources */,

--- a/InternxtDesktop.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/InternxtDesktop.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -110,5 +110,5 @@
       }
     }
   ],
-  "version" : 3
+  "version" : 2
 }

--- a/InternxtDesktop/AppDelegate.swift
+++ b/InternxtDesktop/AppDelegate.swift
@@ -41,6 +41,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     let activityManager = ActivityManager()
     var globalUIManager = GlobalUIManager()
     let backupsService = BackupsService()
+    let settingsManager = SettingsTabManager()
 
     var popover: NSPopover?
     var statusBarItem: NSStatusItem?
@@ -61,7 +62,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         initializeBackups()
 
         self.windowsManager = WindowsManager(
-            initialWindows: defaultWindows(authManager: authManager, usageManager: usageManager, backupsService: backupsService, updater: updaterController.updater,closeSendFeedbackWindow: closeSendFeedbackWindow, finishOrSkipOnboarding: self.finishOrSkipOnboarding),
+            initialWindows: defaultWindows(settingsManager: settingsManager, authManager: authManager, usageManager: usageManager, backupsService: backupsService, updater: updaterController.updater,closeSendFeedbackWindow: closeSendFeedbackWindow, finishOrSkipOnboarding: self.finishOrSkipOnboarding),
             onWindowClose: receiveOnWindowClose
         )
         self.windowsManager.loadInitialWindows()
@@ -350,6 +351,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 .environmentObject(self.globalUIManager)
                 .environmentObject(self.usageManager)
                 .environmentObject(self.activityManager)
+                .environmentObject(self.settingsManager)
         )
     }
     

--- a/InternxtDesktop/Services/SettingsTabManager.swift
+++ b/InternxtDesktop/Services/SettingsTabManager.swift
@@ -1,0 +1,14 @@
+//
+//  SettingsTabManager.swift
+//  InternxtDesktop
+//
+//  Created by Richard Ascanio on 3/20/24.
+//
+
+import Foundation
+
+class SettingsTabManager: ObservableObject {
+
+    @Published var focusedTab: TabView = .General
+
+}

--- a/InternxtDesktop/Views/Backup/BackupComponent.swift
+++ b/InternxtDesktop/Views/Backup/BackupComponent.swift
@@ -54,7 +54,7 @@ struct BackupComponent: View {
                     } else {
                         AppButton(title: "COMMON_BACKUP_NOW", onClick: {
                             doBackup()
-                        }, type: .primary, isExpanded: true)
+                        }, type: .primary, isEnabled: !backupsService.foldernames.isEmpty, isExpanded: true)
                     }
                 } else {
                     AppButton(title: "BACKUP_DOWNLOAD", onClick: {
@@ -89,9 +89,6 @@ struct BackupComponent: View {
                     }
                 }
                 .padding([.top], 12)
-
-                UploadFrequencySelector(currentFrequency: self.$currentFrequency)
-                    .padding([.top], 12)
             }
 
             VStack(alignment: .leading, spacing: 8) {

--- a/InternxtDesktop/Views/Backup/DeleteBackupDialog.swift
+++ b/InternxtDesktop/Views/Backup/DeleteBackupDialog.swift
@@ -48,6 +48,7 @@ struct DeleteBackupDialog: View {
         .background(colorScheme == .dark ? Color.Gray1 : Color.white)
         .cornerRadius(10)
         .frame(width: 320)
+        .shadow(color: .black.opacity(0.1), radius: 1.5, x: 0, y: 1)
         .shadow(color: .black.opacity(0.1), radius: 1, x: 0, y: 1)
     }
 

--- a/InternxtDesktop/Views/Backup/DeleteBackupDialog.swift
+++ b/InternxtDesktop/Views/Backup/DeleteBackupDialog.swift
@@ -48,6 +48,7 @@ struct DeleteBackupDialog: View {
         .background(colorScheme == .dark ? Color.Gray1 : Color.white)
         .cornerRadius(10)
         .frame(width: 320)
+        .shadow(color: .black.opacity(0.1), radius: 1, x: 0, y: 1)
     }
 
     func deleteBackup() throws {

--- a/InternxtDesktop/Views/Backup/FolderSelectorView.swift
+++ b/InternxtDesktop/Views/Backup/FolderSelectorView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct FolderSelectorView: View {
 
+    @Environment(\.colorScheme) var colorScheme
     @StateObject var backupsService: BackupsService
     let closeWindow: () -> Void
     @State private var selectedId: String?
@@ -92,8 +93,9 @@ struct FolderSelectorView: View {
         }
         .frame(width: 480, height: 380, alignment: .top)
         .padding(20)
-        .background(Color.Surface)
+        .background(colorScheme == .dark ? Color.Gray1 : Color.white)
         .cornerRadius(10)
+        .shadow(color: .black.opacity(0.1), radius: 1, x: 0, y: 1)
     }
 
     private func doBackup() {

--- a/InternxtDesktop/Views/Backup/FolderSelectorView.swift
+++ b/InternxtDesktop/Views/Backup/FolderSelectorView.swift
@@ -95,6 +95,7 @@ struct FolderSelectorView: View {
         .padding(20)
         .background(colorScheme == .dark ? Color.Gray1 : Color.white)
         .cornerRadius(10)
+        .shadow(color: .black.opacity(0.1), radius: 1.5, x: 0, y: 1)
         .shadow(color: .black.opacity(0.1), radius: 1, x: 0, y: 1)
     }
 

--- a/InternxtDesktop/Views/Backup/StopBackupDialog.swift
+++ b/InternxtDesktop/Views/Backup/StopBackupDialog.swift
@@ -41,6 +41,7 @@ struct StopBackupDialog: View {
         .background(colorScheme == .dark ? Color.Gray1 : Color.white)
         .cornerRadius(10)
         .frame(width: 320)
+        .shadow(color: .black.opacity(0.1), radius: 1, x: 0, y: 1)
     }
 
     private func stopBackup() throws {

--- a/InternxtDesktop/Views/Backup/StopBackupDialog.swift
+++ b/InternxtDesktop/Views/Backup/StopBackupDialog.swift
@@ -41,6 +41,7 @@ struct StopBackupDialog: View {
         .background(colorScheme == .dark ? Color.Gray1 : Color.white)
         .cornerRadius(10)
         .frame(width: 320)
+        .shadow(color: .black.opacity(0.1), radius: 1.5, x: 0, y: 1)
         .shadow(color: .black.opacity(0.1), radius: 1, x: 0, y: 1)
     }
 

--- a/InternxtDesktop/Views/Settings/BackupsTabView.swift
+++ b/InternxtDesktop/Views/Settings/BackupsTabView.swift
@@ -36,9 +36,6 @@ struct BackupsTabView: View {
 
     var DevicesTab: some View {
         VStack(alignment: .leading, spacing: 8) {
-            AppText("BACKUP_SETTINGS_DEVICES")
-                .foregroundColor(.Gray80)
-                .font(.SMMedium)
 
             WidgetDeviceSelector(
                 backupsService: backupsService,

--- a/InternxtDesktop/Views/Settings/SettingsView.swift
+++ b/InternxtDesktop/Views/Settings/SettingsView.swift
@@ -18,7 +18,7 @@ struct SettingsView: View {
     @EnvironmentObject var authManager: AuthManager
     @EnvironmentObject var usageManager: UsageManager
     @EnvironmentObject var backupsService: BackupsService
-    @State var focusedTab: TabView = .General
+    @EnvironmentObject var settingsManager: SettingsTabManager
     public var updater: SPUUpdater? = nil
     @State private var selectedDeviceId: Int? = nil
     @State private var showFolderSelector = false
@@ -86,7 +86,7 @@ struct SettingsView: View {
     
     @ViewBuilder
     var Tabcontent: some View {
-        switch self.focusedTab {
+        switch settingsManager.focusedTab {
         case .General:
             GeneralTabView(updater: updater)
         case .Account:
@@ -108,11 +108,11 @@ struct SettingsView: View {
         
         .padding(.horizontal, 16)
         .padding(.vertical, 6)
-        .background(Color(colorScheme == .dark ? "Gray10" : "Gray5").opacity(focusedTab == id ? 1 : 0))
+        .background(Color(colorScheme == .dark ? "Gray10" : "Gray5").opacity(settingsManager.focusedTab == id ? 1 : 0))
         .cornerRadius(8)
         .contentShape(Rectangle())
         .onTapGesture {
-            focusedTab = id
+            settingsManager.focusedTab = id
         }
     }
 }

--- a/InternxtDesktop/Views/Settings/SettingsView.swift
+++ b/InternxtDesktop/Views/Settings/SettingsView.swift
@@ -52,7 +52,7 @@ struct SettingsView: View {
                     }
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .background(Color.Gray1.opacity(0.8))
+                .background(Color.Gray40.opacity(0.4))
             }
 
             // stop ongoing backup dialog
@@ -63,7 +63,7 @@ struct SettingsView: View {
                     })
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .background(Color.Gray1.opacity(0.8))
+                .background(Color.Gray40.opacity(0.4))
             }
 
             // delete backup dialog
@@ -78,7 +78,7 @@ struct SettingsView: View {
                     )
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .background(Color.Gray1.opacity(0.8))
+                .background(Color.Gray40.opacity(0.4))
             }
         }
         .frame(width: 600)

--- a/InternxtDesktop/Views/Widget/SettingsMenuView.swift
+++ b/InternxtDesktop/Views/Widget/SettingsMenuView.swift
@@ -11,6 +11,7 @@ struct SettingsMenuView: View {
     
     @EnvironmentObject var authManager: AuthManager
     @EnvironmentObject var usageManager: UsageManager
+    @EnvironmentObject var settingsManager: SettingsTabManager
     var openSendFeedback: () -> Void
     var isPreview: Bool = false;
     
@@ -56,6 +57,7 @@ struct SettingsMenuView: View {
     }
     
     func handleOpenPreferences() -> Void {
+        settingsManager.focusedTab = .General
         Task { await usageManager.updateUsage() }
         NSApp.sendAction(#selector(AppDelegate.openSettingsWindow), to: nil, from: nil)
     }

--- a/InternxtDesktop/Views/Widget/WidgetBackupBannerView.swift
+++ b/InternxtDesktop/Views/Widget/WidgetBackupBannerView.swift
@@ -21,6 +21,7 @@ struct ImageContainerView: View {
 
 struct WidgetBackupBannerView: View {
 
+    @EnvironmentObject var settingsManager: SettingsTabManager
     let dismiss: () -> Void
 
     var body: some View {
@@ -57,7 +58,7 @@ struct WidgetBackupBannerView: View {
                 }
 
                 AppButton(title: "BACKUP_BUTTON_LABEL", onClick: {
-                    handleOpenPreferences()
+                    handleOpenBackupSettings()
                 }, size: .SM)
             }
             .padding([.leading], 16)
@@ -70,7 +71,13 @@ struct WidgetBackupBannerView: View {
 
     }
 
-    func handleOpenPreferences() -> Void {
+    func handleOpenBackupSettings() -> Void {
+        do {
+            try ConfigLoader().shouldDisplayBackupsBanner(shouldDisplay: false)
+        } catch {
+            error.reportToSentry()
+        }
+        settingsManager.focusedTab = .Backup
         NSApp.sendAction(#selector(AppDelegate.openSettingsWindow), to: nil, from: nil)
     }
 }

--- a/InternxtDesktop/Views/Widget/WidgetDeviceSelector.swift
+++ b/InternxtDesktop/Views/Widget/WidgetDeviceSelector.swift
@@ -19,34 +19,45 @@ struct WidgetDeviceSelector: View {
             switch backupsService.deviceResponse {
             case .success(let devices):
                 if devices.isEmpty {
-                    VStack(alignment: .center) {
-                        Spacer()
+                    VStack(alignment: .leading) {
+                        HStack(spacing: 5) {
+                            AppText("BACKUP_SETTINGS_DEVICES")
+                                .foregroundColor(.Gray80)
+                                .font(.SMMedium)
 
-                        ProgressView()
-                            .progressViewStyle(CircularProgressViewStyle(tint: .blue))
-                            .scaleEffect(2.0, anchor: .center)
+                            ProgressView()
+                                .progressViewStyle(CircularProgressViewStyle(tint: .blue))
+                                .scaleEffect(0.5, anchor: .center)
+                        }
 
                         Spacer()
                     }
-                    .frame(width: 160, alignment: .center)
+                    .frame(width: 160, alignment: .leading)
                 } else {
-                    VStack(alignment: .leading, spacing: 0) {
-                        ForEach(devices) { device in
-                            DeviceItem(
-                                deviceName: device.plainName ?? "",
-                                isSelected: self.selectedDeviceId == device.id,
-                                isCurrentDevice: device.isCurrentDevice
-                            ) {
-                                withAnimation {
-                                    self.selectedDeviceId = device.id
-                                    self.selectedDevice = device
+                    VStack(alignment: .leading, spacing: 8) {
+                        AppText("BACKUP_SETTINGS_DEVICES")
+                            .foregroundColor(.Gray80)
+                            .font(.SMMedium)
+
+                        VStack(alignment: .leading, spacing: 0) {
+                            ForEach(devices) { device in
+                                DeviceItem(
+                                    deviceName: device.plainName ?? "",
+                                    isSelected: self.selectedDeviceId == device.id,
+                                    isCurrentDevice: device.isCurrentDevice
+                                ) {
+                                    withAnimation {
+                                        self.selectedDeviceId = device.id
+                                        self.selectedDevice = device
+                                    }
                                 }
                             }
                         }
-                    }
-                    .onAppear {
-                        self.selectedDeviceId = devices.first?.id
-                        self.selectedDevice = devices.first
+                        .onAppear {
+                            self.selectedDeviceId = devices.first?.id
+                            self.selectedDevice = devices.first
+                        }
+                        .frame(width: 160, alignment: .leading)
                     }
                     .frame(width: 160, alignment: .leading)
                 }
@@ -89,7 +100,7 @@ struct WidgetDeviceSelector: View {
 }
 
 struct DeviceItem: View {
-    
+
     @Environment(\.colorScheme) var colorScheme
     var deviceName: String
     var isSelected: Bool
@@ -107,6 +118,8 @@ struct DeviceItem: View {
             AppText(deviceName)
                 .foregroundColor(.Gray80)
                 .font(.SMMedium)
+                .lineLimit(1)
+
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding([.horizontal], 16)
@@ -116,6 +129,7 @@ struct DeviceItem: View {
         .onTapGesture {
             onTap()
         }
+        .help(Text(deviceName))
         .cornerRadius(8.0)
         .shadow(color: isSelected ? .black.opacity(0.05) : .clear, radius: 1, x: 0.0, y: 1.0)
         .overlay(

--- a/InternxtDesktop/Views/Widget/WidgetDeviceSelector.swift
+++ b/InternxtDesktop/Views/Widget/WidgetDeviceSelector.swift
@@ -46,10 +46,8 @@ struct WidgetDeviceSelector: View {
                                     isSelected: self.selectedDeviceId == device.id,
                                     isCurrentDevice: device.isCurrentDevice
                                 ) {
-                                    withAnimation {
-                                        self.selectedDeviceId = device.id
-                                        self.selectedDevice = device
-                                    }
+                                    self.selectedDeviceId = device.id
+                                    self.selectedDevice = device                                    
                                 }
                             }
                         }

--- a/InternxtDesktop/Views/Widget/WidgetHeaderView.swift
+++ b/InternxtDesktop/Views/Widget/WidgetHeaderView.swift
@@ -12,6 +12,7 @@ import Combine
 struct WidgetHeaderView: View {
     @EnvironmentObject var globalUIManager: GlobalUIManager
     @EnvironmentObject var usageManager: UsageManager
+    @EnvironmentObject var settingsManager: SettingsTabManager
     @Environment(\.colorScheme) var colorScheme
 
     @State var settingsMenuOpen = false
@@ -90,12 +91,12 @@ struct WidgetHeaderView: View {
                 
                 if #available(macOS 12, *) {
                     view.overlay(alignment: .bottomLeading) {
-                        SettingsMenuView(openSendFeedback: self.openSendFeedback).opacity((settingsMenuOpen) ? 1 : 0).environmentObject(usageManager).onTapBackground(enabled: settingsMenuOpen) {
+                        SettingsMenuView(openSendFeedback: self.openSendFeedback).opacity((settingsMenuOpen) ? 1 : 0).environmentObject(usageManager).environmentObject(settingsManager).onTapBackground(enabled: settingsMenuOpen) {
                                 self.settingsMenuOpen = false
                             }
                     }
                 } else {
-                    view.overlay(SettingsMenuView(openSendFeedback: self.openSendFeedback).opacity((settingsMenuOpen) ? 1 : 0).environmentObject(usageManager)
+                    view.overlay(SettingsMenuView(openSendFeedback: self.openSendFeedback).opacity((settingsMenuOpen) ? 1 : 0).environmentObject(usageManager).environmentObject(settingsManager)
                                  ,alignment: .bottomLeading)
                 }
                     

--- a/InternxtDesktop/Views/Widget/WidgetView.swift
+++ b/InternxtDesktop/Views/Widget/WidgetView.swift
@@ -14,6 +14,7 @@ struct WidgetView: View {
     @EnvironmentObject var authManager: AuthManager
     @EnvironmentObject var globalUIManager: GlobalUIManager
     @EnvironmentObject var usageManager: UsageManager
+    @EnvironmentObject var settingsManager: SettingsTabManager
 
     @State private var showBackupBanner = false
     var isEmpty: Bool = true
@@ -33,11 +34,13 @@ struct WidgetView: View {
                         .zIndex(100)
                         .environmentObject(self.globalUIManager)
                         .environmentObject(self.usageManager)
+                        .environmentObject(self.settingsManager)
 
                     if !activityManager.activityEntries.isEmpty && self.showBackupBanner {
                         WidgetBackupBannerView() {
                             self.showBackupBanner = false
                         }
+                        .environmentObject(self.settingsManager)
                     }
 
                     VStack(alignment: .center) {

--- a/InternxtDesktop/Windows.swift
+++ b/InternxtDesktop/Windows.swift
@@ -13,7 +13,7 @@ import Sparkle
 /// Return the default windows config, this
 /// windows will be available without needing to explicitly
 /// creating them
-func defaultWindows(authManager: AuthManager, usageManager: UsageManager, backupsService: BackupsService, updater: SPUUpdater, closeSendFeedbackWindow: @escaping () -> Void, finishOrSkipOnboarding: @escaping () -> Void) -> [WindowConfig] {
+func defaultWindows(settingsManager: SettingsTabManager, authManager: AuthManager, usageManager: UsageManager, backupsService: BackupsService, updater: SPUUpdater, closeSendFeedbackWindow: @escaping () -> Void, finishOrSkipOnboarding: @escaping () -> Void) -> [WindowConfig] {
     let windows = [
         WindowConfig(
             view: AnyView(AppSettingsManagerView{SignInWithBrowserView().environmentObject(authManager)}),
@@ -28,6 +28,7 @@ func defaultWindows(authManager: AuthManager, usageManager: UsageManager, backup
                     .environmentObject(authManager)
                     .environmentObject(usageManager)
                     .environmentObject(backupsService)
+                    .environmentObject(settingsManager)
             }),
             title: "Internxt Drive",
             id: "settings",

--- a/InternxtDesktopTests/Backups/Services/BackupTreeGeneratorTests.swift
+++ b/InternxtDesktopTests/Backups/Services/BackupTreeGeneratorTests.swift
@@ -18,7 +18,7 @@ final class BackupTreeGeneratorTests: XCTestCase {
         tmpDirectoryURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("BACKUP_TREE_GENERATOR_TESTS_\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: tmpDirectoryURL, withIntermediateDirectories: true)
         let networkAPI = NetworkAPI(baseUrl: "", basicAuthToken: "", clientName: "", clientVersion: "")
-        sut = BackupTreeGenerator(root: tmpDirectoryURL, backupUploadService: BackupUploadService(networkFacade: NetworkFacade(mnemonic: "", networkAPI: networkAPI), encryptedContentDirectory: URL(string: "https://drive.internxt.com/app")!, deviceId: 0, bucketId: "", authToken: ""), progress: Progress())
+        sut = BackupTreeGenerator(root: tmpDirectoryURL, backupUploadService: BackupUploadService(networkFacade: NetworkFacade(mnemonic: "", networkAPI: networkAPI), encryptedContentDirectory: URL(string: "https://drive.internxt.com/app")!, deviceId: 0, bucketId: "", authToken: "", newAuthToken: ""), progress: Progress())
     }
     
     override func tearDownWithError() throws {


### PR DESCRIPTION
this fixes the following:

- Ocultar UI para programar Backup en intervalos (esta feature no estará disponible en la 2.2.0)
- Al hacer click en el banner de Backups, no lleva al tab de Backups
- El banner de backups no parece desaparecer al arrancar la app de nuevo, si ya has hecho click en el
- La UI de los diálogos no esta como en Figma (faltan las sombras por ejemplo, el background del overlay tampoco es el del Figma)
- Las backups no funcionan si no hay carpetas seleccionadas
- No hay dialogo de confirmación de borrar un Backup al borrarlo, la borra directamente (super peligroso esto)
- Al hacer click en "Backup now" en el diálogo de carpetas, debemos cerrar el diálogo
- El LOADER debería ir al lado del texto de "Devices" en vez de aparecer tan grande en la lista.
- El nombre del device debe ir en una linea, si no cabe, usar ellipsis, pero mostrar el nombre del device al pasar el raton por encima 