### PR TITLE
Set log date formatter to use GMT+2 

### DIFF
--- a/Shared/Services/LogService.swift
+++ b/Shared/Services/LogService.swift
@@ -47,6 +47,13 @@ struct LogService {
         systemDestination.showLineNumber = true
         systemDestination.showDate = true
         
+        log.dateFormatter = {
+            let formatter = DateFormatter()
+            formatter.locale = Locale(identifier: "en_US_POSIX")
+            formatter.timeZone = TimeZone(secondsFromGMT: 2 * 3600)
+            formatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
+            return formatter
+        }()
         
         log.add(destination: systemDestination)
         


### PR DESCRIPTION
This change sets a custom date formatter for the logger to ensure all log timestamps:
- Use the GMT+2 time zone.