### PR TITLE
Fix: Crash on macOS 13 Ventura due to ViewBuilder availability checks

### DIFF
--- a/InternxtDesktop/Views/UIKit/AppTextArea.swift
+++ b/InternxtDesktop/Views/UIKit/AppTextArea.swift
@@ -27,25 +27,13 @@ struct AppTextArea: View {
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 10)
                 .padding(.horizontal, 12)
-                .ifAvailable {
-                    if #available(macOS 13.0, *) {
-                        $0.scrollDisabled(true).scrollContentBackground(.hidden)
-                    }
+                .scrollDisabled(true)
+                .scrollContentBackground(.hidden)
+                .overlay {
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(Color.Gray40, lineWidth: 1)
+                        .zIndex(5)
                 }
-                .ifAvailable{view in
-                    if #available(macOS 12.0, *) {
-                        view.overlay{
-                            RoundedRectangle(cornerRadius: 8)
-                                .stroke(Color.Gray40, lineWidth: 1)
-                                .zIndex(5)
-                        }
-                    } else {
-                        view.overlay(RoundedRectangle(cornerRadius: 8)
-                            .stroke(Color.Gray40, lineWidth: 1)
-                            .zIndex(5), alignment: .topLeading)
-                    }
-                }
-
         }
     }
 }

--- a/InternxtDesktop/Views/Widget/SettingsMenuView.swift
+++ b/InternxtDesktop/Views/Widget/SettingsMenuView.swift
@@ -46,14 +46,8 @@ struct SettingsMenuView: View {
                 }
                 .padding(.vertical, 6).ifAvailable{view in
                     
-                    if #available(macOS 12, *) {
-                        view.overlay{
-                            RoundedRectangle(cornerRadius: 8).stroke(Color.Gray20, lineWidth: 1)
-                        }
-                    } else {
-                        view.overlay(
-                            RoundedRectangle(cornerRadius: 8).stroke(Color.Gray20, lineWidth: 1)
-                            , alignment: .top)
+                    view.overlay{
+                        RoundedRectangle(cornerRadius: 8).stroke(Color.Gray20, lineWidth: 1)
                     }
                     
                 }


### PR DESCRIPTION
The `ifAvailable` helper with `#available(macOS 12)` was generating incompatible 
ViewBuilder code for macOS 13 runtime, causing SIGSEGV in swift::ResolveAsSymbolicReference.

Removed availability checks and used SwiftUI APIs directly (all available in macOS 13+)