### PR TITLE
Fix: Prevent backup progress reset when scheduled backup overlaps

### DIFF
--- a/Shared/Services/Backups/ScheduledBackupManager.swift
+++ b/Shared/Services/Backups/ScheduledBackupManager.swift
@@ -160,6 +160,12 @@ class ScheduledBackupManager : ObservableObject{
         Task.detached { [weak self] in
             guard let self = self else { return }
             
+            
+            if await MainActor.run(body: { self.backupsService.backupUploadStatus }) == .InProgress {
+                await self.scheduleNextBackupAfterCompletion()
+                return
+            }
+            
             do {
                 await self.backupsService.loadAllDevices()
                 self.backupsService.loadFoldersToBackup()


### PR DESCRIPTION
When a backup is scheduled (e.g., every hour), if the previous backup hasn't finished 
when the next one triggers, the progress was being reset to 0. This caused visual 
inconsistency in the UI and potential confusion for users.

Added a check in `ScheduledBackupManager.performBackup()` to verify if a backup is 
already in progress before starting a new one. If a backup is running:
- The scheduled backup cycle is skipped
- The next backup is rescheduled based on the completion time