### PR TITLE
Fix: Scheduled backup time changes after app restart

### DIFF
--- a/InternxtDesktop/Views/Backups/BackupConfigView.swift
+++ b/InternxtDesktop/Views/Backups/BackupConfigView.swift
@@ -273,6 +273,7 @@ struct BackupConfigView: View {
     
     private func removeBackupDate(){
         UserDefaults.standard.removeObject(forKey: "INTERNXT_LAST_BACKUP_TIME_KEY")
+        UserDefaults.standard.removeObject(forKey: "INTERNXT_NEXT_SCHEDULED_BACKUP_KEY")
     }
 }
 

--- a/Shared/Services/Backups/BackupsService.swift
+++ b/Shared/Services/Backups/BackupsService.swift
@@ -802,7 +802,7 @@ class BackupsService: ObservableObject {
     
     private func removeScheduledBackup() {
         UserDefaults.standard.removeObject(forKey: LAST_BACKUP_TIME_KEY)
-
+        UserDefaults.standard.removeObject(forKey: "INTERNXT_NEXT_SCHEDULED_BACKUP_KEY")
     }
 }
 

--- a/Shared/Services/Backups/ScheduledBackupManager.swift
+++ b/Shared/Services/Backups/ScheduledBackupManager.swift
@@ -17,6 +17,7 @@ class ScheduledBackupManager : ObservableObject{
     private let queue = DispatchQueue(label: "com.internxt.backup.scheduler")
     private let BACKUP_FREQUENCY_KEY = "INTERNXT_SELECTED_BACKUP_FREQUENCY"
     private let LAST_BACKUP_TIME_KEY = "INTERNXT_LAST_BACKUP_TIME_KEY"
+    private let NEXT_SCHEDULED_BACKUP_KEY = "INTERNXT_NEXT_SCHEDULED_BACKUP_KEY"
     private var sleepObserver: NSObjectProtocol?
     private var wakeObserver: NSObjectProtocol?
     
@@ -85,6 +86,7 @@ class ScheduledBackupManager : ObservableObject{
         
         guard frequency != .manually else {
             userDefaults.removeObject(forKey: LAST_BACKUP_TIME_KEY)
+            userDefaults.removeObject(forKey: NEXT_SCHEDULED_BACKUP_KEY)
             DispatchQueue.main.async {
                 self.nextBackupTime = ""
             }
@@ -94,18 +96,29 @@ class ScheduledBackupManager : ObservableObject{
         let interval = frequency.timeInterval
         let now = Date()
         
-        if let lastBackupTime = userDefaults.object(forKey: LAST_BACKUP_TIME_KEY) as? Date {
+        if let savedNextBackup = userDefaults.object(forKey: NEXT_SCHEDULED_BACKUP_KEY) as? Date {
+            let timeUntilNext = savedNextBackup.timeIntervalSince(now)
+            
+            if timeUntilNext <= 0 {
+                performBackup()
+            } else {
+                displayNextBackupTime(savedNextBackup)
+                scheduleNextBackup(after: timeUntilNext, interval: interval)
+            }
+        } else if let lastBackupTime = userDefaults.object(forKey: LAST_BACKUP_TIME_KEY) as? Date {
             let nextScheduledBackup = lastBackupTime.addingTimeInterval(interval)
             let timeUntilNext = nextScheduledBackup.timeIntervalSince(now)
             
             if timeUntilNext <= 0 {
                 performBackup()
             } else {
+                saveNextScheduledBackup(nextScheduledBackup)
                 displayNextBackupTime(nextScheduledBackup)
                 scheduleNextBackup(after: timeUntilNext, interval: interval)
             }
         } else {
             let nextBackupDate = now.addingTimeInterval(interval)
+            saveNextScheduledBackup(nextBackupDate)
             displayNextBackupTime(nextBackupDate)
             scheduleNextBackup(after: interval, interval: interval)
         }
@@ -145,6 +158,14 @@ class ScheduledBackupManager : ObservableObject{
         }
     }
     
+    private func saveNextScheduledBackup(_ date: Date) {
+        userDefaults.set(date, forKey: NEXT_SCHEDULED_BACKUP_KEY)
+    }
+    
+    private func clearNextScheduledBackup() {
+        userDefaults.removeObject(forKey: NEXT_SCHEDULED_BACKUP_KEY)
+    }
+    
     private func displayNextBackupTime(_ date: Date) {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "HH:mm"
@@ -173,6 +194,7 @@ class ScheduledBackupManager : ObservableObject{
                 
                 let completionTime = Date()
                 self.userDefaults.set(completionTime, forKey: self.LAST_BACKUP_TIME_KEY)
+                self.clearNextScheduledBackup()
                 
                 await MainActor.run {
                     self.backupError = ""
@@ -209,6 +231,8 @@ class ScheduledBackupManager : ObservableObject{
         
         let timeUntilNext = nextBackupDate.timeIntervalSince(now)
         let capturedNextBackupDate = nextBackupDate
+        
+        saveNextScheduledBackup(capturedNextBackupDate)
         
         await MainActor.run {
             self.displayNextBackupTime(capturedNextBackupDate)


### PR DESCRIPTION
## Problem
When a user configured a scheduled backup (e.g., hourly at 20:07), closing and reopening the app would cause the next backup time to be recalculated from the current time (e.g., 21:09 instead of 21:07). This happened because only the last completed backup time was persisted, not the scheduled next backup time.
## Solution
- Added `NEXT_SCHEDULED_BACKUP_KEY` to persist the next scheduled backup date
- Modified `startBackupTimer()` to first check for a saved scheduled time before recalculating
- Clear the scheduled backup key when:
  - A backup completes (so next schedule is based on completion time)
  - User changes the backup frequency
