### PR TITLE
feat: add low bandwidth mode to prevent network saturation

### DIFF
--- a/InternxtDesktop/Views/Settings/GeneralTabView.swift
+++ b/InternxtDesktop/Views/Settings/GeneralTabView.swift
@@ -29,6 +29,10 @@ struct GeneralTabView: View {
                 .background(Color.Gray10).padding(.vertical, 24)
             VStack(alignment: .leading,spacing: 0) {
                 StartOnLaunchView()
+                
+                AppCheckbox(label: "SETTINGS_ENABLE_LOW_BANDWIDTH", checked: $appSettings.reduceBandwidth)
+                    .padding(.top, 16)
+                
                 HStack(spacing:0) {
                     VStack(alignment:.leading,spacing: 8){
                         AppText("COMMON_LANGUAGE")

--- a/Shared/Services/AppSettings.swift
+++ b/Shared/Services/AppSettings.swift
@@ -54,6 +54,7 @@ class AppSettings: ObservableObject {
 
     @Published public var selectedLanguage: Languages = .en
     @Published public var selectedBackupFrequency: BackupFrequencyEnum = .manually
+    @Published public var reduceBandwidth: Bool = false
 
     private var bag = Set<AnyCancellable>()
 
@@ -62,6 +63,9 @@ class AppSettings: ObservableObject {
 
     @AppUserDefault(.selectedBackupFrequency, defaultValue: nil)
     private var _backupFrequency: String?
+
+    @AppUserDefault(.reduceBandwidth, defaultValue: false, suiteName: INTERNXT_GROUP_NAME)
+    private var userDefaultsReduceBandwidth: Bool
 
     public init(defaultLanguage: Languages = .deviceLanguage, defaultBackupFrequency: BackupFrequencyEnum = .manually) {
         if _language == nil {
@@ -75,9 +79,11 @@ class AppSettings: ObservableObject {
         }
         
         selectedBackupFrequency = BackupFrequencyEnum(rawValue: _backupFrequency!)!
+        reduceBandwidth = userDefaultsReduceBandwidth
         
         observeForSelectedLanguage()
         observeForSelectedBackupFrequency()
+        observeForReduceBandwidth()
     }
 
     private func observeForSelectedLanguage() {
@@ -94,6 +100,14 @@ class AppSettings: ObservableObject {
             .map({ $0.rawValue })
             .sink { [weak self] value in
                 self?._backupFrequency = value
+            }
+            .store(in: &bag)
+    }
+
+    private func observeForReduceBandwidth() {
+        $reduceBandwidth
+            .sink { [weak self] value in
+                self?.userDefaultsReduceBandwidth = value
             }
             .store(in: &bag)
     }

--- a/Shared/Services/ConfigLoader.swift
+++ b/Shared/Services/ConfigLoader.swift
@@ -102,6 +102,10 @@ public struct ConfigLoader {
         return self.getFromUserDefaults(key: "AuthToken")
     }
     
+    public func getReduceBandwidth() -> Bool {
+        return UserDefaults(suiteName: SUITE_NAME)?.bool(forKey: "INTERNXT_REDUCE_BANDWIDTH") ?? false
+    }
+    
     public func getMnemonic() -> String? {
         return self.getFromUserDefaults(key: "Mnemonic")
     }

--- a/Shared/Utils/AppUserDefaults.swift
+++ b/Shared/Utils/AppUserDefaults.swift
@@ -14,18 +14,20 @@ import Foundation
 struct AppUserDefault<T> {
   let key: String
   let defaultValue: T
+  let defaults: UserDefaults
 
-  init(_ key: DefaultsKeys, defaultValue: T) {
+  init(_ key: DefaultsKeys, defaultValue: T, suiteName: String? = nil) {
     self.key = key.rawValue
     self.defaultValue = defaultValue
+    self.defaults = suiteName != nil ? UserDefaults(suiteName: suiteName!) ?? .standard : .standard
   }
 
   var wrappedValue: T {
     get {
-      return UserDefaults.standard.object(forKey: key) as? T ?? defaultValue
+      return defaults.object(forKey: key) as? T ?? defaultValue
     }
     set {
-      UserDefaults.standard.set(newValue, forKey: key)
+      defaults.set(newValue, forKey: key)
     }
   }
 }
@@ -33,4 +35,5 @@ struct AppUserDefault<T> {
 enum DefaultsKeys: String {
   case selectedLanguage = "INTERNXT_SELECTED_LANGUAGE"
   case selectedBackupFrequency = "INTERNXT_SELECTED_BACKUP_FREQUENCY"
+  case reduceBandwidth = "INTERNXT_REDUCE_BANDWIDTH"
 }

--- a/Shared/en.lproj/Localizable.strings
+++ b/Shared/en.lproj/Localizable.strings
@@ -271,4 +271,4 @@
 "CLEANER_DEVICE_CLEAN_TITLE" = "Your device is clean";
 "CLEANER_DEVICE_CLEAN_SUBTITLE" = "No further actions are necessary";
 "CLEANER_FINISH" = "Finish";
-"SETTINGS_ENABLE_LOW_BANDWIDTH" = "Enable low bandwidth mode";
+"SETTINGS_ENABLE_LOW_BANDWIDTH" = "Enable network low usage mode";

--- a/Shared/en.lproj/Localizable.strings
+++ b/Shared/en.lproj/Localizable.strings
@@ -271,3 +271,4 @@
 "CLEANER_DEVICE_CLEAN_TITLE" = "Your device is clean";
 "CLEANER_DEVICE_CLEAN_SUBTITLE" = "No further actions are necessary";
 "CLEANER_FINISH" = "Finish";
+"SETTINGS_ENABLE_LOW_BANDWIDTH" = "Enable low bandwidth mode";

--- a/Shared/es.lproj/Localizable.strings
+++ b/Shared/es.lproj/Localizable.strings
@@ -273,4 +273,4 @@
 "CLEANER_DEVICE_CLEAN_TITLE" = "Tu dispositivo está limpio";
 "CLEANER_DEVICE_CLEAN_SUBTITLE" = "No se requieren más acciones";
 "CLEANER_FINISH" = "Finalizar";
-"SETTINGS_ENABLE_LOW_BANDWIDTH" = "Habilitar el modo de red lento";
+"SETTINGS_ENABLE_LOW_BANDWIDTH" = "Habilitar el modo de uso reducido de red";

--- a/Shared/es.lproj/Localizable.strings
+++ b/Shared/es.lproj/Localizable.strings
@@ -273,3 +273,4 @@
 "CLEANER_DEVICE_CLEAN_TITLE" = "Tu dispositivo está limpio";
 "CLEANER_DEVICE_CLEAN_SUBTITLE" = "No se requieren más acciones";
 "CLEANER_FINISH" = "Finalizar";
+"SETTINGS_ENABLE_LOW_BANDWIDTH" = "Habilitar el modo de red lento";

--- a/Shared/fr.lproj/Localizable.strings
+++ b/Shared/fr.lproj/Localizable.strings
@@ -272,4 +272,4 @@
 "CLEANER_DEVICE_CLEAN_TITLE" = "Votre appareil est propre";
 "CLEANER_DEVICE_CLEAN_SUBTITLE" = "Aucune autre action nécessaire";
 "CLEANER_FINISH" = "Terminer";
-"SETTINGS_ENABLE_LOW_BANDWIDTH" = "Activer le mode réseau lent";
+"SETTINGS_ENABLE_LOW_BANDWIDTH" = "Activer le mode de faible utilisation du réseau";

--- a/Shared/fr.lproj/Localizable.strings
+++ b/Shared/fr.lproj/Localizable.strings
@@ -272,3 +272,4 @@
 "CLEANER_DEVICE_CLEAN_TITLE" = "Votre appareil est propre";
 "CLEANER_DEVICE_CLEAN_SUBTITLE" = "Aucune autre action nécessaire";
 "CLEANER_FINISH" = "Terminer";
+"SETTINGS_ENABLE_LOW_BANDWIDTH" = "Activer le mode réseau lent";

--- a/SyncExtension/FileProviderExtension.swift
+++ b/SyncExtension/FileProviderExtension.swift
@@ -93,7 +93,9 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension, NSFile
         }
         
         self.mnemonic = mnemonic
-        self.networkFacade = NetworkFacade(mnemonic: self.mnemonic, networkAPI: APIFactory.Network)
+        
+        let reduceBandwidth = config.getReduceBandwidth()
+        self.networkFacade = NetworkFacade(mnemonic: self.mnemonic, networkAPI: APIFactory.Network, reduceBandwidth: reduceBandwidth)
         
         do {
             self.tmpURL = try manager.temporaryDirectoryURL()
@@ -255,7 +257,7 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension, NSFile
                 return Progress()
             }
             return DownloadFileWorkspaceUseCase(
-                networkFacade: NetworkFacade(mnemonic: workspaceMnemonic, networkAPI: APIFactory.NetworkWorkspace),
+                networkFacade: NetworkFacade(mnemonic: workspaceMnemonic, networkAPI: APIFactory.NetworkWorkspace, reduceBandwidth: config.getReduceBandwidth()),
                 user: user,
                 activityManager: activityManager,
                 itemIdentifier: itemIdentifier,
@@ -430,7 +432,8 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension, NSFile
                         let useCase = UploadFileOrUpdateContentWorkspaceUseCase(
                             networkFacade: NetworkFacade(
                                 mnemonic: workspaceMnemonic,
-                                networkAPI: APIFactory.NetworkWorkspace
+                                networkAPI: APIFactory.NetworkWorkspace,
+                                reduceBandwidth: config.getReduceBandwidth()
                             ),
                             user: self.user,
                             activityManager: self.activityManager,
@@ -598,7 +601,7 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension, NSFile
                     return Progress()
                 }
                 return UpdateFileContentWorkspaceUseCase(
-                    networkFacade: NetworkFacade(mnemonic: workspaceMnemonic, networkAPI: APIFactory.NetworkWorkspace),
+                    networkFacade: NetworkFacade(mnemonic: workspaceMnemonic, networkAPI: APIFactory.NetworkWorkspace, reduceBandwidth: config.getReduceBandwidth()),
                     user: self.user,
                     item: item,
                     fileUuid: item.itemIdentifier.rawValue,

--- a/XPCBackupService/Utils/BackupConfigurationManager.swift
+++ b/XPCBackupService/Utils/BackupConfigurationManager.swift
@@ -57,7 +57,7 @@ class BackupConfigurationManager {
         let networkAPI = NetworkAPI(baseUrl: config.NETWORK_API_URL, basicAuthToken: networkAuth, clientName: clientName, clientVersion: getVersion())
         
         guard let mnemonic = getMnemonic() else { return nil }
-        let networkFacade = NetworkFacade(mnemonic: mnemonic, networkAPI: networkAPI, debug: true)
+        let networkFacade = NetworkFacade(mnemonic: mnemonic, networkAPI: networkAPI, reduceBandwidth: ConfigLoader().getReduceBandwidth(), debug: false)
         return (backupAPI, driveNewAPI, networkFacade)
     }
 }

--- a/XPCBackupService/XPCBackupService.swift
+++ b/XPCBackupService/XPCBackupService.swift
@@ -71,7 +71,7 @@ public class XPCBackupService: NSObject, XPCBackupServiceProtocol {
             let networkAPI = NetworkAPI(baseUrl: config.NETWORK_API_URL, basicAuthToken: networkAuth, clientName: CLIENT_NAME, clientVersion: getVersion())
 
             backupUploadService = BackupUploadService(
-                networkFacade: NetworkFacade(mnemonic: mnemonic, networkAPI: networkAPI),
+                networkFacade: NetworkFacade(mnemonic: mnemonic, networkAPI: networkAPI, reduceBandwidth: configLoader.getReduceBandwidth()),
                 encryptedContentDirectory: FileManager.default.temporaryDirectory,
                 deviceId: deviceId,
                 bucketId: bucketId,


### PR DESCRIPTION
Adds a new checkbox in **General Settings** that, when enabled, reduces the app's upload speed by ~50% to prevent network saturation.

- New `AppCheckbox` in **General Settings** → "Enable low bandwidth mode"
- Setting persisted via `AppGroup` shared `UserDefaults` so all targets can read it