### PR TITLE
Fix/clean xpc token

### DIFF
--- a/InternxtDesktop.xcodeproj/project.pbxproj
+++ b/InternxtDesktop.xcodeproj/project.pbxproj
@@ -357,6 +357,7 @@
 		31EBEF722B32006F0017590F /* WidgetBackupBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetBackupBannerView.swift; sourceTree = "<group>"; };
 		31ED949C2B7151E200EF699F /* DecryptUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecryptUtils.swift; sourceTree = "<group>"; };
 		AA43956F2C174B52003AA905 /* ScheduledBackupManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduledBackupManager.swift; sourceTree = "<group>"; };
+		AAAC21442C2E567100B44904 /* XPCBackupServiceDebug.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = XPCBackupServiceDebug.entitlements; sourceTree = "<group>"; };
 		AAC188EE2C2231B1007E321A /* MockBackupRealm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBackupRealm.swift; sourceTree = "<group>"; };
 		AAC188F02C2231E7007E321A /* MockBackupUploadService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBackupUploadService.swift; sourceTree = "<group>"; };
 		AAED64A02C23E85000CD971B /* JWTDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWTDecoder.swift; sourceTree = "<group>"; };
@@ -581,6 +582,7 @@
 		31DEAEAF2B75139400E76D53 /* XPCBackupService */ = {
 			isa = PBXGroup;
 			children = (
+				AAAC21442C2E567100B44904 /* XPCBackupServiceDebug.entitlements */,
 				3120B56D2B84F6B100F524F1 /* Extensions */,
 				E15F8C0E2B76291B00C60EFA /* Services */,
 				E15F8C0D2B76290B00C60EFA /* Entities */,
@@ -1553,7 +1555,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
-				CODE_SIGN_ENTITLEMENTS = XPCBackupService/XPCBackupService.entitlements;
+				CODE_SIGN_ENTITLEMENTS = XPCBackupService/XPCBackupServiceDebug.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;

--- a/Shared/Services/Backups/BackupsService.swift
+++ b/Shared/Services/Backups/BackupsService.swift
@@ -393,12 +393,6 @@ class BackupsService: ObservableObject {
             throw BackupError.bucketIdIsNil
         }
 
-        let authManager = AuthManager()
-        guard let mnemonic = authManager.mnemonic else {
-            logger.error("Cannot get mnemonic")
-            throw BackupError.cannotGetMnemonic
-        }
-
         logger.info("Setting connection to XPCBackupService...")
         //Connection to xpc service
         let xpcBackupService = try await getXPCBackupServiceProtocol(onConnectionIssue: {
@@ -413,7 +407,7 @@ class BackupsService: ObservableObject {
         let urlsStrings = foldersToBackup.map { folderToBackup in folderToBackup.url.absoluteString.replacingOccurrences(of: "file://", with: "").removingPercentEncoding ?? "" }
 
 
-        xpcBackupService.uploadDeviceBackup(backupAt: urlsStrings, mnemonic: mnemonic, networkAuth: networkAuth,deviceId: currentDevice.id, bucketId: bucketId, with: { response, error in
+        xpcBackupService.uploadDeviceBackup(backupAt: urlsStrings,networkAuth: networkAuth,deviceId: currentDevice.id, bucketId: bucketId, with: { response, error in
             if let error = error {
                 self.propagateError(errorMessage: error)
             } else {
@@ -445,11 +439,6 @@ class BackupsService: ObservableObject {
             throw BackupError.bucketIdIsNil
         }
 
-        let authManager = AuthManager()
-        guard let mnemonic = authManager.mnemonic else {
-            logger.error("Cannot get mnemonic")
-            throw BackupError.cannotGetMnemonic
-        }
 
         logger.info("Setting connection to XPCBackupService...")
         
@@ -472,7 +461,6 @@ class BackupsService: ObservableObject {
         backupDownloadProgressTimer?.cancel()
         xpcBackupService.downloadDeviceBackup(
             downloadAt: URLAsString,
-            mnemonic: mnemonic,
             networkAuth: networkAuthUnwrapped,
             deviceId:device.id,
             bucketId: deviceBucketId,

--- a/Shared/Services/Backups/BackupsService.swift
+++ b/Shared/Services/Backups/BackupsService.swift
@@ -408,18 +408,12 @@ class BackupsService: ObservableObject {
         logger.info("✅ Connection to XPCBackupService stablished")
         let configLoader = ConfigLoader()
         let networkAuth = configLoader.getNetworkAuth()
-        let authToken = configLoader.getLegacyAuthToken()
-        let newAuthToken = configLoader.getAuthToken()
-
-        guard let authToken = authToken, let newAuthToken = newAuthToken else {
-            logger.error("Cannot create auth token")
-            throw BackupError.cannotCreateAuthToken
-        }
+    
 
         let urlsStrings = foldersToBackup.map { folderToBackup in folderToBackup.url.absoluteString.replacingOccurrences(of: "file://", with: "").removingPercentEncoding ?? "" }
 
 
-        xpcBackupService.uploadDeviceBackup(backupAt: urlsStrings, mnemonic: mnemonic, networkAuth: networkAuth, authToken: authToken, newAuthToken: newAuthToken, deviceId: currentDevice.id, bucketId: bucketId, with: { response, error in
+        xpcBackupService.uploadDeviceBackup(backupAt: urlsStrings, mnemonic: mnemonic, networkAuth: networkAuth,deviceId: currentDevice.id, bucketId: bucketId, with: { response, error in
             if let error = error {
                 self.propagateError(errorMessage: error)
             } else {
@@ -466,13 +460,6 @@ class BackupsService: ObservableObject {
         logger.info("✅ Connection to XPCBackupService stablished")
         let configLoader = ConfigLoader()
         let networkAuth = configLoader.getNetworkAuth()
-        let authToken = configLoader.getLegacyAuthToken()
-        let newAuthToken = configLoader.getAuthToken()
-
-        guard let authToken = authToken, let newAuthToken = newAuthToken else {
-            logger.error("Cannot create auth token")
-            throw BackupError.cannotCreateAuthToken
-        }
         
         guard let URLAsString = downloadAt.absoluteString.replacingOccurrences(of: "file://", with: "").removingPercentEncoding else {
             throw BackupError.invalidDownloadURL
@@ -487,8 +474,6 @@ class BackupsService: ObservableObject {
             downloadAt: URLAsString,
             mnemonic: mnemonic,
             networkAuth: networkAuthUnwrapped,
-            authToken: authToken,
-            newAuthToken: newAuthToken,
             deviceId:device.id,
             bucketId: deviceBucketId,
             with: {result, error in

--- a/XPCBackupService/XPCBackupService.entitlements
+++ b/XPCBackupService/XPCBackupService.entitlements
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+    <dict>
+        <key>com.apple.security.application-groups</key>
+        <array>
+            <string>$(TeamIdentifierPrefix)group.internxt.desktop</string>
+        </array>
+    </dict>
 </plist>

--- a/XPCBackupService/XPCBackupService.swift
+++ b/XPCBackupService/XPCBackupService.swift
@@ -19,13 +19,11 @@ public class XPCBackupService: NSObject, XPCBackupServiceProtocol {
     private var downloadOperationQueue = OperationQueue()
     private var backupUploadStatus: BackupStatus = .Idle
     private var backupDownloadStatus: BackupStatus = .Idle
-    
+    private let GroupName = "JR4S3SY396.group.internxt.desktop"
     @objc func uploadDeviceBackup(
         backupAt backupURLs: [String],
         mnemonic: String,
         networkAuth: String?,
-        authToken: String,
-        newAuthToken: String,
         deviceId: Int,
         bucketId: String,
         with reply: @escaping (_ result: String?, _ error: String?) -> Void
@@ -41,6 +39,18 @@ public class XPCBackupService: NSObject, XPCBackupServiceProtocol {
             guard let networkAuth = networkAuth else {
                 logger.error("Cannot get network auth")
                 reply(nil, "Cannot get network auth")
+                return
+            }
+            
+            guard let sharedDefaults = UserDefaults(suiteName: GroupName) else {
+                return
+            }
+            
+            guard let authToken = sharedDefaults.string(forKey: "LegacyAuthToken") else{
+                return
+            }
+            
+            guard let newAuthToken = sharedDefaults.string(forKey: "AuthToken") else{
                 return
             }
 
@@ -137,8 +147,6 @@ public class XPCBackupService: NSObject, XPCBackupServiceProtocol {
         downloadAt downloadAtURL: String,
         mnemonic: String,
         networkAuth: String,
-        authToken: String,
-        newAuthToken: String,
         deviceId: Int,
         bucketId: String,
         with reply: @escaping (_ result: String?, _ error: String?) -> Void
@@ -147,6 +155,14 @@ public class XPCBackupService: NSObject, XPCBackupServiceProtocol {
         self.backupDownloadProgress = Progress()
         let downloadAtURL = URL(fileURLWithPath: downloadAtURL)
         let config = ConfigLoader().get()
+        
+        guard let sharedDefaults = UserDefaults(suiteName: GroupName) else {
+            return
+        }
+        
+        guard let newAuthToken = sharedDefaults.string(forKey: "AuthToken") else{
+            return
+        }
         let backupAPI = BackupAPI(baseUrl: config.DRIVE_NEW_API_URL, authToken: newAuthToken, clientName: CLIENT_NAME, clientVersion: getVersion())
         let driveNewAPI = DriveAPI(baseUrl: config.DRIVE_NEW_API_URL, authToken: newAuthToken, clientName: CLIENT_NAME, clientVersion: getVersion())
         let networkAPI = NetworkAPI(baseUrl: config.NETWORK_API_URL, basicAuthToken: networkAuth, clientName: CLIENT_NAME, clientVersion: getVersion())

--- a/XPCBackupService/XPCBackupService.swift
+++ b/XPCBackupService/XPCBackupService.swift
@@ -20,9 +20,11 @@ public class XPCBackupService: NSObject, XPCBackupServiceProtocol {
     private var backupUploadStatus: BackupStatus = .Idle
     private var backupDownloadStatus: BackupStatus = .Idle
     private let GroupName = "JR4S3SY396.group.internxt.desktop"
+    private let AUTH_TOKEN_KEY = "AuthToken"
+    private let LEGACY_TOKEN_KEY = "LegacyAuthToken"
+    private let MNEMONIC_TOKEN_KEY = "Mnemonic"
     @objc func uploadDeviceBackup(
         backupAt backupURLs: [String],
-        mnemonic: String,
         networkAuth: String?,
         deviceId: Int,
         bucketId: String,
@@ -43,14 +45,26 @@ public class XPCBackupService: NSObject, XPCBackupServiceProtocol {
             }
             
             guard let sharedDefaults = UserDefaults(suiteName: GroupName) else {
+                logger.error("Cannot get sharedDefaults")
+                reply(nil, "Cannot get sharedDefaults")
                 return
             }
             
-            guard let authToken = sharedDefaults.string(forKey: "LegacyAuthToken") else{
+            guard let authToken = sharedDefaults.string(forKey: LEGACY_TOKEN_KEY) else{
+                logger.error("Cannot get LegacyAuthToken")
+                reply(nil, "Cannot get LegacyAuthToken")
                 return
             }
             
-            guard let newAuthToken = sharedDefaults.string(forKey: "AuthToken") else{
+            guard let newAuthToken = sharedDefaults.string(forKey: AUTH_TOKEN_KEY) else{
+                logger.error("Cannot get AuthToken")
+                reply(nil, "Cannot get AuthToken")
+                return
+            }
+            
+            guard let mnemonic = sharedDefaults.string(forKey: MNEMONIC_TOKEN_KEY) else{
+                logger.error("Cannot get mnemonic")
+                reply(nil, "Cannot get mnemonic")
                 return
             }
 
@@ -145,7 +159,6 @@ public class XPCBackupService: NSObject, XPCBackupServiceProtocol {
     
     @objc func downloadDeviceBackup(
         downloadAt downloadAtURL: String,
-        mnemonic: String,
         networkAuth: String,
         deviceId: Int,
         bucketId: String,
@@ -157,10 +170,21 @@ public class XPCBackupService: NSObject, XPCBackupServiceProtocol {
         let config = ConfigLoader().get()
         
         guard let sharedDefaults = UserDefaults(suiteName: GroupName) else {
+            logger.error("Cannot get sharedDefaults")
+            reply(nil, "Cannot get sharedDefaults")
             return
         }
         
-        guard let newAuthToken = sharedDefaults.string(forKey: "AuthToken") else{
+        
+        guard let newAuthToken = sharedDefaults.string(forKey: AUTH_TOKEN_KEY) else{
+            logger.error("Cannot get AuthToken")
+            reply(nil, "Cannot get AuthToken")
+            return
+        }
+        
+        guard let mnemonic = sharedDefaults.string(forKey: MNEMONIC_TOKEN_KEY) else{
+            logger.error("Cannot get mnemonic")
+            reply(nil, "Cannot get mnemonic")
             return
         }
         let backupAPI = BackupAPI(baseUrl: config.DRIVE_NEW_API_URL, authToken: newAuthToken, clientName: CLIENT_NAME, clientVersion: getVersion())

--- a/XPCBackupService/XPCBackupServiceDebug.entitlements
+++ b/XPCBackupService/XPCBackupServiceDebug.entitlements
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/XPCBackupService/XPCBackupServiceDebug.entitlements
+++ b/XPCBackupService/XPCBackupServiceDebug.entitlements
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>$(TeamIdentifierPrefix)group.internxt.desktop</string>
+	</array>
+</dict>
 </plist>

--- a/XPCBackupService/XPCBackupServiceProtocol.swift
+++ b/XPCBackupService/XPCBackupServiceProtocol.swift
@@ -9,11 +9,10 @@ import Foundation
 
 @objc protocol XPCBackupServiceProtocol {
     
-    func uploadDeviceBackup(backupAt backupURLs: [String], mnemonic: String, networkAuth: String?,deviceId: Int, bucketId: String, with reply: @escaping (_ result: String?, _ error: String?) -> Void)
+    func uploadDeviceBackup(backupAt backupURLs: [String],networkAuth: String?,deviceId: Int, bucketId: String, with reply: @escaping (_ result: String?, _ error: String?) -> Void)
     
     func downloadDeviceBackup(
         downloadAt downloadAtURL: String,
-        mnemonic: String,
         networkAuth: String,
         deviceId: Int,
         bucketId: String,

--- a/XPCBackupService/XPCBackupServiceProtocol.swift
+++ b/XPCBackupService/XPCBackupServiceProtocol.swift
@@ -9,14 +9,12 @@ import Foundation
 
 @objc protocol XPCBackupServiceProtocol {
     
-    func uploadDeviceBackup(backupAt backupURLs: [String], mnemonic: String, networkAuth: String?, authToken: String, newAuthToken: String, deviceId: Int, bucketId: String, with reply: @escaping (_ result: String?, _ error: String?) -> Void)
+    func uploadDeviceBackup(backupAt backupURLs: [String], mnemonic: String, networkAuth: String?,deviceId: Int, bucketId: String, with reply: @escaping (_ result: String?, _ error: String?) -> Void)
     
     func downloadDeviceBackup(
         downloadAt downloadAtURL: String,
         mnemonic: String,
         networkAuth: String,
-        authToken: String,
-        newAuthToken: String,
         deviceId: Int,
         bucketId: String,
         with reply: @escaping (_ result: String?, _ error: String?) -> Void


### PR DESCRIPTION

This PR removes unnecessary declarations, and parameters that are sent to xpcbackup. Now the user defaults parameters will be taken