### PR TITLE
fix: use endpoints that support nil fileId for rename and file retrieval

### DIFF
--- a/Shared/Services/DriveFileService.swift
+++ b/Shared/Services/DriveFileService.swift
@@ -65,7 +65,7 @@ struct DriveFileService {
     /// - Returns: A `DriveFile` with the updated name
     ///
     public func renameFile(uuid: String, bucketId: String, newName: String) async throws -> DriveFile {
-        let fileMeta = try await driveNewAPI.getFileMetaByUuid(uuid: uuid)
+        let fileMeta = try await driveNewAPI.getFileMetaByUuidV2(uuid: uuid)
         
         let updated = try await driveNewAPI.updateFileNew(
             uuid: fileMeta.uuid,

--- a/SyncExtension/UseCases/All/GetFileOrFolderMetaUseCase.swift
+++ b/SyncExtension/UseCases/All/GetFileOrFolderMetaUseCase.swift
@@ -142,9 +142,9 @@ struct GetFileOrFolderMetaUseCase {
         return Progress()
     }
     
-    private func getFileMetaOrNil(maybeFileUuid: String) async -> GetFileMetaByIdResponse? {
+    private func getFileMetaOrNil(maybeFileUuid: String) async -> GetFileMetaByIdResponseV2? {
         do {
-            let fileMeta = try await driveNewAPI.getFileMetaByUuid(uuid: maybeFileUuid)
+            let fileMeta = try await driveNewAPI.getFileMetaByUuidV2(uuid: maybeFileUuid)
             
             if fileMeta.uuid != maybeFileUuid {
                 return nil


### PR DESCRIPTION
## Problem
Some folders may contain files without a `fileId`. When the app processes this data and attempts to destructure it in Swift

## Solution
Updated the references to use endpoints that support a `nil fileId` when renaming or retrieving files. This prevents failures when the API returns files without a `fileId`.