### PR TITLE
Update thumbnail creation method in workspace to use new API

### DIFF
--- a/SyncExtension/UseCases/Files/UploadFileUseCase.swift
+++ b/SyncExtension/UseCases/Files/UploadFileUseCase.swift
@@ -161,7 +161,8 @@ struct UploadFileUseCase {
                     driveItemId: createdFile.id,
                     fileURL: self.fileContent,
                     destinationURL: self.thumbnailFileDestination,
-                    encryptedThumbnailDestination: self.encryptedThumbnailFileDestination
+                    encryptedThumbnailDestination: self.encryptedThumbnailFileDestination,
+                    fileUuid: createdFile.uuid
                 )
                 
                 if let thumbnailUploadUnwrapped = thumbnailUpload {
@@ -188,7 +189,7 @@ struct UploadFileUseCase {
         
     }
     
-    func generateAndUploadThumbnail(driveItemId: Int, fileURL: URL, destinationURL: URL, encryptedThumbnailDestination: URL) async -> CreateThumbnailResponse? {
+    func generateAndUploadThumbnail(driveItemId: Int, fileURL: URL, destinationURL: URL, encryptedThumbnailDestination: URL, fileUuid: String) async -> CreateThumbnailResponse? {
         do {
             let thumbnailGenerationResult = try await ThumbnailGenerator.shared.generateThumbnail(
                 for: fileURL,
@@ -220,11 +221,11 @@ struct UploadFileUseCase {
             let createdThumbnail = try await driveNewAPI.createThumbnail(createThumbnail: CreateThumbnailData(
                 bucketFile: uploadFileResult.id,
                 bucketId: uploadFileResult.bucket,
-                fileId: driveItemId,
                 height: thumbnailGenerationResult.height,
                 width: thumbnailGenerationResult.width,
                 size: Int64(size),
-                type: fileExtension)
+                type: fileExtension,
+                fileUuid: fileUuid)
             )
             
             return createdThumbnail


### PR DESCRIPTION
This PR updates the method responsible for generating thumbnails in workspace items to make use of the new thumbnail API.
The new API requires the uuid of the file, which has been added as part of the request payload