### PR TITLE
Fix: Handle nullable file name fields from API response

### DIFF
--- a/SyncExtension/UseCases/Folders/EnumerateFolderItemsUseCase.swift
+++ b/SyncExtension/UseCases/Folders/EnumerateFolderItemsUseCase.swift
@@ -107,9 +107,13 @@ struct EnumerateFolderItemsUseCase {
                         return
                     }
                     
+                    guard let resolvedName = file.plainName ?? file.name else {
+                        self.logger.error("Cannot get filename for item \(file.fileId ?? "unknown"), both plainName and name are nil")
+                        return
+                    }
                     
-
-                    let filename = FileProviderItem.getFilename(name: file.plainName ?? file.name , itemExtension: file.type
+                    
+                    let filename = FileProviderItem.getFilename(name: resolvedName , itemExtension: file.type
                     )
                     
                     let item = FileProviderItem(


### PR DESCRIPTION
The API can return `name: null` for some files (e.g. files without 
an encrypted name). This caused a decoding crash since `name` was 
defined as non-optional in `GetFolderFilesResultV2`.

Changes:
- Made `name`  optional in `GetFolderFilesResultV2`
- Added fallback logic when processing files: `plainName ?? name`, 
  skipping the file if both are nil