### PR TITLE
fix: Intermittent ISO date parsing failures causing missing files in Finder

### DIFF
--- a/Shared/Services/Time.swift
+++ b/Shared/Services/Time.swift
@@ -10,10 +10,16 @@ import Foundation
 
 public class Time {
     public static func dateFromISOString(_ dateString: String) -> Date? {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         
-        return dateFormatter.date(from: dateString)
+        if let date = formatter.date(from: dateString) {
+            return date
+        }
+        
+        
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.date(from: dateString)
     }
 
     public static func stringDateFromDate(_ date: Date, dateStyle: DateFormatter.Style, timeStyle: DateFormatter.Style) -> String {


### PR DESCRIPTION
Users reported that some files and folders were not appearing in Finder through the FileProvider extension. Investigation of the SyncExtension logs revealed errors like:

[ERROR] [EnumerateFolderItemsUseCase.swift:101] Cannot create createdAt date for item Optional("695e4227384037e869fce647") with value 2025-12-14T15:50:47.712Z
[ERROR] [EnumerateFolderItemsUseCase.swift:106] Cannot create updatedAt date for item Optional("6977d2c116ceabcf39a755d9") with value 2026-01-26T20:46:58.000Z
The issue was intermittent — some items with dates in the same format (e.g. 2026-03-16T17:18:54.000Z) parsed successfully while others failed.

Root Cause
Time.dateFromISOString() used DateFormatter without a fixed locale, causing unpredictable parsing of the Z (UTC) suffix in ISO 8601 dates. The Z format specifier maps to RFC 822 offsets (+0000) and its handling of the literal Z character is inconsistent and locale-dependent.

Fix
Replaced DateFormatter with ISO8601DateFormatter, which is purpose-built for ISO 8601 and locale-independent. Includes a fallback for dates without fractional seconds.