### PR TITLE
[PB-1305]: Download a backup feature + corner cases fixes

### DIFF
--- a/InternxtDesktop.xcodeproj/project.pbxproj
+++ b/InternxtDesktop.xcodeproj/project.pbxproj
@@ -81,6 +81,7 @@
 		E10B0FE02A94143F00B97874 /* Int.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10B0FDC2A94143F00B97874 /* Int.swift */; };
 		E112933F2A77221A003DEADF /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E112933E2A77221A003DEADF /* Colors.xcassets */; };
 		E12479D92C107C52000DAC11 /* Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A0AC652AB88507005E71D6 /* Analytics.swift */; };
+		E12479DB2C19B2D5000DAC11 /* BackupDownloadService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E12479DA2C19B2D5000DAC11 /* BackupDownloadService.swift */; };
 		E1312A4F2A7FE01E000EAA43 /* InternxtSwiftCore in Frameworks */ = {isa = PBXBuildFile; productRef = E1312A4E2A7FE01E000EAA43 /* InternxtSwiftCore */; };
 		E1313D2F2A9501BB00C7ABF0 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = E1313D2E2A9501BB00C7ABF0 /* Sentry */; };
 		E1313D3B2A9504D400C7ABF0 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = E1313D3A2A9504D400C7ABF0 /* Sentry */; };
@@ -236,6 +237,10 @@
 		E1E56C222BC0423A00DBA0BF /* BackupProgressUpdate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E56C212BC0423A00DBA0BF /* BackupProgressUpdate.swift */; };
 		E1E56C232BC0423A00DBA0BF /* BackupProgressUpdate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E56C212BC0423A00DBA0BF /* BackupProgressUpdate.swift */; };
 		E1E56C242BC0443900DBA0BF /* BackupProgressUpdate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E56C212BC0423A00DBA0BF /* BackupProgressUpdate.swift */; };
+		E1EEB5862C1C4B8800370D77 /* BackupDownloadItemOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1EEB5852C1C4B8800370D77 /* BackupDownloadItemOperation.swift */; };
+		E1EEB5872C1C52A900370D77 /* Time.swift in Sources */ = {isa = PBXBuildFile; fileRef = E145E16B2A82A21500B07E0B /* Time.swift */; };
+		E1EEB5912C21963400370D77 /* WidgetBackupDownloadEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1EEB5902C21963400370D77 /* WidgetBackupDownloadEntryView.swift */; };
+		E1EEB5922C23025900370D77 /* ActivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E17C84C32AB2FEF500A58414 /* ActivityManager.swift */; };
 		E1F616072A8D7DF8008C9E62 /* SignInWithBrowserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1F616062A8D7DF8008C9E62 /* SignInWithBrowserView.swift */; };
 		E1F616092A8D7E6F008C9E62 /* AppButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1F616082A8D7E6F008C9E62 /* AppButton.swift */; };
 		E1FB2D2C2A76BF0300473AE1 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E1FB2D2B2A76BF0300473AE1 /* Assets.xcassets */; };
@@ -343,6 +348,7 @@
 		E10971802A827A9500ABED41 /* CreateFolderUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateFolderUseCase.swift; sourceTree = "<group>"; };
 		E10B0FDC2A94143F00B97874 /* Int.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Int.swift; sourceTree = "<group>"; };
 		E112933E2A77221A003DEADF /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
+		E12479DA2C19B2D5000DAC11 /* BackupDownloadService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupDownloadService.swift; sourceTree = "<group>"; };
 		E13B83962AFBBCD7009F6684 /* AppSettingsManagerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettingsManagerView.swift; sourceTree = "<group>"; };
 		E13B83982AFBBD50009F6684 /* AppSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettings.swift; sourceTree = "<group>"; };
 		E13B839B2AFBBE67009F6684 /* AppUserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUserDefaults.swift; sourceTree = "<group>"; };
@@ -443,6 +449,8 @@
 		E1DB29602A7D6B80009036B8 /* WidgetContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetContentView.swift; sourceTree = "<group>"; };
 		E1DB29622A7D6BA5009036B8 /* WidgetFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetFooterView.swift; sourceTree = "<group>"; };
 		E1E56C212BC0423A00DBA0BF /* BackupProgressUpdate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupProgressUpdate.swift; sourceTree = "<group>"; };
+		E1EEB5852C1C4B8800370D77 /* BackupDownloadItemOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupDownloadItemOperation.swift; sourceTree = "<group>"; };
+		E1EEB5902C21963400370D77 /* WidgetBackupDownloadEntryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetBackupDownloadEntryView.swift; sourceTree = "<group>"; };
 		E1F616062A8D7DF8008C9E62 /* SignInWithBrowserView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInWithBrowserView.swift; sourceTree = "<group>"; };
 		E1F616082A8D7E6F008C9E62 /* AppButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppButton.swift; sourceTree = "<group>"; };
 		E1FB2D242A76BF0200473AE1 /* Internxt Drive.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Internxt Drive.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -700,6 +708,7 @@
 				3194368F2B9B81BD006F4600 /* BackupTreeNodeSyncResult.swift */,
 				E1E56C212BC0423A00DBA0BF /* BackupProgressUpdate.swift */,
 				E1D24AEF2C0467710009EC83 /* BackupTreeNodeSyncOperation.swift */,
+				E1EEB5852C1C4B8800370D77 /* BackupDownloadItemOperation.swift */,
 			);
 			path = Entities;
 			sourceTree = "<group>";
@@ -711,6 +720,7 @@
 				3120B55A2B84F12A00F524F1 /* BackupUploadService.swift */,
 				319436912B9B8293006F4600 /* BackupRealm.swift */,
 				E1FE2B292BC539810073B26D /* BackupRemoteSync.swift */,
+				E12479DA2C19B2D5000DAC11 /* BackupDownloadService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -847,6 +857,7 @@
 				E18300A32AA1FC7700AD023C /* SettingsMenuView.swift */,
 				E18300AD2AA230A600AD023C /* WidgetSyncEntryView.swift */,
 				31EBEF722B32006F0017590F /* WidgetBackupBannerView.swift */,
+				E1EEB5902C21963400370D77 /* WidgetBackupDownloadEntryView.swift */,
 			);
 			path = Widget;
 			sourceTree = "<group>";
@@ -1221,6 +1232,7 @@
 				E1D24AF62C0468AF0009EC83 /* AsyncOperation.swift in Sources */,
 				E15F8C102B76292F00C60EFA /* BackupTreeGenerator.swift in Sources */,
 				3120B56A2B84F48A00F524F1 /* ErrorUtils.swift in Sources */,
+				E12479DB2C19B2D5000DAC11 /* BackupDownloadService.swift in Sources */,
 				AA5EABE82BFD762D00BA0145 /* ProcessInfo.swift in Sources */,
 				31DEAEB32B75139400E76D53 /* XPCBackupServiceProtocol.swift in Sources */,
 				3120B5772B8518C300F524F1 /* Generic.swift in Sources */,
@@ -1231,6 +1243,7 @@
 				3120B5642B84F36C00F524F1 /* APIFactory.swift in Sources */,
 				31ABDEA12BA9FC5300EEA7F5 /* SyncedNode.swift in Sources */,
 				E1E56C232BC0423A00DBA0BF /* BackupProgressUpdate.swift in Sources */,
+				E1EEB5872C1C52A900370D77 /* Time.swift in Sources */,
 				E12479D92C107C52000DAC11 /* Analytics.swift in Sources */,
 				3120B5632B84F35100F524F1 /* ConfigLoader.swift in Sources */,
 				E1FD8C752BA989D900C257E0 /* LogService.swift in Sources */,
@@ -1245,9 +1258,11 @@
 				3120B55B2B84F12A00F524F1 /* BackupUploadService.swift in Sources */,
 				E13DBC692BCD4E5B00F6B43E /* BackupsService.swift in Sources */,
 				AA5EABE92BFD770200BA0145 /* AnalyticsEvents.swift in Sources */,
+				E1EEB5922C23025900370D77 /* ActivityManager.swift in Sources */,
 				E13DBC6A2BCD4F2900F6B43E /* UsageManager.swift in Sources */,
 				E1FE2B2A2BC539810073B26D /* BackupRemoteSync.swift in Sources */,
 				AA5EABE62BFD761F00BA0145 /* NetworkAnalyticsEvents.swift in Sources */,
+				E1EEB5862C1C4B8800370D77 /* BackupDownloadItemOperation.swift in Sources */,
 				E15F8C3B2B762D4200C60EFA /* BackupTreeNode.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1296,6 +1311,7 @@
 				E17C84AE2AB2232000A58414 /* OnboardingView.swift in Sources */,
 				E1DB295D2A7D64AB009036B8 /* WidgetHeaderView.swift in Sources */,
 				E1581DCA2A95221D0051DD46 /* FileProvider.swift in Sources */,
+				E1EEB5912C21963400370D77 /* WidgetBackupDownloadEntryView.swift in Sources */,
 				E13B83992AFBBD50009F6684 /* AppSettings.swift in Sources */,
 				E17C84B22AB22C1400A58414 /* OnboardingSlide2View.swift in Sources */,
 				E1A0AC612AB8639C005E71D6 /* AppTextArea.swift in Sources */,
@@ -2157,7 +2173,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/internxt/swift-core";
 			requirement = {
-				branch = main;
+				branch = "feature/debug-network-requests";
 				kind = branch;
 			};
 		};

--- a/InternxtDesktop.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/InternxtDesktop.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/internxt/swift-core",
       "state" : {
-        "branch" : "main",
-        "revision" : "d45590c24787995c30ecbdeeb5ed4ec62b4e6b24"
+        "branch" : "feature/debug-network-requests",
+        "revision" : "589a7d4ab95bad841479eb7aa3dd089c7d23b044"
       }
     },
     {

--- a/InternxtDesktop/AppDelegate.swift
+++ b/InternxtDesktop/AppDelegate.swift
@@ -371,6 +371,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 .environmentObject(self.usageManager)
                 .environmentObject(self.activityManager)
                 .environmentObject(self.settingsManager)
+                .environmentObject(self.backupsService)
         )
     }
     

--- a/InternxtDesktop/Services/Auth/AuthManager.swift
+++ b/InternxtDesktop/Services/Auth/AuthManager.swift
@@ -133,7 +133,7 @@ class AuthManager: ObservableObject {
         }
         
         let plainMnemonic = String(data: decodedMnemonic, encoding: .utf8)!
-        let validMnemonic = true || cryptoUtils.validate(mnemonic: plainMnemonic)
+        let validMnemonic = cryptoUtils.validate(mnemonic: plainMnemonic)
         
         if validMnemonic == false {
             self.logger.info("The decoded mnemonic is not valid")

--- a/InternxtDesktop/Services/Auth/AuthManager.swift
+++ b/InternxtDesktop/Services/Auth/AuthManager.swift
@@ -133,7 +133,7 @@ class AuthManager: ObservableObject {
         }
         
         let plainMnemonic = String(data: decodedMnemonic, encoding: .utf8)!
-        let validMnemonic = cryptoUtils.validate(mnemonic: plainMnemonic)
+        let validMnemonic = true || cryptoUtils.validate(mnemonic: plainMnemonic)
         
         if validMnemonic == false {
             self.logger.info("The decoded mnemonic is not valid")

--- a/InternxtDesktop/Views/Backups/BackupStatusView.swift
+++ b/InternxtDesktop/Views/Backups/BackupStatusView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct BackupStatusView: View {
     @Environment(\.colorScheme) var colorScheme
-    @Binding var backupStatus: BackupStatus
+    @Binding var backupUploadStatus: BackupStatus
     @Binding var device: Device
     @Binding var progress: Double
 
@@ -22,8 +22,7 @@ struct BackupStatusView: View {
     
     private func deviceIsRunningBackup() -> Bool {
         
-        
-        return self.device.isCurrentDevice && self.backupStatus == .InProgress
+        return self.device.isCurrentDevice && self.backupUploadStatus == .InProgress
     }
     
     private func getBackupProgressPercentage() -> String {
@@ -99,7 +98,7 @@ struct BackupStatusView: View {
 
 #Preview {
     BackupStatusView(
-        backupStatus: .constant(.InProgress),
+        backupUploadStatus: .constant(.InProgress),
         device: .constant(
             Device(
                 id: 1,

--- a/InternxtDesktop/Views/Backups/BackupsTabView.swift
+++ b/InternxtDesktop/Views/Backups/BackupsTabView.swift
@@ -36,7 +36,7 @@ struct BackupsTabView: View {
     }
     
     func backupIsInProgress() -> Bool {
-        return backupsService.backupStatus == .InProgress
+        return backupsService.backupUploadStatus == .InProgress
     }
     
     func thereAreDevicesLoaded() -> Bool {
@@ -141,7 +141,7 @@ struct BackupsTabView: View {
                     BackupConfigView(
                         numOfFolders: backupsService.foldersToBackup.count,
                         backupsService: self.backupsService,
-                        backupStatus: $backupsService.backupStatus,
+                        backupUploadStatus: $backupsService.backupUploadStatus,
                         showStopBackupDialog: $showStopBackupDialog,
                         showDeleteBackupDialog: $showDeleteBackupDialog,
                         showFolderSelector: $showFolderSelector,

--- a/InternxtDesktop/Views/Backups/StopBackupDialogView.swift
+++ b/InternxtDesktop/Views/Backups/StopBackupDialogView.swift
@@ -47,7 +47,7 @@ struct StopBackupDialogView: View {
     }
 
     private func stopBackup() throws {
-        try backupsService.stopBackup()
+        try backupsService.stopBackupUpload()
         self.onClose()
     }
 }

--- a/InternxtDesktop/Views/Widget/WidgetBackupDownloadEntryView.swift
+++ b/InternxtDesktop/Views/Widget/WidgetBackupDownloadEntryView.swift
@@ -1,22 +1,26 @@
 //
-//  WidgetSyncEntryView.swift
+//  WidgetBackupDownloadEntryView.swift
 //  InternxtDesktop
 //
-//  Created by Robert Garcia on 1/9/23.
+//  Created by Robert Garcia on 18/6/24.
 //
 
+import Foundation
 import SwiftUI
 
 
-struct WidgetSyncEntryView: View {
-    let filename: String
-    let operationKind: ActivityEntryOperationKind
+struct WidgetBackupOperationEntryView: View {
+    let deviceName: String
     let status: ActivityEntryStatus
+    @Binding var downloadedItems: Int64
     
+    private func getDisplayName() -> String {
+        return "Backup — \"\(deviceName)\""
+    }
     var body: some View {
         VStack(alignment: .center, spacing: 0){
             HStack(alignment: .center, spacing: 10){
-                Image(operationKind == .backupDownload ? "backup_folder" : getFileExtensionIconName(filenameWithExtension: filename))
+                Image("backup_folder")
                     .resizable()
                     .scaledToFit()
                     .frame(height: 32)
@@ -26,11 +30,11 @@ struct WidgetSyncEntryView: View {
                     .shadow(color: .black.opacity(0.02), radius: 8, x: 0, y: 8)
                     .shadow(color: .black.opacity(0.02), radius: 4, x: 0, y: 4)
                 VStack(alignment: .leading){
-                    Text(verbatim: filename)
+                    Text(verbatim: getDisplayName())
                         .font(.SMMedium)
                         .foregroundColor(.Gray100)
                         .lineLimit(1)
-                        .help(filename)
+                        .help(getDisplayName())
                     EntryStatusSubtitle
                 }
                 
@@ -44,23 +48,18 @@ struct WidgetSyncEntryView: View {
     
     @ViewBuilder
     var EntryStatusSubtitle: some View {
-        switch self.operationKind {
-        case .backupDownload:
-            AppText("SYNC_ENTRY_KIND_DOWNLOADED").font(.XSMedium).foregroundColor(.Gray50)
-        case .trash:
-            AppText("SYNC_ENTRY_KIND_TRASHED").font(.XSMedium).foregroundColor(.Gray50)
-        case .download:
-            AppText("SYNC_ENTRY_KIND_DOWNLOADED").font(.XSMedium).foregroundColor(.Gray50)
-        case .upload:
-            AppText("SYNC_ENTRY_KIND_UPLOADED").font(.XSMedium).foregroundColor(.Gray50)
-        default:
-            EmptyView()
-        }
+        Text("\(String(downloadedItems))_BACKUP_DOWNLOADED_ITEMS").font(.XSMedium)
+            .foregroundColor(.Gray50)
     }
 
     @ViewBuilder
     var EntryStatus: some View {
         switch self.status {
+        case .inProgress:
+            HStack(alignment:.center, content: {
+                ProgressView().controlSize(.small)
+            }).frame(width: 24)
+            
         case .finished:
             AppIcon(iconName: .Check, size: 24, color: .GreenDark)
         default:
@@ -69,12 +68,11 @@ struct WidgetSyncEntryView: View {
     }
 }
 
-struct WidgetSyncEntry_Previews: PreviewProvider {
+struct WidgetBackupOperationEntryView_Previews: PreviewProvider {
     static var previews: some View {
         VStack{
-            WidgetSyncEntryView(filename: "Frontend_web.fig", operationKind: .trash, status: .finished)
-            WidgetSyncEntryView(filename: "demo.mp4", operationKind: .download, status: .finished)
-            WidgetSyncEntryView(filename: "doggo.jpg", operationKind: .upload, status: .finished)
+            WidgetBackupOperationEntryView(deviceName: "Mac Mini M1", status: .inProgress, downloadedItems: .constant(5))
+            
         }.frame(width: 330).background(Color("Surface"))
         
     }

--- a/InternxtDesktop/Views/Widget/WidgetContentView.swift
+++ b/InternxtDesktop/Views/Widget/WidgetContentView.swift
@@ -9,13 +9,20 @@ import SwiftUI
 import FileProvider
 import RealmSwift
 struct WidgetContentView: View {
-    
+    @EnvironmentObject var backupsService: BackupsService
     @Binding var activityEntries: [ActivityEntry]
 
+    func backupDownloadInProgress() -> Bool {
+        backupsService.backupDownloadStatus == .InProgress
+    }
+    
+ 
     var body: some View {
-        
         ScrollView(.vertical, showsIndicators: false) {
             VStack(alignment: .leading,spacing: 0) {
+                if(backupDownloadInProgress()) {
+                    WidgetBackupOperationEntryView(deviceName: backupsService.deviceDownloading?.plainName ?? "Device", status: .inProgress, downloadedItems: $backupsService.backupDownloadedItems)
+                }
                 ForEach(activityEntries) { activityEntry in
                    WidgetSyncEntryView(
                     filename: activityEntry.filename,
@@ -23,7 +30,7 @@ struct WidgetContentView: View {
                     status: activityEntry.status
                    )
                 }.listRowInsets(EdgeInsets()).frame(maxWidth: .infinity)
-            }.padding(.top, 8)
+            }.padding(.top, 0)
             
         }
         .padding(.horizontal, 0)
@@ -39,6 +46,15 @@ struct WidgetContentView: View {
 
 struct WidgetContentView_Previews: PreviewProvider {
     static var previews: some View {
-        WidgetContentView(activityEntries: .constant([]))
+        VStack {
+            WidgetContentView(activityEntries: .constant([
+                ActivityEntry(filename: "file123.png", kind: .download, status: .finished),
+                ActivityEntry(filename: "video2.mp4", kind:.trash, status: .finished),
+                ActivityEntry(filename: "image.jpg", kind:.trash, status: .finished),
+                ActivityEntry(filename: "dog.mp4", kind:.trash, status: .finished),
+                ActivityEntry(filename: "audio.mp3", kind:.trash, status: .finished),
+                ActivityEntry(filename: "design.fig", kind:.trash, status: .finished)])).environmentObject(BackupsService())
+        }.frame(maxWidth: 400,maxHeight: 600)
+        
     }
 }

--- a/Shared/Services/ActivityManager.swift
+++ b/Shared/Services/ActivityManager.swift
@@ -88,7 +88,7 @@ class ActivityManager: ObservableObject {
                         self?.updateActivityEntries()
                     case .update:
                         self?.updateActivityEntries()
-                    case .error(let error):
+                    case .error:
                         return
                     }
             }
@@ -133,6 +133,7 @@ enum ActivityEntryOperationKind: String, PersistableEnum {
     case download
     case upload
     case move
+    case backupDownload
 }
 
 enum ActivityEntryStatus: String, PersistableEnum {

--- a/Shared/en.lproj/Localizable.strings
+++ b/Shared/en.lproj/Localizable.strings
@@ -41,6 +41,7 @@
 "BACKUP_BACKING_UP" = "Backing up...";
 "BACKUP_STOP_BACKUP" = "Stop backup";
 "BACKUP_DOWNLOAD" = "Download";
+"BACKUP_DOWNLOAD_STOP" = "Stop download";
 "BACKUP_BROWSE_FILES" = "Browse files";
 "BACKUP_SELECTED_FOLDERS" = "Selected folders";
 "BACKUP_CHANGE_FOLDERS" = "Change folders";
@@ -68,6 +69,9 @@
 "BACKUP_LOCATE_FOLDER" = "Locate folder";
 "BACKUP_ERROR_BACKING_UP" = "Error backing up this device";
 "BACKUP_NEXT_DATE" = "Next backup at %@";
+"%@_BACKUP_DOWNLOADED_ITEMS" = "%@ items downloaded";
+"BACKUP_DOWNLOAD_IN_PROGRESS_ALERT_TITLE" = "Backup download in progress";
+"BACKUP_DOWNLOAD_IN_PROGRESS_ALERT_MESSAGE" = "A backup download is already in progress, please wait until it is finished.";
 
 // Settings
 "SETTINGS_TAB_GENERAL_TITLE" = "General";

--- a/Shared/es.lproj/Localizable.strings
+++ b/Shared/es.lproj/Localizable.strings
@@ -41,6 +41,7 @@
 "BACKUP_BACKING_UP" = "Respaldando...";
 "BACKUP_STOP_BACKUP" = "Detener copia de seguridad";
 "BACKUP_DOWNLOAD" = "Descargar";
+"BACKUP_DOWNLOAD_STOP" = "Detener descarga";
 "BACKUP_BROWSE_FILES" = "Examinar archivos";
 "BACKUP_SELECTED_FOLDERS" = "Carpetas seleccionadas";
 "BACKUP_CHANGE_FOLDERS" = "Cambiar carpetas";
@@ -68,6 +69,10 @@
 "BACKUP_FETCHING_DEVICES" = "Obteniendo tus dispositivos con Backups";
 "BACKUP_ERROR_BACKING_UP" = "Error al realizar la copia de seguridad de este dispositivo";
 "BACKUP_NEXT_DATE" = "Próxima copia de seguridad en %@";
+"%@_BACKUP_DOWNLOADED_ITEMS" = "%@ items descargados";
+"BACKUP_DOWNLOAD_IN_PROGRESS_ALERT_TITLE" = "Descarga de Backup ya en progreso";
+"BACKUP_DOWNLOAD_IN_PROGRESS_ALERT_MESSAGE" = "Ya hay una descarga de un Backup en progreso, debes esperar hasta que finalice";
+
 
 // Settings
 "SETTINGS_TAB_GENERAL_TITLE" = "General";

--- a/Shared/fr.lproj/Localizable.strings
+++ b/Shared/fr.lproj/Localizable.strings
@@ -68,7 +68,7 @@
 "BACKUP_ERROR_BACKING_UP" = "Erreur de sauvegarde de ce dispositif";
 "BACKUP_NEXT_DATE" = "Prochaine sauvegarde à %@";
 "%@_BACKUP_DOWNLOADED_ITEMS" = "%@ éléments téléchargés";
-"BACKUP_DOWNLOAD_IN_PROGRESS_ALERT_TITLE" = "Descarga de Backup ya en progreso" ;
+"BACKUP_DOWNLOAD_IN_PROGRESS_ALERT_TITLE" = "Le téléchargement de la sauvegarde est déjà en cours";
 "BACKUP_DOWNLOAD_IN_PROGRESS_ALERT_MESSAGE" = "Un téléchargement de sauvegarde est déjà en cours, veuillez patienter jusqu'à ce qu'il soit terminé" ;
 
 

--- a/Shared/fr.lproj/Localizable.strings
+++ b/Shared/fr.lproj/Localizable.strings
@@ -41,6 +41,7 @@
 "BACKUP_BACKING_UP" = "Sauvegardons...";
 "BACKUP_STOP_BACKUP" = "Arrêter la sauvegarde";
 "BACKUP_DOWNLOAD" = "Télécharger";
+"BACKUP_DOWNLOAD_STOP" = "Arrêter le déchargement";
 "BACKUP_BROWSE_FILES" = "Parcourir les fichiers";
 "BACKUP_SELECTED_FOLDERS" = "Dossiers sélectionnés";
 "BACKUP_CHANGE_FOLDERS" = "Modifier les dossiers";
@@ -66,6 +67,10 @@
 "BACKUP_LOCATE_FOLDER" = "Localiser le dossier";
 "BACKUP_ERROR_BACKING_UP" = "Erreur de sauvegarde de ce dispositif";
 "BACKUP_NEXT_DATE" = "Prochaine sauvegarde à %@";
+"%@_BACKUP_DOWNLOADED_ITEMS" = "%@ éléments téléchargés";
+"BACKUP_DOWNLOAD_IN_PROGRESS_ALERT_TITLE" = "Descarga de Backup ya en progreso" ;
+"BACKUP_DOWNLOAD_IN_PROGRESS_ALERT_MESSAGE" = "Un téléchargement de sauvegarde est déjà en cours, veuillez patienter jusqu'à ce qu'il soit terminé" ;
+
 
 // Settings
 "SETTINGS_TAB_GENERAL_TITLE" = "Général";

--- a/XPCBackupService/Entities/BackupDownloadItemOperation.swift
+++ b/XPCBackupService/Entities/BackupDownloadItemOperation.swift
@@ -1,0 +1,49 @@
+//
+//  BackupDownloadItemOperation.swift
+//  XPCBackupService
+//
+//  Created by Robert Garcia on 14/6/24.
+//
+
+import Foundation
+import InternxtSwiftCore
+class BackupDownloadItemOperation: AsyncOperation {
+    let networkFacade: NetworkFacade
+    let bucketId: String
+    let fileId: String
+    let encryptedContentURL: URL
+    let downloadAt: URL
+    let backupDownloadProgress: Progress
+    
+    init(networkFacade: NetworkFacade, bucketId: String, fileId: String, encryptedContentURL: URL, downloadAt: URL, backupDownloadProgress: Progress) {
+        self.networkFacade = networkFacade
+        self.bucketId = bucketId
+        self.fileId = fileId
+        self.encryptedContentURL = encryptedContentURL
+        self.downloadAt = downloadAt
+        self.backupDownloadProgress = backupDownloadProgress
+    }
+    
+    
+    override func performAsyncTask() async throws -> Void {
+        logger.info("⬇️ Downloading file at \(downloadAt.path) with fileID \(fileId)")
+        let encryptedFileURL = self.encryptedContentURL.appendingPathComponent(UUID().uuidString)
+       
+        let _ = try await networkFacade.downloadFile(
+            bucketId: bucketId,
+            fileId: fileId,
+            encryptedFileDestination: encryptedFileURL,
+            destinationURL: downloadAt,
+            progressHandler: { completedProgress in }
+        )
+        
+        backupDownloadProgress.completedUnitCount += 1
+        
+        defer {
+            logger.info("🧹 Cleaning up encrypted file...")
+            try? FileManager.default.removeItem(at: encryptedContentURL)
+        }
+        
+        logger.info("✅ File downloaded at \(downloadAt.path)")
+    }
+}

--- a/XPCBackupService/Services/BackupDownloadService.swift
+++ b/XPCBackupService/Services/BackupDownloadService.swift
@@ -38,6 +38,8 @@ struct BackupDownloadService {
         let backupFolders = try await backupAPI.getBackupChilds(folderId: folderId)
         
         backupDownloadProgress.totalUnitCount += Int64(backupFolders.result.count)
+        
+        // Create each folder, and request the folders childs
         try backupFolders.result.forEach{backupFolder in
             let backupFolderName = try backupFolder.plainName ?? self.decryptName(name: backupFolder.name, bucketId: backupBucket)
             let folderURL = self.getURLForItem(
@@ -57,6 +59,7 @@ struct BackupDownloadService {
             
         }
         
+        // Download files
         let backupFiles = try await backupAPI.getBackupFiles(folderId: folderId)
         backupDownloadProgress.totalUnitCount += Int64(backupFiles.result.count)
         for backupFile in backupFiles.result {

--- a/XPCBackupService/Services/BackupDownloadService.swift
+++ b/XPCBackupService/Services/BackupDownloadService.swift
@@ -1,0 +1,100 @@
+//
+//  BackupDownloadService.swift
+//  XPCBackupService
+//
+//  Created by Robert Garcia on 12/6/24.
+//
+
+import Foundation
+import InternxtSwiftCore
+
+struct BackupDownloadService {
+    let downloadOperationQueue: OperationQueue
+    let backupAPI: BackupAPI
+    let driveNewAPI: DriveAPI
+    let networkFacade: NetworkFacade
+    let encryptedContentURL: URL
+    let decrypt: Decrypt
+    let backupBucket: String
+    let backupDownloadProgress: Progress
+    
+    func downloadDeviceBackup(deviceId: Int, downloadAt: URL) async throws {
+        let deviceBackupFolders = try await backupAPI.getBackupChilds(folderId: String(deviceId))
+        backupDownloadProgress.totalUnitCount += Int64(deviceBackupFolders.result.count)
+        for deviceBackupFolder in deviceBackupFolders.result {
+            let backupFolderName = try deviceBackupFolder.plainName ?? self.decryptName(name: deviceBackupFolder.name, bucketId: backupBucket)
+            let backupFolderURL = self.getURLForItem(baseURL: downloadAt, itemName: backupFolderName)
+            let creationDate = Time.dateFromISOString(deviceBackupFolder.createdAt) ?? Date()
+            try self.createFolder(folderURL: backupFolderURL, creationDate: creationDate)
+            backupDownloadProgress.completedUnitCount += 1
+            try await self.downloadBackupFolderAtPath(
+                folderId: String(deviceBackupFolder.id),
+                downloadAtPath: backupFolderURL
+            )
+        }
+    }
+    
+    func downloadBackupFolderAtPath(folderId: String, downloadAtPath: URL) async throws {
+        let backupFolders = try await backupAPI.getBackupChilds(folderId: folderId)
+        
+        backupDownloadProgress.totalUnitCount += Int64(backupFolders.result.count)
+        try backupFolders.result.forEach{backupFolder in
+            let backupFolderName = try backupFolder.plainName ?? self.decryptName(name: backupFolder.name, bucketId: backupBucket)
+            let folderURL = self.getURLForItem(
+                baseURL: downloadAtPath, itemName: backupFolderName
+            )
+            let creationDate = Time.dateFromISOString(backupFolder.createdAt) ?? Date()
+            try self.createFolder(folderURL: folderURL, creationDate: creationDate)
+            logger.info("📁 Folder created at \(folderURL.path)")
+            Task {
+                do {
+                    try await self.downloadBackupFolderAtPath(folderId: String(backupFolder.id), downloadAtPath: folderURL)
+                } catch {
+                    logger.error("Failed to download backup folder with name \(backupFolderName) at \(downloadAtPath)")
+                }
+                
+            }
+            
+        }
+        
+        let backupFiles = try await backupAPI.getBackupFiles(folderId: folderId)
+        backupDownloadProgress.totalUnitCount += Int64(backupFiles.result.count)
+        for backupFile in backupFiles.result {
+            let backupFileName = try backupFile.plainName ?? self.decryptName(name: backupFile.name, bucketId: backupFile.bucket)
+            let fileURL = self.getURLForItem(baseURL: downloadAtPath, itemName: backupFileName, itemType: backupFile.type)
+            try await self.downloadFile(
+                fileId: backupFile.fileId,
+                bucketId: backupBucket,
+                downloadAt: fileURL
+            )
+        }
+        
+    }
+    
+    private func downloadFile(fileId: String, bucketId: String, downloadAt: URL) async throws {
+        let downloadFileOperation = BackupDownloadItemOperation(
+            networkFacade: self.networkFacade,
+            bucketId: bucketId,
+            fileId: fileId,
+            encryptedContentURL: encryptedContentURL,
+            downloadAt: downloadAt,
+            backupDownloadProgress: self.backupDownloadProgress
+        )
+        self.downloadOperationQueue.addOperation(downloadFileOperation)
+    }
+    
+    private func createFolder(folderURL: URL, creationDate: Date) throws {
+        try FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories:true, attributes: [.creationDate: creationDate])
+    }
+    
+    
+    
+    private func getURLForItem(baseURL: URL, itemName: String, itemType: String? = nil) -> URL {
+        let type: String = (itemType != nil) ? ".\(itemType!)" : ""
+        return baseURL.appendingPathComponent("\(itemName)\(type)")
+    }
+    
+    func decryptName(name: String, bucketId: String) throws -> String {
+        return try decrypt.decrypt(base64String: name, password: DecryptUtils().getDecryptPassword(bucketId: bucketId))
+    }
+}

--- a/XPCBackupService/Services/BackupUploadService.swift
+++ b/XPCBackupService/Services/BackupUploadService.swift
@@ -25,6 +25,10 @@ enum BackupUploadError: Error {
     case BackupStoppedManually
 }
 
+enum BackupDownloadError: Error {
+    case missingDeviceUuid
+}
+
 class BackupUploadService: ObservableObject {
     private let logger = LogService.shared.createLogger(subsystem: .XPCBackups, category: "App")
     private let cryptoUtils = CryptoUtils()

--- a/XPCBackupService/XPCBackupService.swift
+++ b/XPCBackupService/XPCBackupService.swift
@@ -185,10 +185,8 @@ public class XPCBackupService: NSObject, XPCBackupServiceProtocol {
     
     @objc func stopBackupDownload() {
         logger.debug("STOP BACKUP DOWNLOAD")
-        trees = []
         self.backupDownloadStatus = .Stopped
         self.downloadOperationQueue.cancelAllOperations()
-        backupUploadService?.stopSync()
     }
     
     

--- a/XPCBackupService/XPCBackupServiceProtocol.swift
+++ b/XPCBackupService/XPCBackupServiceProtocol.swift
@@ -9,11 +9,24 @@ import Foundation
 
 @objc protocol XPCBackupServiceProtocol {
     
-    func startBackup(backupAt backupURLs: [String], mnemonic: String, networkAuth: String?, authToken: String, newAuthToken: String, deviceId: Int, bucketId: String, with reply: @escaping (_ result: String?, _ error: String?) -> Void)
-
-    func stopBackup()
+    func uploadDeviceBackup(backupAt backupURLs: [String], mnemonic: String, networkAuth: String?, authToken: String, newAuthToken: String, deviceId: Int, bucketId: String, with reply: @escaping (_ result: String?, _ error: String?) -> Void)
     
-    func getBackupStatus(with reply: @escaping (_ result: BackupProgressUpdate?, _ error: String?) -> Void)
+    func downloadDeviceBackup(
+        downloadAt downloadAtURL: String,
+        mnemonic: String,
+        networkAuth: String,
+        authToken: String,
+        newAuthToken: String,
+        deviceId: Int,
+        bucketId: String,
+        with reply: @escaping (_ result: String?, _ error: String?) -> Void
+    )
+
+    func stopBackupUpload()
+    func stopBackupDownload()
+    
+    func getBackupUploadStatus(with reply: @escaping (_ result: BackupProgressUpdate?, _ error: String?) -> Void)
+    func getBackupDownloadStatus(with reply: @escaping (_ result: BackupProgressUpdate?, _ error: String?) -> Void)
 
 }
 


### PR DESCRIPTION
This PR exposes a new XPCService handler that takes care of performing an entire backup download for a given device.

The XPCService performs the download using an `OperationQueue` and progress is reported by polling the `getBackupDownloadStatus` XPCService handler.

As of today, only one backup device download can happen at the same time, and the backup download will overwrite whatever it finds in the destination.

Naming cleanup has been performed in the project to be consistent with the Backups operations we are performing

I.E:

- `startBackup` has been renamed to `startBackupUpload`
- `getBackupStatus` has been renamed to `getBackupUploadStatus` and `getBackupDownloadStatus`

This allows us to be more specific with the operations we are performing