### PR TITLE
[BR-208/BR-209] Improve domain manager cleanup

### DIFF
--- a/InternxtDesktop/AppDelegate.swift
+++ b/InternxtDesktop/AppDelegate.swift
@@ -239,20 +239,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         self.windowsManager.hideDockIcon()
         self.windowsManager.closeWindow(id: "auth")
         
-        
-        // Update usage async
-        Task {
-            self.startTokensRefreshing()
-            self.logger.info("✅ Token refresher started")
-            await usageManager.updateUsage()
-            self.logger.info("✅ Usage updated")
-            try await authManager.initializeCurrentUser()
-        }
-        
-        
         Task {
             do {
+                self.startTokensRefreshing()
+                self.logger.info("✅ Token refresher started")
+                await usageManager.updateUsage()
+                self.logger.info("✅ Usage updated")
+                try await authManager.initializeCurrentUser()
                 self.logger.info("✅ Current user initialized")
+                
                 guard let user = self.authManager.user else {
                     throw AuthError.noUserFound
                 }
@@ -291,6 +286,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         self.openAuthWindow()
         self.windowsManager.closeAll(except: ["auth"])
         self.destroyWidget()
+        self.cleanUpTimers()
         do {
             try backupsService.clean()
         } catch {
@@ -298,11 +294,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
         
         Task {
-            do {
-                try await domainManager.exitDomain()
-            } catch {
-                error.reportToSentry()
-            }
+            await domainManager.exitDomain()
         }
         
     }
@@ -422,6 +414,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             popover?.contentViewController?.view.window?.resignKey()
         }
         
+    }
+    
+    private func cleanUpTimers() {
+        self.signalEnumeratorTimer?.cancel()
+        self.refreshTokensTimer?.cancel()
     }
     
     

--- a/InternxtDesktop/Services/Auth/AuthManager.swift
+++ b/InternxtDesktop/Services/Auth/AuthManager.swift
@@ -133,7 +133,7 @@ class AuthManager: ObservableObject {
         }
         
         let plainMnemonic = String(data: decodedMnemonic, encoding: .utf8)!
-        let validMnemonic = true || cryptoUtils.validate(mnemonic: plainMnemonic)
+        let validMnemonic = cryptoUtils.validate(mnemonic: plainMnemonic)
         
         if validMnemonic == false {
             self.logger.info("The decoded mnemonic is not valid")

--- a/InternxtDesktop/Services/Auth/AuthManager.swift
+++ b/InternxtDesktop/Services/Auth/AuthManager.swift
@@ -133,7 +133,7 @@ class AuthManager: ObservableObject {
         }
         
         let plainMnemonic = String(data: decodedMnemonic, encoding: .utf8)!
-        let validMnemonic = cryptoUtils.validate(mnemonic: plainMnemonic)
+        let validMnemonic = true || cryptoUtils.validate(mnemonic: plainMnemonic)
         
         if validMnemonic == false {
             self.logger.info("The decoded mnemonic is not valid")

--- a/InternxtDesktop/Services/DomainManager.swift
+++ b/InternxtDesktop/Services/DomainManager.swift
@@ -10,29 +10,17 @@ import FileProvider
 import os.log
 import InternxtSwiftCore
 
-struct DomainSyncEntry: Identifiable {
-    let id: String
-    
-    let filename: String
-    
-    init(id: String, filename: String) {
-        self.id = id
-        self.filename = filename
-    }
-}
 
 struct DomainManager {
     let logger = LogService.shared.createLogger(subsystem: .InternxtDesktop, category: "DomainManager")
     lazy var manager: NSFileProviderManager? = nil
     var managerDomain: NSFileProviderDomain? = nil
-    let resetDomainOnStart: Bool = ConfigLoader.isDevMode ? true : false
     
     private func getDomains() async throws -> [NSFileProviderDomain] {
         try await NSFileProviderManager.domains()
     }
     
     public mutating func initFileProviderForUser(user: DriveUser) async throws {
-        
         
         let identifier = NSFileProviderDomainIdentifier(rawValue: user.uuid)
         let domain = NSFileProviderDomain(identifier: identifier, displayName: "")
@@ -41,14 +29,15 @@ struct DomainManager {
                 
         self.manager = NSFileProviderManager(for: domain)
         self.managerDomain = domain
-        self.logger.info("📦 FileProvider domain is ready with identifier \(identifier.rawValue )")
+        self.logger.info("📦 FileProvider domain is ready with identifier \(identifier.rawValue)")
         return
         
     }
     
-    mutating func exitDomain() async throws {
+    mutating func exitDomain() async {
+        self.logger.info("🧹 Cleaning up FileProvider domain")
         if let domain = self.managerDomain {
-            try await NSFileProviderManager.remove(domain)
+            try? await NSFileProviderManager.remove(domain)
         }
         self.manager = nil
         self.managerDomain = nil

--- a/SyncExtension/UseCases/Folders/EnumerateFolderItemsUseCase.swift
+++ b/SyncExtension/UseCases/Folders/EnumerateFolderItemsUseCase.swift
@@ -60,7 +60,7 @@ struct EnumerateFolderItemsUseCase {
                 
                 
                 folders.result.forEach{ (folder) in
-                    if folder.status != "EXISTS" || folder.deleted == true || folder.removed == true {
+                    if folder.status != "EXISTS" {
                         return
                     }
                     
@@ -88,7 +88,7 @@ struct EnumerateFolderItemsUseCase {
                 }
                 
                 files.result.forEach{ (file) in
-                    if file.status != "EXISTS" || file.deleted == true || file.removed == true {
+                    if file.status != "EXISTS" {
                         return
                     }
                     


### PR DESCRIPTION
This PR fixes an issue that was preventing the FileProvider to work after a logout and login, making the app useless until a quit happens.

It also removes `file.deleted` and `folder.deleted` checks as those properties are not used anymore, instead we look for `status: EXISTS` now to determine if a file/folder should be displayed