### PR TITLE
add function when user cancel operations in backup folder view

### DIFF
--- a/InternxtDesktop/Views/Backups/FolderSelectorView.swift
+++ b/InternxtDesktop/Views/Backups/FolderSelectorView.swift
@@ -126,6 +126,10 @@ struct FolderSelectorView: View {
                 HStack {
                     AppButton(title: "COMMON_CANCEL", onClick: {
                         withAnimation {
+                            Task {
+                                await backupsService.restoreFolderToBackup()
+                            }
+                         
                             closeWindow()
                         }
                     }, type: .secondary, size: .SM)
@@ -149,6 +153,11 @@ struct FolderSelectorView: View {
         .cornerRadius(10)
         .shadow(color: .black.opacity(0.1), radius: 1.5, x: 0, y: 1)
         .shadow(color: .black.opacity(0.1), radius: 1, x: 0, y: 1)
+        .onAppear{
+            Task{
+                await backupsService.initFolderToBackup()
+            }
+        }
         
     }
 

--- a/InternxtDesktop/Views/Settings/GeneralTabView.swift
+++ b/InternxtDesktop/Views/Settings/GeneralTabView.swift
@@ -96,9 +96,9 @@ struct GeneralTabView: View {
         guard let version = Bundle.main.releaseVersionNumber else {
             return "NO_VERSION"
         }
-        guard let buildNumber = Bundle.main.buildVersionNumber else {
-            return "NO_BUILD_NUMBER"
-        }
+//        guard let buildNumber = Bundle.main.buildVersionNumber else {
+//            return "NO_BUILD_NUMBER"
+//        }
         
         return "\(version)"//.\(buildNumber)"
     }


### PR DESCRIPTION
This PR Contains a fix when the user cancelled the action in the backups view and no action was taken.