### PR TITLE
Fix: Files re-downloading on every open in FileProvider

### DIFF
--- a/SyncExtension/FileProviderExtension.swift
+++ b/SyncExtension/FileProviderExtension.swift
@@ -622,13 +622,33 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension, NSFile
         
         if contentModificationDateHasChanged {
             logger.info("File content modification date has changed, let it pass")
-            completionHandler(item, [], false, nil)
+            let filename = item.filename as NSString
+            let properItem = FileProviderItem(
+                identifier: item.itemIdentifier,
+                filename: item.filename,
+                parentId: item.parentItemIdentifier,
+                createdAt: (item.creationDate ?? Date()) ?? Date(),
+                updatedAt: (item.contentModificationDate ?? Date()) ?? Date(),
+                itemExtension: filename.pathExtension,
+                itemType: item.contentType == .folder ? .folder : .file
+            )
+            completionHandler(properItem, [], false, nil)
             return Progress()
         }
         
         if lastUsedDateHasChanged {
             logger.info("File last use date has changed, let it pass")
-            completionHandler(item, [], false, nil)
+            let filename = item.filename as NSString
+            let properItem = FileProviderItem(
+                identifier: item.itemIdentifier,
+                filename: item.filename,
+                parentId: item.parentItemIdentifier,
+                createdAt: (item.creationDate ?? Date()) ?? Date(),
+                updatedAt: (item.contentModificationDate ?? Date()) ?? Date(),
+                itemExtension: filename.pathExtension,
+                itemType: item.contentType == .folder ? .folder : .file
+            )
+            completionHandler(properItem, [], false, nil)
             return Progress()
         }
                 


### PR DESCRIPTION
## Problem
When a user double-clicks a file in the FileProvider domain, the file downloads
correctly but immediately re-downloads when opened again.
## Root Cause
The `modifyItem` handlers for `lastUsedDateHasChanged` and
`contentModificationDateHasChanged` were returning the system's raw
`NSFileProviderItem` directly via the completion handler. This item has a
different `itemVersion` than our `FileProviderItem` (which consistently
returns `contentVersion: "STATIC"`), causing the system to believe the
content had changed and triggering an immediate re-download.
## Fix
Both handlers now construct a proper `FileProviderItem` instance with
consistent version information before returning it to the completion handler.