### PR TITLE
fix: Size discrepancy after toggling Select All in file preview

### DIFF
--- a/InternxtDesktop/Views/Cleaner/CleanupView.swift
+++ b/InternxtDesktop/Views/Cleaner/CleanupView.swift
@@ -222,6 +222,9 @@ class CleanupViewModel: ObservableObject {
     // MARK: - File Selection Methods
     func isFileSelected(_ filePath: String) -> Bool {
         guard let categoryId = selectedCategoryForPreview?.id else { return false }
+        if selectedCategories.contains(categoryId) {
+            return true
+        }
         return selectedFilesByCategory[categoryId]?.contains(filePath) ?? false
     }
 
@@ -260,13 +263,12 @@ class CleanupViewModel: ObservableObject {
         
         let newState: SelectionState = filesSelectAllState == .full ? .none : .full
         
-        selectedCategories.remove(categoryId)
-        
         switch newState {
         case .full:
-            let allFilePaths = Set(getAllCachedFiles(for: categoryId).map { $0.path })
-            selectedFilesByCategory[categoryId] = allFilePaths
+            selectedCategories.insert(categoryId)
+            selectedFilesByCategory.removeValue(forKey: categoryId)
         case .none:
+            selectedCategories.remove(categoryId)
             selectedFilesByCategory.removeValue(forKey: categoryId)
         case .partial:
             break


### PR DESCRIPTION

## Problem
Toggling Select All off/on in the Cleaner file preview caused the total 
size to change due to a mismatch between category-level and individual file-level size calculations.
## Solution
Ensure consistent size calculation after re-selecting all files in the preview.