### PR TITLE
fix: log out user when AuthManager is missing to prevent unexpected behavior

### DIFF
--- a/SyncExtension/FileProviderExtension.swift
+++ b/SyncExtension/FileProviderExtension.swift
@@ -58,6 +58,12 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension, NSFile
         let authManager = AuthManager()
         self.authManager = authManager
         guard let user = authManager.user else {
+            do {
+                logger.error("Cannot find user in auth manager, cannot initialize extension")
+                try authManager.signOut()
+            }catch {
+                logger.error("error to logout user \(error.localizedDescription)")
+            }
             ErrorUtils.fatal("Cannot find user in auth manager, cannot initialize extension")
         }
         


### PR DESCRIPTION
Log out the user when the AuthManager cannot be found, preventing unexpected or inconsistent behavior in the application.
When, due to some caching issue or unknown error, the application cannot retrieve that value, the extension does not start correctly. Therefore, it is necessary to retrieve that value, and to avoid inconsistencies, the user session is closed.