### PR TITLE
fix: replace use of name by plainName

### DIFF
--- a/SyncExtension/UseCases/All/GetFileOrFolderMetaUseCase.swift
+++ b/SyncExtension/UseCases/All/GetFileOrFolderMetaUseCase.swift
@@ -118,7 +118,7 @@ struct GetFileOrFolderMetaUseCase {
 
                         let folderItem = FileProviderItem(
                             identifier: self.identifier,
-                            filename: folderMeta.plainName ?? folderMeta.name,
+                            filename: folderMeta.plainName,
                             parentId: parentId,
                             createdAt: createdAt,
                             updatedAt: updatedAt,

--- a/SyncExtension/UseCases/All/Workspaces/GetFileOrFolderMetaWorkspaceUseCase.swift
+++ b/SyncExtension/UseCases/All/Workspaces/GetFileOrFolderMetaWorkspaceUseCase.swift
@@ -104,7 +104,7 @@ struct GetFileOrFolderMetaWorkspaceUseCase {
                     let folderItem = FileProviderItem(
                         identifier: self.identifier,
                         // TODO: Decrypt the name if needed
-                        filename: folderMeta.plainName ?? folderMeta.name,
+                        filename: folderMeta.plainName,
                         parentId: parentId,
                         createdAt: createdAt,
                         updatedAt: updatedAt,

--- a/SyncExtension/UseCases/Folders/GetFolderMetaUseCase.swift
+++ b/SyncExtension/UseCases/Folders/GetFolderMetaUseCase.swift
@@ -48,7 +48,7 @@ struct GetFolderMetaUseCase {
                 
                 let folderItem = FileProviderItem(
                     identifier: self.identifier,
-                    filename: folderMeta.name,
+                    filename: folderMeta.plainName,
                     parentId: parentId ,
                     createdAt: createdAt,
                     updatedAt: updateAt,


### PR DESCRIPTION
In this Pr, the use of name is replaced by plainName, since in the endpoint of /folders/\(id)/metadata the name is arriving null, and is causing an error at the time of certain operations, and the name has been added as optional so that it does not cause an error when decoding the response.