### PR TITLE
Fix UUID usage when downloading a single folder

### DIFF
--- a/InternxtDesktop/ViewModels/BackupContentNavigatorViewModel.swift
+++ b/InternxtDesktop/ViewModels/BackupContentNavigatorViewModel.swift
@@ -13,10 +13,12 @@ struct BackupContentItem {
     var id: String
     var name: String
     var type: String
+    var uuid: String
 }
 
 struct BackupNavigationLevel {
     var id: String
+    var uuid: String?
     var name: String
 }
 
@@ -72,11 +74,18 @@ extension BackupContentNavigator {
         
         func loadFolderContent(folderName: String, folderId: Int, bucketId: String) async throws -> Void {
             do {
+                
+                let folderMeta = try await backupAPI.getBackupFolderMeta(folderId: folderId.toString())
+
+                guard let folderUuid = folderMeta.uuid  else {
+                    return
+                }
+                
                 let levelExistsAlready = navigationLevels.contains{$0.id == folderId.toString()}
                 if levelExistsAlready {
                     self.navigateToLevel(folderId: folderId.toString())
                 } else {
-                    self.addNavigationLevel(folderName: folderName, folderId: folderId.toString())
+                    self.addNavigationLevel(folderName: folderName, folderId: folderId.toString(), folderUuid: folderUuid)
                 }
                 
                 DispatchQueue.main.sync {
@@ -85,11 +94,7 @@ extension BackupContentNavigator {
                     self.currentItems = []
                 }
                                 
-                let folderMeta = try await backupAPI.getBackupFolderMeta(folderId: folderId.toString())
 
-                guard let folderUuid = folderMeta.uuid  else {
-                    return
-                }
                 
                 async let childs = try self.getFolderChildsAsBackupContentItems(folderUuid: folderUuid, bucketId: bucketId, offset: 0, limit: LIMIT_PER_REQUEST)
                 async let files = try self.getFolderFilesAsBackupContentItems(folderUuid: folderUuid, bucketId: bucketId, offset: 0, limit: LIMIT_PER_REQUEST)
@@ -117,7 +122,7 @@ extension BackupContentNavigator {
             
             return childs.folders.map { child in
                 let name = child.plainName ?? self.decryptName(name: child.name, bucketId: bucketId)
-                return BackupContentItem(id: child.id.toString(), name: name, type: "folder")
+                return BackupContentItem(id: child.id.toString(), name: name, type: "folder", uuid: child.uuid!)
             }
         }
         
@@ -126,7 +131,7 @@ extension BackupContentNavigator {
             
             return files.files.map { file in
                 let name = file.plainName ?? self.decryptName(name: file.name, bucketId: bucketId)
-                return BackupContentItem(id: file.fileId, name: name, type: file.type ?? "")
+                return BackupContentItem(id: file.fileId, name: name, type: file.type ?? "", uuid: file.uuid)
             }
         }
         
@@ -138,15 +143,22 @@ extension BackupContentNavigator {
             }
         }
         
-        private func addNavigationLevel(folderName: String, folderId: String) {
+        private func addNavigationLevel(folderName: String, folderId: String, folderUuid: String?) {
             DispatchQueue.main.sync {
-                navigationLevels.append(BackupNavigationLevel(id: folderId, name: folderName))
+                navigationLevels.append(BackupNavigationLevel(
+                    id: folderId,
+                    uuid: folderUuid,
+                    name: folderName
+                ))
             }
-            
         }
         
         private func decryptName(name: String, bucketId: String) -> String {
             return (try? decrypt.decrypt(base64String: name, password: DecryptUtils().getDecryptPassword(bucketId: bucketId))) ?? name
+        }
+        
+        func getUUIDFromItem(forID id: String) -> String? {
+            return currentItems.first(where: { $0.id == id })?.uuid
         }
     }
 }

--- a/InternxtDesktop/Views/Backups/FolderListView.swift
+++ b/InternxtDesktop/Views/Backups/FolderListView.swift
@@ -11,6 +11,7 @@ struct FolderListItem: Identifiable {
     var name: String
     var type: String?
     var folderIsMissing: Bool?
+    var uuid: String?
 }
 
 
@@ -20,6 +21,7 @@ struct FolderListView<Empty: View>: View {
 
     @Binding var items: [FolderListItem]
     @Binding var selectedId: String?
+    @Binding var selectedUuid: String?
     @Binding var isLoading: Bool
     let onItemSingleTap: (FolderListItem) -> Void
     let onItemDoubleTap: (FolderListItem) -> Void
@@ -166,6 +168,7 @@ struct FolderListView<Empty: View>: View {
                 self.onItemDoubleTap(item)
             }, secondCount: 1, secondAction: {
                 self.selectedId = item.id
+                self.selectedUuid = item.uuid 
                 self.onItemSingleTap(item)
             }
         ))
@@ -209,6 +212,7 @@ struct FolderListView<Empty: View>: View {
             type: "jpg"
         )]),
         selectedId: .constant(nil),
+        selectedUuid: .constant(nil),
         isLoading: .constant(false),
         onItemSingleTap: {item in
             

--- a/InternxtDesktop/Views/Backups/FolderSelectorView.swift
+++ b/InternxtDesktop/Views/Backups/FolderSelectorView.swift
@@ -91,8 +91,7 @@ struct FolderSelectorView: View {
             FolderListView(
                 items: self.getSelectorItems(),
                 selectedId: $folderToBackupId,
-                isLoading: .constant(false),
-                
+                selectedUuid: .constant(nil), isLoading: .constant(false),
                 onItemSingleTap: {item in},
                 onItemDoubleTap: {item in},
                 onMissingFolderURLLocated: handleMissingFolderURLLocated,

--- a/InternxtDesktop/Views/UIKit/AppBreadcrumbs.swift
+++ b/InternxtDesktop/Views/UIKit/AppBreadcrumbs.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct AppBreadcrumbLevel {
     let id: String
+    let uuid: String?  
     let name: String
 }
 struct AppBreadcrumbs: View {
@@ -69,12 +70,4 @@ struct AppBreadcrumbLevelView: View {
     
 }
 
-#Preview {
-    AppBreadcrumbs(onLevelTap: {_ in },levels: .constant([
-        AppBreadcrumbLevel(id: "1", name: "Root"),
-        AppBreadcrumbLevel(id: "2", name: "FolderA"),
-        AppBreadcrumbLevel(id: "3", name: "FolderB"),
-        AppBreadcrumbLevel(id: "4", name: "FolderC"),
-        AppBreadcrumbLevel(id: "5", name: "FolderD"),
-    ]))
-}
+


### PR DESCRIPTION
This PR corrects the download flow for individual folders.  
Previously, the request was sending the item ID instead of the UUID, which caused errors in the API call.  
The logic was updated to ensure all related calls now send the correct UUID value.
