### PR TITLE
[_]: Improve UI consistency

### DIFF
--- a/InternxtDesktop/Views/Backups/BackupAvailableDevicesView.swift
+++ b/InternxtDesktop/Views/Backups/BackupAvailableDevicesView.swift
@@ -137,7 +137,6 @@ struct BackupDeviceItem: View {
         .shadow(color: isSelected ? .black.opacity(0.05) : .clear, radius: 1, x: 0.0, y: 1.0)
         .overlay(
             RoundedRectangle(cornerRadius: 8)
-                .inset(by: -0.5)
                 .stroke(isSelected ? Color.Gray10 : .clear, lineWidth: 1)
         )
     }

--- a/InternxtDesktop/Views/Backups/BackupConfigView.swift
+++ b/InternxtDesktop/Views/Backups/BackupConfigView.swift
@@ -48,7 +48,7 @@ struct BackupConfigView: View {
                         if backupsService.thereAreMissingFoldersToBackup {
                             AppButton(title: "BACKUP_CHANGE_FOLDERS", onClick: {
                                 fixMissingFolders()
-                            }, type: .secondary)
+                            }, type: .secondary, size: .MD)
                             HStack(spacing:4) {
                                 ZStack {
                                     Color.white.ignoresSafeArea().frame(width:12, height:12).clipShape(RoundedRectangle(cornerRadius: 100))
@@ -68,7 +68,7 @@ struct BackupConfigView: View {
                         } else {
                             AppButton(title: "BACKUP_CHANGE_FOLDERS", onClick: {
                                 changeFolders()
-                            }, type: .secondary)
+                            }, type: .secondary, size: .MD)
                             
                             Text("BACKUP_\("\(numOfFolders)")_NUMBER_OF_FOLDERS_SELECTED")
                                 .font(.SMRegular)

--- a/InternxtDesktop/Views/Backups/BackupFrequencySelectorView.swift
+++ b/InternxtDesktop/Views/Backups/BackupFrequencySelectorView.swift
@@ -17,7 +17,7 @@ struct BackupFrequencySelectorView: View {
             AppText("BACKUP_UPLOAD_FREQUENCY")
                 .font(.SMMedium)
                 .foregroundColor(.Gray80)
-            HStack(spacing: 10){
+            HStack(spacing: 8){
                 AppSelector(
                     size: .MD,
                     options: [
@@ -32,8 +32,7 @@ struct BackupFrequencySelectorView: View {
                     setFrequency(option: selectedOption)
                     self.onClick(self.currentFrequency)
 
-                }
-                .frame(width: 150)
+                }.frame(width: 140)
                
                 if self.currentFrequency != .manually {
                     AppText(String(format: NSLocalizedString("BACKUP_NEXT_DATE", comment: ""), nextBackupTime))

--- a/InternxtDesktop/Views/Backups/BackupStatusView.swift
+++ b/InternxtDesktop/Views/Backups/BackupStatusView.swift
@@ -92,7 +92,6 @@ struct BackupStatusView: View {
         .shadow(color: .black.opacity(0.05), radius: 1, x: 0, y: 1)
         .overlay(
             RoundedRectangle(cornerRadius: 8)
-                .inset(by: -0.5)
                 .stroke(Color.Gray10, lineWidth: 1)
         )
     }

--- a/InternxtDesktop/Views/Backups/BackupsFolderListView.swift
+++ b/InternxtDesktop/Views/Backups/BackupsFolderListView.swift
@@ -25,7 +25,6 @@ struct BackupsFolderListView: View {
             .cornerRadius(8.0)
             .overlay(
                 RoundedRectangle(cornerRadius: 8)
-                    .inset(by: -0.5)
                     .stroke(Color.Gray10, lineWidth: 1)
             )
         } else {
@@ -42,7 +41,6 @@ struct BackupsFolderListView: View {
             .cornerRadius(8.0)
             .overlay(
                 RoundedRectangle(cornerRadius: 8)
-                    .inset(by: -0.5)
                     .stroke(Color.Gray10, lineWidth: 1)
             )
         }

--- a/InternxtDesktop/Views/Settings/AccountUsageView.swift
+++ b/InternxtDesktop/Views/Settings/AccountUsageView.swift
@@ -50,7 +50,6 @@ struct AccountUsageView: View {
         .cornerRadius(12)
         .overlay(
             RoundedRectangle(cornerRadius: 12)
-                .inset(by: -0.5)
                 .stroke(Color("Gray10"), lineWidth: 1)
         )
     }

--- a/InternxtDesktop/Views/Settings/GeneralTabView.swift
+++ b/InternxtDesktop/Views/Settings/GeneralTabView.swift
@@ -43,7 +43,7 @@ struct GeneralTabView: View {
                                     appSettings.selectedLanguage = language
                                 }
                             }
-                    }.padding(.top, 24)
+                    }.frame(width: 140).padding(.top, 24)
                 }
             }
             Divider().background(Color.Gray10).padding(.vertical, 24).zIndex(-1)

--- a/InternxtDesktop/Views/UIKit/AppButton.swift
+++ b/InternxtDesktop/Views/UIKit/AppButton.swift
@@ -23,9 +23,9 @@ enum AppButtonType {
 func getHeightBySize(size: AppButtonSize) -> CGFloat {
     switch size {
     case .SM:
-        return 28
-    case .MD:
         return 32
+    case .MD:
+        return 36
     case .LG:
         return 40
     }
@@ -131,7 +131,7 @@ struct SecondaryAppButtonStyle: ButtonStyle {
             .shadow(color: .black.opacity(0.05), radius: 1, x: 0, y: 1)
             .overlay(
                 RoundedRectangle(cornerRadius: 8)
-                    .inset(by: -0.5)
+                    
                     .stroke(getStrokeColor(), lineWidth: 1)
             )
 

--- a/InternxtDesktop/Views/UIKit/AppSelector.swift
+++ b/InternxtDesktop/Views/UIKit/AppSelector.swift
@@ -66,8 +66,8 @@ struct AppSelector: View {
                     
                 }.padding(.horizontal,12)
                 RoundedRectangle(cornerRadius: 6)
-                    .stroke(Color.Gray10, lineWidth: 2)
-            }.frame(height: getAppSelectorHeight(size) ).fixedSize(horizontal: true, vertical: true).contentShape(Rectangle()).onTapGesture {
+                    .stroke(Color.Gray10, lineWidth: 1)
+            }.frame(minWidth:geometry.size.width, minHeight: getAppSelectorHeight(size) ).fixedSize(horizontal: true, vertical: true).contentShape(Rectangle()).onTapGesture {
                 withAnimation {
                     self.optionsVisible = !self.optionsVisible
                 }


### PR DESCRIPTION
This PR fixes incorrect UI implementations, below described:

- Removed `insetBy` modifier from views, as it was causing sharp edges on some views
- Corrected button sizes to match Figma ones, MD buttons height has been increased to 32px as stated in Figma
- AppSelector now uses the parent view width, or fills the available space otherwise