### PR TITLE
[PB-1916]:(feature) Speed up backups upload by using an OperationQueue

### DIFF
--- a/InternxtDesktop.xcodeproj/project.pbxproj
+++ b/InternxtDesktop.xcodeproj/project.pbxproj
@@ -214,6 +214,11 @@
 		E1D24AF52C0468AF0009EC83 /* AsyncOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D24AF32C0468AF0009EC83 /* AsyncOperation.swift */; };
 		E1D24AF62C0468AF0009EC83 /* AsyncOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D24AF32C0468AF0009EC83 /* AsyncOperation.swift */; };
 		E1D24AF72C0468AF0009EC83 /* AsyncOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D24AF32C0468AF0009EC83 /* AsyncOperation.swift */; };
+		E1D24AF82C0DA3D00009EC83 /* LogService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1FD8C722BA989D900C257E0 /* LogService.swift */; };
+		E1D24AF92C0DA3DD0009EC83 /* BackupRealm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 319436912B9B8293006F4600 /* BackupRealm.swift */; };
+		E1D24AFA2C0DA4100009EC83 /* SyncedNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31ABDE9F2BA9FC2E00EEA7F5 /* SyncedNode.swift */; };
+		E1D24AFB2C0DA4210009EC83 /* BackupTreeNodeSyncOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D24AEF2C0467710009EC83 /* BackupTreeNodeSyncOperation.swift */; };
+		E1D24AFC2C0DA4270009EC83 /* BackupTreeNodeSyncResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3194368F2B9B81BD006F4600 /* BackupTreeNodeSyncResult.swift */; };
 		E1DB29542A7D56C4009036B8 /* AppTextInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1DB29532A7D56C4009036B8 /* AppTextInput.swift */; };
 		E1DB29562A7D5CD5009036B8 /* env.local.json in Resources */ = {isa = PBXBuildFile; fileRef = E1DB29552A7D5CD5009036B8 /* env.local.json */; };
 		E1DB29572A7D5CD5009036B8 /* env.local.json in Resources */ = {isa = PBXBuildFile; fileRef = E1DB29552A7D5CD5009036B8 /* env.local.json */; };
@@ -1244,11 +1249,16 @@
 				31F9EF2D2B867F42007DAD86 /* ErrorUtils.swift in Sources */,
 				31F9EF2B2B867E16007DAD86 /* ConfigLoader.swift in Sources */,
 				31F9EF2E2B867FE9007DAD86 /* APIFactory.swift in Sources */,
+				E1D24AFA2C0DA4100009EC83 /* SyncedNode.swift in Sources */,
 				E15F8C352B762BAF00C60EFA /* BackupTreeGeneratorTests.swift in Sources */,
+				E1D24AFC2C0DA4270009EC83 /* BackupTreeNodeSyncResult.swift in Sources */,
 				E15F8C422B762EFF00C60EFA /* BackupTreeNodeSyncStatus.swift in Sources */,
+				E1D24AF92C0DA3DD0009EC83 /* BackupRealm.swift in Sources */,
 				E15F8C442B7669F600C60EFA /* URL.swift in Sources */,
 				E15F8C3F2B762E6400C60EFA /* BackupTreeNodeType.swift in Sources */,
+				E1D24AFB2C0DA4210009EC83 /* BackupTreeNodeSyncOperation.swift in Sources */,
 				31F9EF2C2B867F24007DAD86 /* Error.swift in Sources */,
+				E1D24AF82C0DA3D00009EC83 /* LogService.swift in Sources */,
 				E15F8C3C2B762D4200C60EFA /* BackupTreeNode.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/InternxtDesktop.xcodeproj/project.pbxproj
+++ b/InternxtDesktop.xcodeproj/project.pbxproj
@@ -61,8 +61,6 @@
 		31F9EF2D2B867F42007DAD86 /* ErrorUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16ECC132A9508B10093D3ED /* ErrorUtils.swift */; };
 		31F9EF2E2B867FE9007DAD86 /* APIFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E109717E2A81143A00ABED41 /* APIFactory.swift */; };
 		31F9EF2F2B867FED007DAD86 /* Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1CC520B2A98B460009DEEAA /* Bundle.swift */; };
-		31F9EF312B86801B007DAD86 /* Completable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3120B56E2B84F6C400F524F1 /* Completable.swift */; };
-		31F9EF322B868025007DAD86 /* Enqueueable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3120B5702B84F6F400F524F1 /* Enqueueable.swift */; };
 		AA059A352BFE36C500A07D45 /* Rudder in Frameworks */ = {isa = PBXBuildFile; productRef = AA059A342BFE36C500A07D45 /* Rudder */; };
 		AA5EABE62BFD761F00BA0145 /* NetworkAnalyticsEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16D3E892AF141540026C504 /* NetworkAnalyticsEvents.swift */; };
 		AA5EABE82BFD762D00BA0145 /* ProcessInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A0AC6C2AB88B5A005E71D6 /* ProcessInfo.swift */; };
@@ -81,6 +79,7 @@
 		E10B0FDD2A94143F00B97874 /* Int.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10B0FDC2A94143F00B97874 /* Int.swift */; };
 		E10B0FE02A94143F00B97874 /* Int.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10B0FDC2A94143F00B97874 /* Int.swift */; };
 		E112933F2A77221A003DEADF /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E112933E2A77221A003DEADF /* Colors.xcassets */; };
+		E12479D92C107C52000DAC11 /* Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A0AC652AB88507005E71D6 /* Analytics.swift */; };
 		E1312A4F2A7FE01E000EAA43 /* InternxtSwiftCore in Frameworks */ = {isa = PBXBuildFile; productRef = E1312A4E2A7FE01E000EAA43 /* InternxtSwiftCore */; };
 		E1313D2F2A9501BB00C7ABF0 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = E1313D2E2A9501BB00C7ABF0 /* Sentry */; };
 		E1313D3B2A9504D400C7ABF0 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = E1313D3A2A9504D400C7ABF0 /* Sentry */; };
@@ -1229,8 +1228,8 @@
 				3120B5642B84F36C00F524F1 /* APIFactory.swift in Sources */,
 				31ABDEA12BA9FC5300EEA7F5 /* SyncedNode.swift in Sources */,
 				E1E56C232BC0423A00DBA0BF /* BackupProgressUpdate.swift in Sources */,
+				E12479D92C107C52000DAC11 /* Analytics.swift in Sources */,
 				3120B5632B84F35100F524F1 /* ConfigLoader.swift in Sources */,
-				E1D24AFD2C0E3A8C0009EC83 /* Analytics.swift in Sources */,
 				E1FD8C752BA989D900C257E0 /* LogService.swift in Sources */,
 				3120B5692B84F47700F524F1 /* Error.swift in Sources */,
 				3120B5682B84F46800F524F1 /* DecryptUtils.swift in Sources */,

--- a/InternxtDesktop.xcodeproj/project.pbxproj
+++ b/InternxtDesktop.xcodeproj/project.pbxproj
@@ -22,8 +22,6 @@
 		3120B5682B84F46800F524F1 /* DecryptUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31ED949C2B7151E200EF699F /* DecryptUtils.swift */; };
 		3120B5692B84F47700F524F1 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1581DD32A9629790051DD46 /* Error.swift */; };
 		3120B56A2B84F48A00F524F1 /* ErrorUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16ECC132A9508B10093D3ED /* ErrorUtils.swift */; };
-		3120B56F2B84F6C400F524F1 /* Completable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3120B56E2B84F6C400F524F1 /* Completable.swift */; };
-		3120B5712B84F6F400F524F1 /* Enqueueable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3120B5702B84F6F400F524F1 /* Enqueueable.swift */; };
 		3120B5742B84FC4400F524F1 /* BackupTreeNodeType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E15F8C3D2B762E6400C60EFA /* BackupTreeNodeType.swift */; };
 		3120B5752B84FC5300F524F1 /* BackupTreeNodeSyncStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = E15F8C402B762EFF00C60EFA /* BackupTreeNodeSyncStatus.swift */; };
 		3120B5762B85185C00F524F1 /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E17AA0232A8A70CE00C7EE6E /* AuthManager.swift */; };
@@ -63,8 +61,6 @@
 		31F9EF2D2B867F42007DAD86 /* ErrorUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16ECC132A9508B10093D3ED /* ErrorUtils.swift */; };
 		31F9EF2E2B867FE9007DAD86 /* APIFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E109717E2A81143A00ABED41 /* APIFactory.swift */; };
 		31F9EF2F2B867FED007DAD86 /* Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1CC520B2A98B460009DEEAA /* Bundle.swift */; };
-		31F9EF312B86801B007DAD86 /* Completable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3120B56E2B84F6C400F524F1 /* Completable.swift */; };
-		31F9EF322B868025007DAD86 /* Enqueueable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3120B5702B84F6F400F524F1 /* Enqueueable.swift */; };
 		E106D45C2AB9DB9300E3BF7A /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = E106D45B2AB9DB9300E3BF7A /* Sparkle */; };
 		E106D45E2AB9DD8200E3BF7A /* CheckForUpdatesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E106D45D2AB9DD8200E3BF7A /* CheckForUpdatesView.swift */; };
 		E106D4602AB9FBDC00E3BF7A /* Phosphor-Light.ttf in Resources */ = {isa = PBXBuildFile; fileRef = E106D45F2AB9FBDC00E3BF7A /* Phosphor-Light.ttf */; };
@@ -213,6 +209,11 @@
 		E1CC52212AA0B4FE009DEEAA /* Icons.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E1CC52202AA0B4FE009DEEAA /* Icons.xcassets */; };
 		E1D0D4172AF55C1500CF1F7F /* AnalyticsEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D0D4162AF55C1500CF1F7F /* AnalyticsEvents.swift */; };
 		E1D0D4182AF55C1500CF1F7F /* AnalyticsEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D0D4162AF55C1500CF1F7F /* AnalyticsEvents.swift */; };
+		E1D24AF02C0467710009EC83 /* BackupTreeNodeSyncOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D24AEF2C0467710009EC83 /* BackupTreeNodeSyncOperation.swift */; };
+		E1D24AF42C0468AF0009EC83 /* AsyncOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D24AF32C0468AF0009EC83 /* AsyncOperation.swift */; };
+		E1D24AF52C0468AF0009EC83 /* AsyncOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D24AF32C0468AF0009EC83 /* AsyncOperation.swift */; };
+		E1D24AF62C0468AF0009EC83 /* AsyncOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D24AF32C0468AF0009EC83 /* AsyncOperation.swift */; };
+		E1D24AF72C0468AF0009EC83 /* AsyncOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D24AF32C0468AF0009EC83 /* AsyncOperation.swift */; };
 		E1DB29542A7D56C4009036B8 /* AppTextInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1DB29532A7D56C4009036B8 /* AppTextInput.swift */; };
 		E1DB29562A7D5CD5009036B8 /* env.local.json in Resources */ = {isa = PBXBuildFile; fileRef = E1DB29552A7D5CD5009036B8 /* env.local.json */; };
 		E1DB29572A7D5CD5009036B8 /* env.local.json in Resources */ = {isa = PBXBuildFile; fileRef = E1DB29552A7D5CD5009036B8 /* env.local.json */; };
@@ -299,8 +300,6 @@
 		3104526D2B4B1C5C00984716 /* StopBackupDialogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopBackupDialogView.swift; sourceTree = "<group>"; };
 		3116129F2B47873D003C8EE8 /* BackupsFolderListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupsFolderListView.swift; sourceTree = "<group>"; };
 		3120B55A2B84F12A00F524F1 /* BackupUploadService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupUploadService.swift; sourceTree = "<group>"; };
-		3120B56E2B84F6C400F524F1 /* Completable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Completable.swift; sourceTree = "<group>"; };
-		3120B5702B84F6F400F524F1 /* Enqueueable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Enqueueable.swift; sourceTree = "<group>"; };
 		315BC68C2B3DDE4E004C85D8 /* BackupsTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupsTabView.swift; sourceTree = "<group>"; };
 		315BC68E2B3DE84F004C85D8 /* BackupAvailableDevicesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupAvailableDevicesView.swift; sourceTree = "<group>"; };
 		315BC6912B3E06A5004C85D8 /* FolderSelectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderSelectorView.swift; sourceTree = "<group>"; };
@@ -422,6 +421,8 @@
 		E1CC521B2AA0A884009DEEAA /* String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
 		E1CC52202AA0B4FE009DEEAA /* Icons.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Icons.xcassets; sourceTree = "<group>"; };
 		E1D0D4162AF55C1500CF1F7F /* AnalyticsEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsEvents.swift; sourceTree = "<group>"; };
+		E1D24AEF2C0467710009EC83 /* BackupTreeNodeSyncOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupTreeNodeSyncOperation.swift; sourceTree = "<group>"; };
+		E1D24AF32C0468AF0009EC83 /* AsyncOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncOperation.swift; sourceTree = "<group>"; };
 		E1DB29532A7D56C4009036B8 /* AppTextInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTextInput.swift; sourceTree = "<group>"; };
 		E1DB29552A7D5CD5009036B8 /* env.local.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = env.local.json; sourceTree = "<group>"; };
 		E1DB29582A7D5D86009036B8 /* ConfigLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigLoader.swift; sourceTree = "<group>"; };
@@ -525,8 +526,6 @@
 		3120B56D2B84F6B100F524F1 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
-				3120B56E2B84F6C400F524F1 /* Completable.swift */,
-				3120B5702B84F6F400F524F1 /* Enqueueable.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -564,6 +563,7 @@
 				E16ECC132A9508B10093D3ED /* ErrorUtils.swift */,
 				E13B839B2AFBBE67009F6684 /* AppUserDefaults.swift */,
 				31ED949C2B7151E200EF699F /* DecryptUtils.swift */,
+				E1D24AF32C0468AF0009EC83 /* AsyncOperation.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -685,6 +685,7 @@
 				E15F8C402B762EFF00C60EFA /* BackupTreeNodeSyncStatus.swift */,
 				3194368F2B9B81BD006F4600 /* BackupTreeNodeSyncResult.swift */,
 				E1E56C212BC0423A00DBA0BF /* BackupProgressUpdate.swift */,
+				E1D24AEF2C0467710009EC83 /* BackupTreeNodeSyncOperation.swift */,
 			);
 			path = Entities;
 			sourceTree = "<group>";
@@ -1199,10 +1200,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3120B56F2B84F6C400F524F1 /* Completable.swift in Sources */,
 				31DEAEB12B75139400E76D53 /* XPCBackupService.swift in Sources */,
 				3120B5652B84F37F00F524F1 /* Bundle.swift in Sources */,
 				E15F8C3E2B762E6400C60EFA /* BackupTreeNodeType.swift in Sources */,
+				E1D24AF62C0468AF0009EC83 /* AsyncOperation.swift in Sources */,
 				E15F8C102B76292F00C60EFA /* BackupTreeGenerator.swift in Sources */,
 				3120B56A2B84F48A00F524F1 /* ErrorUtils.swift in Sources */,
 				31DEAEB32B75139400E76D53 /* XPCBackupServiceProtocol.swift in Sources */,
@@ -1210,6 +1211,7 @@
 				319436902B9B81BD006F4600 /* BackupTreeNodeSyncResult.swift in Sources */,
 				3120B5662B84F41300F524F1 /* BackupsDeviceService.swift in Sources */,
 				31DEAEC12B75143F00E76D53 /* XPCBackupServiceDelegate.swift in Sources */,
+				E1D24AF02C0467710009EC83 /* BackupTreeNodeSyncOperation.swift in Sources */,
 				3120B5642B84F36C00F524F1 /* APIFactory.swift in Sources */,
 				31ABDEA12BA9FC5300EEA7F5 /* SyncedNode.swift in Sources */,
 				E1E56C232BC0423A00DBA0BF /* BackupProgressUpdate.swift in Sources */,
@@ -1222,7 +1224,6 @@
 				E15F8C412B762EFF00C60EFA /* BackupTreeNodeSyncStatus.swift in Sources */,
 				319436922B9B8293006F4600 /* BackupRealm.swift in Sources */,
 				31DEAEB52B75139400E76D53 /* main.swift in Sources */,
-				3120B5712B84F6F400F524F1 /* Enqueueable.swift in Sources */,
 				3120B5762B85185C00F524F1 /* AuthManager.swift in Sources */,
 				3120B55B2B84F12A00F524F1 /* BackupUploadService.swift in Sources */,
 				E13DBC692BCD4E5B00F6B43E /* BackupsService.swift in Sources */,
@@ -1236,12 +1237,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				31F9EF322B868025007DAD86 /* Enqueueable.swift in Sources */,
 				E15F8C392B762D3400C60EFA /* BackupTreeGenerator.swift in Sources */,
+				E1D24AF72C0468AF0009EC83 /* AsyncOperation.swift in Sources */,
 				31F9EF2F2B867FED007DAD86 /* Bundle.swift in Sources */,
 				31F9EF2A2B867DFE007DAD86 /* BackupUploadService.swift in Sources */,
 				31F9EF2D2B867F42007DAD86 /* ErrorUtils.swift in Sources */,
-				31F9EF312B86801B007DAD86 /* Completable.swift in Sources */,
 				31F9EF2B2B867E16007DAD86 /* ConfigLoader.swift in Sources */,
 				31F9EF2E2B867FE9007DAD86 /* APIFactory.swift in Sources */,
 				E15F8C352B762BAF00C60EFA /* BackupTreeGeneratorTests.swift in Sources */,
@@ -1291,6 +1291,7 @@
 				3120B5742B84FC4400F524F1 /* BackupTreeNodeType.swift in Sources */,
 				E13B83972AFBBCD7009F6684 /* AppSettingsManagerView.swift in Sources */,
 				315BC6922B3E06A5004C85D8 /* FolderSelectorView.swift in Sources */,
+				E1D24AF42C0468AF0009EC83 /* AsyncOperation.swift in Sources */,
 				E1F616092A8D7E6F008C9E62 /* AppButton.swift in Sources */,
 				E106D4622AB9FD6300E3BF7A /* URL.swift in Sources */,
 				316D247A2B4D9997007DE91A /* BackupsService.swift in Sources */,
@@ -1394,6 +1395,7 @@
 				E1CC520F2A98B460009DEEAA /* Bundle.swift in Sources */,
 				E1A0AC692AB88507005E71D6 /* Analytics.swift in Sources */,
 				E1581DE02A96835F0051DD46 /* DownloadFileUseCase.swift in Sources */,
+				E1D24AF52C0468AF0009EC83 /* AsyncOperation.swift in Sources */,
 				31ED949E2B7151E200EF699F /* DecryptUtils.swift in Sources */,
 				31DEAEC32B7514F500E76D53 /* XPCBackupServiceProtocol.swift in Sources */,
 				E145E1712A82C6C000B07E0B /* TrashFileUseCase.swift in Sources */,

--- a/InternxtDesktop/Views/Backups/BackupStatusView.swift
+++ b/InternxtDesktop/Views/Backups/BackupStatusView.swift
@@ -25,6 +25,15 @@ struct BackupStatusView: View {
         
         return self.device.isCurrentDevice && self.backupStatus == .InProgress
     }
+    
+    private func getBackupProgressPercentage() -> String {
+        var progress = Float(progress * 100)
+        
+        if(progress > 100.0) {
+            progress = 100.0
+        }
+        return "\(String(format: "%.2f", progress))%"
+    }
     var body: some View {
         VStack(spacing: 10) {
             HStack(spacing: 10) {
@@ -64,7 +73,7 @@ struct BackupStatusView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
 
                 if deviceIsRunningBackup() {
-                    AppText("\(String(format: "%.2f", Float(progress * 100)))%")
+                    AppText(getBackupProgressPercentage())
                         .font(.LGMedium)
                         .foregroundColor(.Primary)
                  

--- a/Shared/Services/Backups/BackupsDeviceService.swift
+++ b/Shared/Services/Backups/BackupsDeviceService.swift
@@ -71,7 +71,7 @@ struct BackupsDeviceService {
 
     public func editDevice(deviceId: Int, deviceName: String) async throws -> Device {
         let backupAPI = APIFactory.getBackupsClient()
-        let deviceAsFolder = try await backupAPI.editDeviceName(deviceId: deviceId, deviceName: deviceName, debug: true)
+        let deviceAsFolder = try await backupAPI.editDeviceName(deviceId: deviceId, deviceName: deviceName)
         return Device(from: deviceAsFolder)
     }
 

--- a/Shared/Services/LogService.swift
+++ b/Shared/Services/LogService.swift
@@ -66,7 +66,7 @@ struct LogService {
         // Writing logs for the SyncExtension raises a "too many files open" error 
         // at some point, needs investigation
         if subsystem != .SyncExtension {
-           // log.add(destination: fileDestination)
+           log.add(destination: fileDestination)
         }
         
         

--- a/Shared/Services/LogService.swift
+++ b/Shared/Services/LogService.swift
@@ -66,7 +66,7 @@ struct LogService {
         // Writing logs for the SyncExtension raises a "too many files open" error 
         // at some point, needs investigation
         if subsystem != .SyncExtension {
-            log.add(destination: fileDestination)
+           // log.add(destination: fileDestination)
         }
         
         

--- a/Shared/Utils/AsyncOperation.swift
+++ b/Shared/Utils/AsyncOperation.swift
@@ -1,0 +1,74 @@
+//
+//  AsyncOperation.swift
+//  InternxtDesktop
+//
+//  Created by Robert Garcia on 27/5/24.
+//
+
+import Foundation
+class AsyncOperation: Operation {
+    
+    private let lockQueue = DispatchQueue(label: "com.internxt.AsyncOperation", attributes: .concurrent)
+    
+    private var _isExecuting: Bool = false
+    override var isExecuting: Bool {
+        get {
+            return lockQueue.sync { _isExecuting }
+        }
+        set {
+            willChangeValue(forKey: "isExecuting")
+            lockQueue.sync(flags: .barrier) { _isExecuting = newValue }
+            didChangeValue(forKey: "isExecuting")
+        }
+    }
+    
+    private var _isFinished: Bool = false
+    override var isFinished: Bool {
+        get {
+            return lockQueue.sync { _isFinished }
+        }
+        set {
+            willChangeValue(forKey: "isFinished")
+            lockQueue.sync(flags: .barrier) { _isFinished = newValue }
+            didChangeValue(forKey: "isFinished")
+        }
+    }
+    
+    override var isAsynchronous: Bool {
+        return true
+    }
+    
+    override func start() {
+        if isCancelled {
+            isFinished = true
+            return
+        }
+        
+        isExecuting = true
+        main()
+    }
+    
+    override func main() {
+        
+        Task {
+            do {
+                try await performAsyncTask()
+                self.finish()
+            } catch {
+                self.finish()
+                print("Failed to perform async task", error)
+            }
+            
+        }
+        
+    }
+    
+    func performAsyncTask() async throws -> Void {
+        // Override this method in subclasses to perform the actual async work.
+    }
+    
+    func finish() {
+        isExecuting = false
+        isFinished = true
+    }
+}

--- a/Shared/Utils/ErrorUtils.swift
+++ b/Shared/Utils/ErrorUtils.swift
@@ -19,7 +19,8 @@ struct ErrorUtils {
             options.dsn = dsn
             options.debug = false
             options.enableAppHangTracking = false
-            options.tracesSampleRate = 1.0
+            options.tracesSampleRate = 0.5
+            options.sampleRate = 0.5
         }
         
         

--- a/XPCBackupService/Entities/BackupTreeNode.swift
+++ b/XPCBackupService/Entities/BackupTreeNode.swift
@@ -138,7 +138,6 @@ class BackupTreeNode {
         
        
         for child in self.childs {
-            //try child.syncBelowNodes(withOperationQueue: withOperationQueue)
             if(self.type == .folder) {
                 // If current node is a folder, make below sync operations dependent of the folder sync operation
                 try child.syncBelowNodes(withOperationQueue: withOperationQueue, dependingOfOperation: operation)

--- a/XPCBackupService/Entities/BackupTreeNodeSyncOperation.swift
+++ b/XPCBackupService/Entities/BackupTreeNodeSyncOperation.swift
@@ -1,0 +1,20 @@
+//
+//  BackupTreeNodeSyncOperation.swift
+//  XPCBackupService
+//
+//  Created by Robert Garcia on 27/5/24.
+//
+
+import Foundation
+
+class BackupTreeNodeSyncOperation: AsyncOperation {
+    private let backupTreeNode: BackupTreeNode
+    
+    init(backupTreeNode: BackupTreeNode) {
+        self.backupTreeNode = backupTreeNode
+    }
+    
+    override func performAsyncTask() async throws -> Void {
+       try await self.backupTreeNode.syncNode()
+    }
+}

--- a/XPCBackupService/Extensions/Completable.swift
+++ b/XPCBackupService/Extensions/Completable.swift
@@ -21,3 +21,5 @@ extension Completable where Self: Operation {
         return completionOperation
     }
 }
+
+

--- a/XPCBackupService/Services/BackupRealm.swift
+++ b/XPCBackupService/Services/BackupRealm.swift
@@ -36,15 +36,17 @@ struct BackupRealm {
         }
     }
     
-    func findSyncedNode(url: URL, deviceId: Int) -> SyncedNode? {
+    func findSyncedNode(url: URL, deviceId: Int) -> ThreadSafeReference<SyncedNode>? {
         do {
             let realm = try getRealm()
 
             let syncedNode = realm?.objects(SyncedNode.self).first { syncedNode in
                 url.absoluteString == syncedNode.url && deviceId == syncedNode.deviceId
             } 
-            
-            return syncedNode
+            guard let syncedNodeUnwrapped = syncedNode else {
+                return nil
+            }
+            return ThreadSafeReference(to: syncedNodeUnwrapped)
         } catch {
             return nil
         }

--- a/XPCBackupService/Services/BackupTreeGenerator.swift
+++ b/XPCBackupService/Services/BackupTreeGenerator.swift
@@ -29,12 +29,14 @@ class BackupTreeGenerator: BackupTreeGeneration {
     let backupUploadService: BackupUploadService
     let backupTotalProgress: Progress
     let deviceId: Int
-    init(root: URL, deviceId: Int, backupUploadService: BackupUploadService, backupTotalProgress: Progress) {
+    let backupRealm: BackupRealm
+    init(root: URL, deviceId: Int, backupUploadService: BackupUploadService, backupTotalProgress: Progress, backupRealm: BackupRealm) {
 
         self.root = root
         self.backupUploadService = backupUploadService
         self.backupTotalProgress = backupTotalProgress
         self.deviceId = deviceId
+        self.backupRealm = backupRealm
         rootNode = BackupTreeNode(
             id: UUID().uuidString,
             deviceId: deviceId,
@@ -46,6 +48,7 @@ class BackupTreeGenerator: BackupTreeGeneration {
             syncStatus: BackupTreeNodeSyncStatus.LOCAL_ONLY,
             childs: [],
             backupUploadService: self.backupUploadService,
+            backupRealm: self.backupRealm,
             backupTotalProgress: self.backupTotalProgress
         )
     }
@@ -130,6 +133,7 @@ class BackupTreeGenerator: BackupTreeGeneration {
             syncStatus: BackupTreeNodeSyncStatus.LOCAL_ONLY,
             childs: [],
             backupUploadService: self.backupUploadService,
+            backupRealm: self.backupRealm,
             backupTotalProgress: self.backupTotalProgress
         )
         

--- a/XPCBackupService/Services/BackupUploadService.swift
+++ b/XPCBackupService/Services/BackupUploadService.swift
@@ -227,7 +227,7 @@ class BackupUploadService: ObservableObject {
 
 
                 // Edit date in synced database
-                try BackupRealm.shared.editSyncedNodeDate(remoteUuid: remoteUuid, date: Date())
+                //try BackupRealm.shared.editSyncedNodeDate(remoteUuid: remoteUuid, date: Date())
 
                 if encryptedContentURL != nil {
                     try FileManager.default.removeItem(at: encryptedContentURL!)

--- a/XPCBackupService/Services/BackupUploadService.swift
+++ b/XPCBackupService/Services/BackupUploadService.swift
@@ -227,7 +227,7 @@ class BackupUploadService: ObservableObject {
 
 
                 // Edit date in synced database
-                //try BackupRealm.shared.editSyncedNodeDate(remoteUuid: remoteUuid, date: Date())
+                try BackupRealm.shared.editSyncedNodeDate(remoteUuid: remoteUuid, date: Date())
 
                 if encryptedContentURL != nil {
                     try FileManager.default.removeItem(at: encryptedContentURL!)

--- a/XPCBackupService/XPCBackupService.swift
+++ b/XPCBackupService/XPCBackupService.swift
@@ -137,7 +137,6 @@ public class XPCBackupService: NSObject, XPCBackupServiceProtocol {
     
     
     func getBackupStatus(with reply: @escaping (BackupProgressUpdate?, String?) -> Void) {
-        //logger.info(["Backup sync status: \(backupTotalProgress.completedUnitCount) of \(backupTotalProgress.totalUnitCount) nodes synced"])
         reply(BackupProgressUpdate(status: self.status, progress: backupTotalProgress), nil)
     }
 

--- a/XPCBackupService/XPCBackupService.swift
+++ b/XPCBackupService/XPCBackupService.swift
@@ -8,12 +8,14 @@
 import Foundation
 import InternxtSwiftCore
 
+let logger = LogService.shared.createLogger(subsystem: .XPCBackups, category: "XPCBackupService")
 public class XPCBackupService: NSObject, XPCBackupServiceProtocol {
     
     private var backupUploadService: BackupUploadService? = nil
     private var trees: [BackupTreeNode] = []
-    private let logger = LogService.shared.createLogger(subsystem: .XPCBackups, category: "XPCBackupService")
+    
     private var backupTotalProgress: Progress = Progress()
+    private var uploadOperationQueue = OperationQueue()
     private var status: BackupStatus = .Idle
     
     @objc func startBackup(
@@ -26,7 +28,8 @@ public class XPCBackupService: NSObject, XPCBackupServiceProtocol {
         bucketId: String,
         with reply: @escaping (_ result: String?, _ error: String?) -> Void
     ) -> Void {
-        
+        let backupRealm = BackupRealm.shared
+        self.uploadOperationQueue.maxConcurrentOperationCount = 10
         logger.info("Going to backup folders: \(backupURLs)")
         self.status = .InProgress
         self.backupTotalProgress = Progress()
@@ -53,7 +56,7 @@ public class XPCBackupService: NSObject, XPCBackupServiceProtocol {
             )
 
             
-            guard let backupUploadService = backupUploadService else {
+            guard let backupUploadService = self.backupUploadService else {
                 logger.error("Cannot create backup upload service")
                 reply(nil, "Cannot create backup upload service")
                 return
@@ -61,27 +64,27 @@ public class XPCBackupService: NSObject, XPCBackupServiceProtocol {
 
             backupUploadService.canDoBackup = true
 
-            var totalCount = backupURLs.count
-            for backupURL in backupURLs {
-                let count = self.getNodesCountFromURL(URL(fileURLWithPath: backupURL))
-                totalCount += count
-            }
-
-            logger.info("Total progress to backup \(totalCount)")
-
-            backupTotalProgress.totalUnitCount = Int64(totalCount)
             
+            var totalNodesCount = 0
+
+            
+          
             for backupURL in backupURLs {
                 do {
+                    let startGeneratingTreeAt = Date()
+                    let nodesCount = self.getNodesCountFromURL(URL(fileURLWithPath: backupURL))
+                    totalNodesCount += nodesCount
                     let backupTreeGenerator = BackupTreeGenerator(
                         root: URL(fileURLWithPath: backupURL),
                         deviceId: deviceId,
                         backupUploadService: backupUploadService,
-                        backupTotalProgress: backupTotalProgress
+                        backupTotalProgress: self.backupTotalProgress,
+                        backupRealm: backupRealm
                     )
 
                     let backupTree = try await backupTreeGenerator.generateTree()
-                    logger.info("Backup tree created successfully")
+                    let elapsedTime = Date().timeIntervalSince(startGeneratingTreeAt)
+                    logger.info("🌳 Backup tree created successfully in \(Float(elapsedTime * 1000))ms with \(nodesCount) nodes ")
 
                     trees.append(backupTree)
                 } catch {
@@ -90,21 +93,33 @@ public class XPCBackupService: NSObject, XPCBackupServiceProtocol {
                 
             }
             
-            
+            backupTotalProgress.totalUnitCount = Int64(totalNodesCount)
+            logger.info("Total progress to backup \(totalNodesCount)")
+
+            logger.info("⏱️ About to start node sync process for \(trees.count) BackupTrees...")
             
             for backupTree in trees {
                 do {
-                    try await backupTree.syncNodes()
+                    logger.error("Adding nodes sync operations")
+                    try backupTree.syncBelowNodes(withOperationQueue: self.uploadOperationQueue)
                 } catch {
                     self.status = .Failed
                     logger.error("Error backing up device \(error)")
                     reply(nil, error.localizedDescription)
                 }
             }
+            
+            self.uploadOperationQueue.addBarrierBlock {
+                logger.info("Sync nodes operations completed")
+                self.status = .Done
+                
+                self.trees = []
+                self.uploadOperationQueue.cancelAllOperations()
+                reply("synced all nodes for all trees", nil)
+            }
 
-            self.status = .Done
+            logger.info("Backups scheduled in OperationQueue")
             logger.info(["Backup sync status: \(backupTotalProgress.completedUnitCount) of \(backupTotalProgress.totalUnitCount) nodes synced"])
-            reply("synced all nodes for all trees", nil)
 
         }
 
@@ -113,14 +128,16 @@ public class XPCBackupService: NSObject, XPCBackupServiceProtocol {
     @objc func stopBackup() {
         logger.debug("STOP BACKUP")
         trees = []
+        
         self.status = .Stopped
+        self.uploadOperationQueue.cancelAllOperations()
         backupUploadService?.stopSync()
     }
     
     
     
     func getBackupStatus(with reply: @escaping (BackupProgressUpdate?, String?) -> Void) {
-        logger.info(["Backup sync status: \(backupTotalProgress.completedUnitCount) of \(backupTotalProgress.totalUnitCount) nodes synced"])
+        //logger.info(["Backup sync status: \(backupTotalProgress.completedUnitCount) of \(backupTotalProgress.totalUnitCount) nodes synced"])
         reply(BackupProgressUpdate(status: self.status, progress: backupTotalProgress), nil)
     }
 


### PR DESCRIPTION
This PR adds an OperationQueue that takes care of syncing the `BackupTreeNodes` in a folder creation dependent order, meaning that no nodes will be synced until the parent node is created.

The OperationQueue concurrency limit sets a treshold which tells the system how many sync operations can be performed at the same time.

The OperationQueue sync mechanism has a retry limit of 3, and uses a FIFO system, when a folder creation fails, it gets moved to the end of the queue until retried, using an exponential wait time which is 1s * Retry #