### PR TITLE
refactor: rename plain_name to plainName

### DIFF
--- a/Shared/Models/Device.swift
+++ b/Shared/Models/Device.swift
@@ -68,7 +68,7 @@ struct Device: Codable, Identifiable {
         self.parentId = deviceAsFolder.parentId
         self.parentUuid = deviceAsFolder.parentUuid
         self.name = deviceAsFolder.name
-        if let plainName = deviceAsFolder.plain_name {
+        if let plainName = deviceAsFolder.plainName {
             self.plainName = plainName
         } else {
             do {


### PR DESCRIPTION
## Description
Renamed `plain_name` to `plainName` to match the property name sent by the backend API.

## Problem
The backend is sending device data with `plainName` in camelCase format, but the frontend was using `plain_name` in snake_case, causing errors when listing devices in backups.
