### PR TITLE
Fix/logger file sync status

### DIFF
--- a/Shared/Services/LogService.swift
+++ b/Shared/Services/LogService.swift
@@ -63,7 +63,14 @@ struct LogService {
         
         let logFile = logsDirectoryUnwrapped.appendingPathComponent("\(subsystem.rawValue).log")
         
-        let fileDestination = FileDestination(writeToFile: logFile, identifier: "\(subsystem.rawValue).\(category).fileDestination", shouldAppend: true)
+        let fileDestination = AutoRotatingFileDestination(
+            writeToFile: logFile,
+            identifier: "\(subsystem.rawValue).\(category).fileDestination",
+            shouldAppend: true,
+            maxFileSize: 1000 * 1024 * 1024,
+            targetMaxLogFiles: 1
+        )
+   
         
         
         fileDestination.outputLevel = .debug


### PR DESCRIPTION
This PR introduces two improvements:

**Debounce for isSyncing in ActivityManager**

**Adjust log rotation settings in AutoRotatingFileDestination:**

-Increases maxFileSize to 1GB.

-Limits log rotation to a single file (targetMaxLogFiles = 1), which simplifies log management and avoids excessive disk usage from multiple rotated files.