### PR TITLE
[_]: Open URLs without scoped resource access

### DIFF
--- a/Shared/Extensions/URL.swift
+++ b/Shared/Extensions/URL.swift
@@ -39,12 +39,7 @@ struct URLFileAttribute {
 
 extension URL {
     func open() {
-        let hasAccess = self.startAccessingSecurityScopedResource()
-        if(hasAccess) {
-            NSWorkspace.shared.open(self)
-            self.stopAccessingSecurityScopedResource()
-        }
-        
+        NSWorkspace.shared.open(self)
     }
     
     func isDirectory() throws -> Bool {


### PR DESCRIPTION
Since this is breaking many URLs opening behaviours we are removing `startAccessingSecurityScopedResource` until we find a better solution