### PR TITLE
fix backup screen when user selected french language

### DIFF
--- a/InternxtDesktop/Views/Backups/BackupFrequencySelectorView.swift
+++ b/InternxtDesktop/Views/Backups/BackupFrequencySelectorView.swift
@@ -46,9 +46,10 @@ struct BackupFrequencySelectorView: View {
 
             if self.currentFrequency == .manually {
                 AppText("BACKUP_UPLOAD_FREQUENCY_MANUALLY_TOOLTIP")
+                    .frame(width: 375,alignment: .leading)
                     .font(.XSRegular)
                     .foregroundColor(.Gray50)
-                    .fixedSize(horizontal: true, vertical: true)
+                 
             }
         }
     }

--- a/InternxtDesktop/Views/Settings/SettingsView.swift
+++ b/InternxtDesktop/Views/Settings/SettingsView.swift
@@ -106,7 +106,7 @@ struct SettingsView: View {
                 .background(Color.Gray40.opacity(0.4))
             }
         }
-        .frame(width: 600)
+        .frame(width: 630)
         .onChange(of: scheduleManager.backupError) { error in
             if !error.isEmpty {
                 showErrorDialog(message: error)


### PR DESCRIPTION
This PR fixes a bad layout of elements on the backup screen when the selected language is French.