### PR TITLE
- add deviceUuid to migration backup endpoints

### DIFF
--- a/Shared/Services/Backups/BackupsService.swift
+++ b/Shared/Services/Backups/BackupsService.swift
@@ -446,7 +446,7 @@ class BackupsService: ObservableObject {
         let urlsStrings = foldersToBackup.map { folderToBackup in folderToBackup.url.absoluteString.replacingOccurrences(of: "file://", with: "").removingPercentEncoding ?? "" }
 
 
-        xpcBackupService.uploadDeviceBackup(backupAt: urlsStrings,networkAuth: networkAuth,deviceId: currentDevice.id, bucketId: bucketId, with: { response, error in
+        xpcBackupService.uploadDeviceBackup(backupAt: urlsStrings,networkAuth: networkAuth,deviceId: currentDevice.id, deviceUuid: currentDevice.uuid, bucketId: bucketId, with: { response, error in
             if let error = error {
                 if error == "storageFull"{
                     self.showAlert()

--- a/XPCBackupService/Entities/BackupTreeNode.swift
+++ b/XPCBackupService/Entities/BackupTreeNode.swift
@@ -26,6 +26,7 @@ class BackupTreeNode {
     var remoteId: Int?
     var remoteUuid: String?
     var remoteParentId: Int?
+    var remoteParentUuid: String?
     private(set) var childs: [BackupTreeNode]
     let backupUploadService: BackupUploadServiceProtocol
     var backupTotalPogress: Progress
@@ -178,6 +179,7 @@ class BackupTreeNode {
                 self.remoteUuid = remoteUuid
                 for child in self.childs {
                     child.remoteParentId = remoteId
+                    child.remoteParentUuid = remoteUuid
                 }
             case .failure(let error):
             if let startUploadError = error as? StartUploadError {
@@ -218,6 +220,7 @@ class BackupTreeNode {
         self.remoteUuid = syncedNoteRemoteUuid
         for child in self.childs {
             child.remoteParentId = remoteId
+            child.remoteParentUuid = remoteUuid
         }
     }
 }

--- a/XPCBackupService/XPCBackupService.swift
+++ b/XPCBackupService/XPCBackupService.swift
@@ -28,6 +28,7 @@ public class XPCBackupService: NSObject, XPCBackupServiceProtocol {
         backupAt backupURLs: [String],
         networkAuth: String?,
         deviceId: Int,
+        deviceUuid: String,
         bucketId: String,
         with reply: @escaping (_ result: String?, _ error: String?) -> Void
     ) -> Void {
@@ -79,7 +80,8 @@ public class XPCBackupService: NSObject, XPCBackupServiceProtocol {
                 deviceId: deviceId,
                 bucketId: bucketId,
                 authToken: authToken,
-                newAuthToken: newAuthToken
+                newAuthToken: newAuthToken,
+                deviceUuid: deviceUuid
             )
             
             

--- a/XPCBackupService/XPCBackupServiceProtocol.swift
+++ b/XPCBackupService/XPCBackupServiceProtocol.swift
@@ -9,7 +9,7 @@ import Foundation
 
 @objc protocol XPCBackupServiceProtocol {
     
-    func uploadDeviceBackup(backupAt backupURLs: [String],networkAuth: String?,deviceId: Int, bucketId: String, with reply: @escaping (_ result: String?, _ error: String?) -> Void)
+    func uploadDeviceBackup(backupAt backupURLs: [String],networkAuth: String?,deviceId: Int,deviceUuid: String ,bucketId: String, with reply: @escaping (_ result: String?, _ error: String?) -> Void)
     
     func downloadDeviceBackup(
         downloadAt downloadAtURL: String,


### PR DESCRIPTION
This PR contains:
- modify functions to send uuid to create files and folders in backups to use new endpoints