### PR TITLE
fix: Compress package bundles to fix encryption and preserve structure

### DIFF
--- a/InternxtDesktop.xcodeproj/project.pbxproj
+++ b/InternxtDesktop.xcodeproj/project.pbxproj
@@ -110,6 +110,7 @@
 		AA93BEC42E72328900F12334 /* CleanupOperationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA93BEC32E72328900F12334 /* CleanupOperationService.swift */; };
 		AA93BEC62E7233BA00F12334 /* ProgressPollingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA93BEC52E7233BA00F12334 /* ProgressPollingService.swift */; };
 		AA94CA6E2E99E8CE007CEBDF /* NotificationsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA94CA6D2E99E8CE007CEBDF /* NotificationsManager.swift */; };
+		AA9DF5452EDF6B2E00D1FE52 /* PackageFileHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA9DF5442EDF6B2E00D1FE52 /* PackageFileHandle.swift */; };
 		AAA424962C51FFC100EEFD69 /* GenericRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFFBE282C50AC4F00C76528 /* GenericRepository.swift */; };
 		AAA666682D402F2900C2B9DF /* CustomModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA666672D402F2900C2B9DF /* CustomModalView.swift */; };
 		AAA6666A2D40380800C2B9DF /* FileSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA666692D40380800C2B9DF /* FileSelectionView.swift */; };
@@ -543,6 +544,7 @@
 		AA93BEC32E72328900F12334 /* CleanupOperationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CleanupOperationService.swift; sourceTree = "<group>"; };
 		AA93BEC52E7233BA00F12334 /* ProgressPollingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressPollingService.swift; sourceTree = "<group>"; };
 		AA94CA6D2E99E8CE007CEBDF /* NotificationsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsManager.swift; sourceTree = "<group>"; };
+		AA9DF5442EDF6B2E00D1FE52 /* PackageFileHandle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackageFileHandle.swift; sourceTree = "<group>"; };
 		AAA666672D402F2900C2B9DF /* CustomModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomModalView.swift; sourceTree = "<group>"; };
 		AAA666692D40380800C2B9DF /* FileSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSelectionView.swift; sourceTree = "<group>"; };
 		AAA6666D2D40684500C2B9DF /* libjson-c.5.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = "libjson-c.5.dylib"; sourceTree = "<group>"; };
@@ -1448,6 +1450,7 @@
 				E17AA02D2A8A826D00C7EE6E /* ExtensionAssets.xcassets */,
 				E198D7DD2AA9EA0A00107753 /* Utils.swift */,
 				E190AC4A2AB0BDEC00F7B69C /* FileProviderItemActionsManager.swift */,
+				AA9DF5442EDF6B2E00D1FE52 /* PackageFileHandle.swift */,
 			);
 			path = SyncExtension;
 			sourceTree = "<group>";
@@ -2101,6 +2104,7 @@
 				E1A0AC702AB88B5A005E71D6 /* ProcessInfo.swift in Sources */,
 				E1A0AC7A2AB8AAFE005E71D6 /* ThumbnailGenerator.swift in Sources */,
 				E1FD8C742BA989D900C257E0 /* LogService.swift in Sources */,
+				AA9DF5452EDF6B2E00D1FE52 /* PackageFileHandle.swift in Sources */,
 				E140C3342AC379AA00A88B9F /* DriveFileService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SyncExtension/PackageFileHandle.swift
+++ b/SyncExtension/PackageFileHandle.swift
@@ -1,0 +1,136 @@
+//
+//  PackageFileHandle.swift
+//  SyncExtension
+//
+//  Created by Patricio Tovar on 2/12/25.
+//
+
+import Foundation
+import AppKit
+import os.log
+
+class PackageFileHandler {
+    private let tmpURL: URL
+    private let logger = syncExtensionLogger
+    
+    init(tmpURL: URL) {
+        self.tmpURL = tmpURL
+    }
+    
+ 
+    func handlePackageFileIfNeeded(url: URL, realFilename: String) throws -> (processedURL: URL, isZippedPackage: Bool, zipURL: URL?) {
+        
+        guard isValidPackage(at: url) else {
+            return (url, false, nil)
+        }
+        let zipURL = makeTemporaryURL("package-zip", "zip")
+        let (tempPackageDir, shouldCleanup) = try prepareTempPackageDir(from: url, named: realFilename)
+        
+        defer {
+            if shouldCleanup {
+                try? FileManager.default.removeItem(at: tempPackageDir)
+            }
+        }
+        
+        
+        let (process, errorPipe) = createZipProcess(
+            zipPath: zipURL.path,
+            packageName: realFilename,
+            workingDir: tempPackageDir.deletingLastPathComponent().path
+        )
+        
+        do {
+            try process.run()
+            process.waitUntilExit()
+            
+            try validateZipProcess(process, errorPipe, zipURL: zipURL)
+            
+            
+            return (zipURL, true, zipURL)
+        } catch {
+            logger.error("❌ Error compressing package: \(error.localizedDescription)")
+            try? FileManager.default.removeItem(at: zipURL)
+            throw error
+        }
+    }
+    
+
+    
+    private func isValidPackage(at url: URL) -> Bool {
+        var isDirectory: ObjCBool = false
+        let path = url.path
+        
+        guard FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory) else {
+            return false
+        }
+        
+        return isDirectory.boolValue && NSWorkspace.shared.isFilePackage(atPath: path)
+    }
+    
+ 
+    
+    private func prepareTempPackageDir(from url: URL, named packageName: String) throws -> (URL, shouldCleanup: Bool) {
+        if url.lastPathComponent == packageName {
+            return (url, false)
+        }
+        
+        let tempDir = tmpURL.appendingPathComponent(packageName)
+        try FileManager.default.copyItem(at: url, to: tempDir)
+        
+        guard FileManager.default.fileExists(atPath: tempDir.path) else {
+            throw NSError(
+                domain: NSCocoaErrorDomain,
+                code: NSFileWriteUnknownError,
+                userInfo: [NSLocalizedDescriptionKey: "Failed to copy package to temporary directory"]
+            )
+        }
+        
+        return (tempDir, true)
+    }
+    
+    private func createZipProcess(zipPath: String, packageName: String, workingDir: String) -> (Process, Pipe) {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/zip")
+        process.arguments = ["-r", zipPath, packageName]
+        process.currentDirectoryPath = workingDir
+        
+        let errorPipe = Pipe()
+        process.standardError = errorPipe
+        process.standardOutput = nil
+        
+        return (process, errorPipe)
+    }
+    
+    private func validateZipProcess(_ process: Process, _ errorPipe: Pipe, zipURL: URL) throws {
+        let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+        errorPipe.fileHandleForReading.closeFile()
+        
+        if let errorString = String(data: errorData, encoding: .utf8), !errorString.isEmpty {
+            logger.info("📦 Zip output: \(errorString)")
+        }
+        
+        guard process.terminationStatus == 0 else {
+            let errorMessage = String(data: errorData, encoding: .utf8) ?? "No error message"
+            throw NSError(
+                domain: NSCocoaErrorDomain,
+                code: NSFileWriteUnknownError,
+                userInfo: [NSLocalizedDescriptionKey: "Error compressing package: exit code \(process.terminationStatus). \(errorMessage)"]
+            )
+        }
+        
+        guard FileManager.default.fileExists(atPath: zipURL.path) else {
+            throw NSError(
+                domain: NSCocoaErrorDomain,
+                code: NSFileWriteUnknownError,
+                userInfo: [NSLocalizedDescriptionKey: "Zip file was not created successfully"]
+            )
+        }
+    }
+    
+    private func makeTemporaryURL(_ purpose: String, _ ext: String? = nil) -> URL {
+        if let ext = ext {
+            return tmpURL.appendingPathComponent("\(purpose)-\(UUID().uuidString).\(ext)")
+        }
+        return tmpURL.appendingPathComponent("\(purpose)-\(UUID().uuidString)")
+    }
+}


### PR DESCRIPTION
### Problem

Package bundles (`.framework`, `.framework.dSYM`, `.bundle`) were **not being uploaded at all** due to encryption and structural issues:

1. **Encryption couldn't be applied**: The folder-based upload flow couldn't properly encrypt the bundle's internal structure
2. **Upload failures**: These bundles were failing to upload completely because the encryption system is designed to work with files, not folder hierarchies

### Solution

Now, package bundles are detected using `NSWorkspace.isFilePackage()` and compressed to `.zip` before upload, **following the same behavior as Drive Web**.


### Changes

- Added `isPackageDirectory` detection for bundles with URLs in `createItem`
- Route detected packages through compression flow using `PackageFileHandler`
- Compressed packages are properly encrypted as single files
- Fixes upload failures for `.framework`, `.dSYM`, and similar bundles
