### PR TITLE
Fix: Backup timing and folder name handling

### DIFF
--- a/Shared/Services/Backups/BackupsService.swift
+++ b/Shared/Services/Backups/BackupsService.swift
@@ -400,6 +400,8 @@ class BackupsService: ObservableObject {
 
     private func propagateUploadSuccess() {
         logger.info("Device backed up successfully, tracking backup success event")
+        UserDefaults.standard.set(Date(), forKey: LAST_BACKUP_TIME_KEY)
+        
         DispatchQueue.main.async { [weak self] in
             self?.backupUploadProgress = 1
             self?.currentDeviceHasBackup = true

--- a/SyncExtension/UseCases/All/GetFileOrFolderMetaUseCase.swift
+++ b/SyncExtension/UseCases/All/GetFileOrFolderMetaUseCase.swift
@@ -118,7 +118,7 @@ struct GetFileOrFolderMetaUseCase {
 
                         let folderItem = FileProviderItem(
                             identifier: self.identifier,
-                            filename: folderMeta.plainName,
+                            filename: (folderMeta.plainName ?? folderMeta.name) ?? "",
                             parentId: parentId,
                             createdAt: createdAt,
                             updatedAt: updatedAt,

--- a/SyncExtension/UseCases/All/Workspaces/GetFileOrFolderMetaWorkspaceUseCase.swift
+++ b/SyncExtension/UseCases/All/Workspaces/GetFileOrFolderMetaWorkspaceUseCase.swift
@@ -104,7 +104,7 @@ struct GetFileOrFolderMetaWorkspaceUseCase {
                     let folderItem = FileProviderItem(
                         identifier: self.identifier,
                         // TODO: Decrypt the name if needed
-                        filename: folderMeta.plainName,
+                        filename: (folderMeta.plainName ?? folderMeta.name) ?? "",
                         parentId: parentId,
                         createdAt: createdAt,
                         updatedAt: updatedAt,

--- a/SyncExtension/UseCases/Folders/GetFolderMetaUseCase.swift
+++ b/SyncExtension/UseCases/Folders/GetFolderMetaUseCase.swift
@@ -48,7 +48,7 @@ struct GetFolderMetaUseCase {
                 
                 let folderItem = FileProviderItem(
                     identifier: self.identifier,
-                    filename: folderMeta.plainName,
+                    filename: (folderMeta.name ?? folderMeta.plainName) ?? "",
                     parentId: parentId ,
                     createdAt: createdAt,
                     updatedAt: updateAt,


### PR DESCRIPTION
In this PR, the following changes were made.

Changes:

**Manual backup timing**
Manual backups now update last backup time, so scheduled backups respect when the last manual backup occurred

**Folder name fallback**
Use name as primary value with plainName as fallback, handling cases where plainName is nil