### PR TITLE
fix: add handling for macOS bundles and packages

### DIFF
--- a/InternxtDesktop/ViewModels/BackupContentNavigatorViewModel.swift
+++ b/InternxtDesktop/ViewModels/BackupContentNavigatorViewModel.swift
@@ -15,6 +15,7 @@ struct BackupContentItem {
     var type: String
     var uuid: String
     var hasFileId: Bool
+    var isBundle: Bool = false
 }
 
 struct BackupNavigationLevel {
@@ -117,12 +118,36 @@ extension BackupContentNavigator {
         }
         
     
+    
+        private static let bundleExtensions: Set<String> = [
+            "app", "pages", "key", "numbers", "rtfd", "bundle",
+            "framework", "kext", "plugin", "xpc"
+        ]
+        
+        static func isBundleFolderName(_ name: String) -> Bool {
+            let ext = (name as NSString).pathExtension.lowercased()
+            return bundleExtensions.contains(ext)
+        }
         
         private func getFolderChildsAsBackupContentItems(folderUuid: String, bucketId: String, offset: Int, limit: Int) async throws -> [BackupContentItem] {
             let childs = try await backupAPI.getBackupChilds(folderUuid:folderUuid, offset: offset, limit: limit)
             
             return childs.folders.map { child in
                 let name = child.plainName ?? self.decryptName(name: child.name, bucketId: bucketId)
+
+                if Self.isBundleFolderName(name) {
+                    let ext = (name as NSString).pathExtension
+                    let nameWithoutExt = (name as NSString).deletingPathExtension
+                    return BackupContentItem(
+                        id: child.id.toString(),
+                        name: nameWithoutExt,
+                        type: ext,
+                        uuid: child.uuid!,
+                        hasFileId: false,
+                        isBundle: true
+                    )
+                }
+                
                 return BackupContentItem(id: child.id.toString(), name: name, type: "folder", uuid: child.uuid!, hasFileId: true)
             }
         }

--- a/InternxtDesktop/Views/Backups/BackupContentNavigator.swift
+++ b/InternxtDesktop/Views/Backups/BackupContentNavigator.swift
@@ -74,7 +74,7 @@ struct BackupContentNavigator: View {
         
         return Binding<[FolderListItem]>(get: {
             current.map{ item in
-                FolderListItem(id: item.id, name: item.name, type: item.type,uuid: item.uuid)
+                FolderListItem(id: item.id, name: item.name, type: item.type, uuid: item.uuid, isBundle: item.isBundle)
             }
         }, set: {_ in })
     }
@@ -96,7 +96,7 @@ struct BackupContentNavigator: View {
                 },
                 onItemDoubleTap: {item in
                     self.selectedFolderListItem = nil
-                    if item.type == "folder" {
+                    if item.type == "folder" && !item.isBundle {
                         self.currentFolderId = item.id
                         self.currentFolderUuid = item.uuid
                         navigateToFolder(item: item)
@@ -186,9 +186,15 @@ struct BackupContentNavigator: View {
                     } else if let selectedFolderListItem = selectedFolderListItem {
                         guard let selectedId = selectedId else { return }
                         guard let selectedUuid = selectedUuid else { return }
-                        if selectedFolderListItem.type == "folder" {
-                            
-                            try await backupsService.downloadFolderBackup(device: device, downloadAt: url, folderId: selectedUuid,folderName: selectedFolderListItem.name)
+                        if selectedFolderListItem.type == "folder" || selectedFolderListItem.isBundle {
+
+                            let folderName: String
+                            if selectedFolderListItem.isBundle, let ext = selectedFolderListItem.type {
+                                folderName = "\(selectedFolderListItem.name).\(ext)"
+                            } else {
+                                folderName = selectedFolderListItem.name
+                            }
+                            try await backupsService.downloadFolderBackup(device: device, downloadAt: url, folderId: selectedUuid, folderName: folderName)
                         } else {
                             let selectedItem = viewModel.currentItems.first { $0.id == selectedId }
                             let downloadURL = self.getURLForItem(baseURL: url, itemName: selectedFolderListItem.name, itemType: selectedFolderListItem.type)

--- a/InternxtDesktop/Views/Backups/FolderListView.swift
+++ b/InternxtDesktop/Views/Backups/FolderListView.swift
@@ -12,6 +12,7 @@ struct FolderListItem: Identifiable {
     var type: String?
     var folderIsMissing: Bool?
     var uuid: String?
+    var isBundle: Bool = false
 }
 
 

--- a/XPCBackupService/Services/BackupDownloadService.swift
+++ b/XPCBackupService/Services/BackupDownloadService.swift
@@ -62,7 +62,7 @@ struct BackupDownloadService {
                     }
                     try await self.downloadBackupFolderAtPath(folderId: folderUuid, downloadAtPath: folderURL)
                 } catch {
-                    logger.error("❌ Failed to download backup folder \(backupFolderName) at \(downloadAtPath.path)")
+                    logger.error("❌ Failed to download backup folder \(backupFolderName) at \(downloadAtPath.path): \(error.localizedDescription)")
                 }
             }
         }

--- a/XPCBackupService/Services/BackupTreeGenerator.swift
+++ b/XPCBackupService/Services/BackupTreeGenerator.swift
@@ -69,7 +69,7 @@ class BackupTreeGenerator: BackupTreeGeneration {
                 if try self.root.isDirectory() {
                     guard let enumerator = FileManager.default.enumerator(
                         at: self.root,
-                        includingPropertiesForKeys: [.isRegularFileKey, .isDirectoryKey],
+                        includingPropertiesForKeys: [.isRegularFileKey, .isDirectoryKey, .isPackageKey, .isSymbolicLinkKey],
                         options: [.skipsHiddenFiles]
                     ) else {
                         logger.error("Enumerator not found")
@@ -79,6 +79,10 @@ class BackupTreeGenerator: BackupTreeGeneration {
 
                     for case let url as URL in enumerator {
                         do {
+                            let symValues = try url.resourceValues(forKeys: [.isSymbolicLinkKey])
+                            if symValues.isSymbolicLink == true {
+                                continue
+                            }
                             try self.insertInTree(url)
                         } catch {
                             // We need to decide what to do in this case, for now, at least log the error
@@ -102,6 +106,12 @@ class BackupTreeGenerator: BackupTreeGeneration {
     }
     
     
+
+    private static let knownBundleExtensions: Set<String> = [
+        "app", "framework", "bundle", "kext", "plugin",
+        "pages", "key", "numbers", "rtfd", "xpc"
+    ]
+
     func insertInTree(_ url: URL) throws {
          //  Check if the node already exists in the parent instead of the whole tree
          if nodeIndex[url] != nil {
@@ -114,10 +124,22 @@ class BackupTreeGenerator: BackupTreeGeneration {
              throw BackupTreeGeneratorError.parentNodeNotFound
          }
 
-         guard let typeID = try url.resourceValues(forKeys: [.typeIdentifierKey]).typeIdentifier,
+         let resourceValues = try url.resourceValues(forKeys: [.typeIdentifierKey, .isPackageKey, .isDirectoryKey])
+
+         guard let typeID = resourceValues.typeIdentifier,
                let type = UTType(typeID) else {
              throw BackupTreeGeneratorError.cannotGetNodeType
          }
+
+
+         let utTypeConforms = type.conforms(to: .package)
+         let isPackageResource = resourceValues.isPackage == true
+         let isDirectory = resourceValues.isDirectory == true
+         let ext = url.pathExtension.lowercased()
+         let extensionMatch = isDirectory && Self.knownBundleExtensions.contains(ext)
+         let isPackage = utTypeConforms || isPackageResource || extensionMatch
+
+         let effectiveType: BackupTreeNodeType = isPackage ? .folder : type
 
          // We have a parent, and the node does not exists, create the BackupTreeNode
          let newNode = BackupTreeNode(
@@ -126,7 +148,7 @@ class BackupTreeGenerator: BackupTreeGeneration {
              rootBackupFolder: root,
              parentId: parentNode.id,
              name: url.lastPathComponent,
-             type: type,
+             type: effectiveType,
              url: url,
              syncStatus: .LOCAL_ONLY,
              childs: [],

--- a/XPCBackupService/XPCBackupService.swift
+++ b/XPCBackupService/XPCBackupService.swift
@@ -297,10 +297,13 @@ public class XPCBackupService: NSObject, XPCBackupServiceProtocol {
     private func getNodesCountFromURL(_ url: URL) -> Int {
         
         var count = 0
-        if let enumerator = FileManager.default.enumerator(at: url, includingPropertiesForKeys: [.isRegularFileKey, .isDirectoryKey], options: [.skipsHiddenFiles]) {
+        if let enumerator = FileManager.default.enumerator(at: url, includingPropertiesForKeys: [.isRegularFileKey, .isDirectoryKey, .isPackageKey, .isSymbolicLinkKey], options: [.skipsHiddenFiles]) {
             for case let fileURL as URL in enumerator {
                 do {
-                    let fileAttributes = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .isDirectoryKey])
+                    let fileAttributes = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .isDirectoryKey, .isSymbolicLinkKey])
+                    if fileAttributes.isSymbolicLink == true {
+                        continue
+                    }
                     if fileAttributes.isRegularFile! || fileAttributes.isDirectory! {
                         count += 1
                     }


### PR DESCRIPTION
This PR introduces comprehensive support for macOS bundle and package files (e.g., `.app`, `.framework`, `.xpc`, `.bundle`) within the `XPCBackupService`. 
Previously, the backup pipeline attempted to treat these directory-structrued bundles as flat files, which caused `InputStream` errors (0 bytes read) or broken operation dependencies during upload. With this update, the system recursively backs up their internal structure while preserving the Finder-like experience in the UI (presenting them as single, opaque files).