### PR TITLE
fix: remove unused code from legacy token in backups

### DIFF
--- a/XPCBackupService/Services/BackupUploadService.swift
+++ b/XPCBackupService/Services/BackupUploadService.swift
@@ -47,16 +47,14 @@ class BackupUploadService:  BackupUploadServiceProtocol, ObservableObject {
     private let deviceId: Int
     private let deviceUuid: String
     private let bucketId: String
-    private let authToken: String
     private let newAuthToken: String
     @Published var canDoBackup = true
 
-    init(networkFacade: NetworkFacade, encryptedContentDirectory: URL, deviceId: Int, bucketId: String, authToken: String, newAuthToken: String, deviceUuid: String) {
+    init(networkFacade: NetworkFacade, encryptedContentDirectory: URL, deviceId: Int, bucketId: String,newAuthToken: String, deviceUuid: String) {
         self.networkFacade = networkFacade
         self.encryptedContentDirectory = encryptedContentDirectory
         self.deviceId = deviceId
         self.bucketId = bucketId
-        self.authToken = authToken
         self.newAuthToken = newAuthToken
         self.deviceUuid = deviceUuid
     }

--- a/XPCBackupService/XPCBackupService.swift
+++ b/XPCBackupService/XPCBackupService.swift
@@ -52,11 +52,7 @@ public class XPCBackupService: NSObject, XPCBackupServiceProtocol {
                 return
             }
             
-            guard let authToken = sharedDefaults.string(forKey: LEGACY_TOKEN_KEY) else{
-                logger.error("Cannot get LegacyAuthToken")
-                reply(nil, "Cannot get LegacyAuthToken")
-                return
-            }
+
             
             guard let newAuthToken = sharedDefaults.string(forKey: AUTH_TOKEN_KEY) else{
                 logger.error("Cannot get AuthToken")
@@ -79,7 +75,6 @@ public class XPCBackupService: NSObject, XPCBackupServiceProtocol {
                 encryptedContentDirectory: FileManager.default.temporaryDirectory,
                 deviceId: deviceId,
                 bucketId: bucketId,
-                authToken: authToken,
                 newAuthToken: newAuthToken,
                 deviceUuid: deviceUuid
             )


### PR DESCRIPTION
Removed the legacy token reference in the backup flow, as it was causing errors during backup operations.