### PR TITLE
fix: trash fails for files with nil fileId or size zero

### DIFF
--- a/Shared/Services/DriveFileService.swift
+++ b/Shared/Services/DriveFileService.swift
@@ -26,11 +26,11 @@ struct DriveFileService {
     /// - Returns: A `DriveFile` with the updated status to `DriveItemStatus.trashed`
     /// 
     public func trashFile(uuid: String) async throws -> DriveFile {
-        let fileMeta = try await driveNewAPI.getFileMetaByUuid(uuid: uuid)
+        let fileMeta = try await driveNewAPI.getFileMetaByUuidV2(uuid: uuid)
       
         
-        let trashed: Bool = try await trashAPI.trashFiles(itemsToTrash: [FileToTrash(
-            id: fileMeta.fileId
+        let trashed: Bool = try await trashAPI.trashItemsByUuid(itemsToTrash: [ItemToTrashV2(
+            uuid: uuid, type: .File
         )])
         
         if trashed == false {


### PR DESCRIPTION
## Problem
Deleting files with size zero or nil `fileId` was throwing an error. Since `fileId` was absent, it failed during decoding when trying to use it to identify the item to trash.

## Solution
Migrate `trashFile` to V2 endpoints, which support nil `fileId` and trash items by `uuid` instead.