### PR TITLE
Fix session handling on 401 Unauthorized response

### DIFF
--- a/InternxtDesktop/AppDelegate.swift
+++ b/InternxtDesktop/AppDelegate.swift
@@ -69,8 +69,13 @@ class AppDelegate: NSObject, NSApplicationDelegate , PKPushRegistryDelegate {
     func applicationDidFinishLaunching(_ aNotification: Notification) {
         logger.info("App starting")
         ErrorUtils.start()
-        
-        
+                
+        NotificationCenter.default.addObserver(self,
+        selector: #selector(handleUserLogout),
+        name: .userDidLogout,
+        object: nil)
+
+
         checkVolumeAndEjectIfNeeded()
         
         self.windowsManager = WindowsManager(
@@ -129,6 +134,20 @@ class AppDelegate: NSObject, NSApplicationDelegate , PKPushRegistryDelegate {
         
     }
     
+    
+    @objc func handleUserLogout(_ notification: Notification) {
+        self.logger.info("🔴 User logout due 401 error")
+        DispatchQueue.main.async { [weak self] in
+            do {
+                try self?.authManager.signOut()
+                self?.logger.info("✅ Successfully signed out user from main app due to 401 error")
+            } catch {
+                self?.logger.error("❌ Failed to sign out user in main app: \(error)")
+                error.reportToSentry()
+            }
+        }
+        
+    }
     
     
     func pushRegistry(
@@ -424,6 +443,7 @@ class AppDelegate: NSObject, NSApplicationDelegate , PKPushRegistryDelegate {
     
     func applicationWillTerminate(_ notification: Notification) {
         destroyWidget()
+        NotificationCenter.default.removeObserver(self)
     }
     
     private func initPreviewMode() {

--- a/InternxtDesktop/Services/UsageManager.swift
+++ b/InternxtDesktop/Services/UsageManager.swift
@@ -44,6 +44,7 @@ class UsageManager: ObservableObject {
             
         } catch {
             error.reportToSentry()
+            error.checkUnauthorizedError()
             DispatchQueue.main.async {
                 self.usageError = error
                 self.loadingUsage = false

--- a/Shared/Extensions/Error.swift
+++ b/Shared/Extensions/Error.swift
@@ -12,7 +12,6 @@ import InternxtSwiftCore
 extension Error {
     func reportToSentry() {
         sentryLogger.error(self.getErrorDescription())
-        checkUnauthorizedError()
         SentrySDK.capture(error: self)
     }
     

--- a/SyncExtension/UseCases/All/GetRemoteChangesUseCase.swift
+++ b/SyncExtension/UseCases/All/GetRemoteChangesUseCase.swift
@@ -82,6 +82,7 @@ class GetRemoteChangesUseCase {
                 
                 self.logger.info("✅ Changes enumerated correctly from the server")
             } catch {
+                error.checkUnauthorizedError()
                 error.reportToSentry()
                 observer.finishEnumeratingWithError(error)
                 self.logger.error(["❌ Failed to enumerate remote changes", error.getErrorDescription()])

--- a/SyncExtension/UseCases/Folders/EnumerateFolderItemsUseCase.swift
+++ b/SyncExtension/UseCases/Folders/EnumerateFolderItemsUseCase.swift
@@ -137,6 +137,7 @@ struct EnumerateFolderItemsUseCase {
                 
                 
             } catch {
+                error.checkUnauthorizedError()
                 error.reportToSentry()
                 self.logger.error("❌ Got error fetching folder content: \(error)")
                 observer.finishEnumeratingWithError(error)


### PR DESCRIPTION
This Pr :
- Detect when API service returns 401 status code indicating an expired or invalid session.
- Trigger logout or session reset process to avoid the user getting stuck in an unusable state.