### PR TITLE
fix: derive widget sync status from in-progress realm entries

### DIFF
--- a/Shared/Services/ActivityManager.swift
+++ b/Shared/Services/ActivityManager.swift
@@ -46,12 +46,28 @@ class ActivityManager: ObservableObject {
         do {
             let realm = getRealm()
             try realm?.write {
-                realm?.add(entry)
+                realm?.add(entry, update: .modified)
             }
         } catch {
             error.reportToSentry()
         }
 
+    }
+    
+    func updateActivityEntryStatus(id: ObjectId, filename: String, kind: ActivityEntryOperationKind, status: ActivityEntryStatus) {
+        guard let realm = getRealm() else { return }
+        if let existing = realm.object(ofType: ActivityEntry.self, forPrimaryKey: id) {
+            do {
+                try realm.write {
+                    existing.filename = filename
+                    existing.status = status
+                }
+            } catch {
+                error.reportToSentry()
+            }
+        } else {
+            saveActivityEntry(entry: ActivityEntry(_id: id, filename: filename, kind: kind, status: status))
+        }
     }
 
     func updateActivityEntries() {
@@ -60,6 +76,9 @@ class ActivityManager: ObservableObject {
         }
         let entries = realm.objects(ActivityEntry.self).sorted(byKeyPath: "createdAt", ascending: false)
 
+        let hasInProgress = !realm.objects(ActivityEntry.self)
+            .filter("status == %@", ActivityEntryStatus.inProgress.rawValue)
+            .isEmpty
         
         var newEntries: [ActivityEntry] = []
         for i in 0..<activityActionsLimit {
@@ -71,6 +90,7 @@ class ActivityManager: ObservableObject {
         
         DispatchQueue.main.async {
             self.activityEntries = newEntries
+            self.isSyncing = hasInProgress
         }
         
     }

--- a/Shared/Services/ActivityManager.swift
+++ b/Shared/Services/ActivityManager.swift
@@ -76,9 +76,9 @@ class ActivityManager: ObservableObject {
         }
         let entries = realm.objects(ActivityEntry.self).sorted(byKeyPath: "createdAt", ascending: false)
 
-        let hasInProgress = !realm.objects(ActivityEntry.self)
+        let hasInProgress = realm.objects(ActivityEntry.self)
             .filter("status == %@", ActivityEntryStatus.inProgress.rawValue)
-            .isEmpty
+            .first != nil
         
         var newEntries: [ActivityEntry] = []
         for i in 0..<activityActionsLimit {

--- a/SyncExtension/UseCases/Files/DownloadFileUseCase.swift
+++ b/SyncExtension/UseCases/Files/DownloadFileUseCase.swift
@@ -135,6 +135,13 @@ struct DownloadFileUseCase {
         
         Task {
            
+            let uuidString = itemIdentifier.rawValue.replacingOccurrences(of: "-", with: "").prefix(24)
+            let trackingObjectId = try? ObjectId(string: String(uuidString))
+            
+            if let trackingObjectId = trackingObjectId {
+                activityManager.saveActivityEntry(entry: ActivityEntry(_id: trackingObjectId, filename: itemIdentifier.rawValue, kind: .download, status: .inProgress))
+            }
+            
             var driveFile: DriveFile? = nil
             do {
                 
@@ -185,9 +192,9 @@ struct DownloadFileUseCase {
                     completionHandler(destinationURL, fileProviderItem, nil)
                     progressHandler(completedProgress: 1)
                     
-                    let uuidString = fileProviderItem.itemIdentifier.rawValue.replacingOccurrences(of: "-", with: "").prefix(24)
-                    let objectId = try ObjectId(string: String(uuidString))
-                    activityManager.saveActivityEntry(entry: ActivityEntry(_id: objectId, filename: filename, kind: .download, status: .finished))
+                    if let trackingObjectId = trackingObjectId {
+                        activityManager.updateActivityEntryStatus(id: trackingObjectId, filename: filename, kind: .download, status: .finished)
+                    }
                     
                     self.logger.info("✅ Created empty file with identifier \(itemIdentifier.rawValue)")
                     return
@@ -221,15 +228,18 @@ struct DownloadFileUseCase {
                 completionHandler(decryptedFileURL, fileProviderItem , nil)
 
                 progressHandler(completedProgress: 1)
-                let uuidString = fileProviderItem.itemIdentifier.rawValue.replacingOccurrences(of: "-", with: "").prefix(24)
-                let objectId = try ObjectId(string: String(uuidString))
-                activityManager.saveActivityEntry(entry: ActivityEntry(_id: objectId, filename: filename, kind: .download, status: .finished))
+                if let trackingObjectId = trackingObjectId {
+                    activityManager.updateActivityEntryStatus(id: trackingObjectId, filename: filename, kind: .download, status: .finished)
+                }
                 self.logger.info("✅ Downloaded and decrypted file correctly with identifier \(itemIdentifier.rawValue)")
             } catch {
           
                 error.reportToSentry()
                 self.logger.error("❌ Failed to fetch file content for file with identifier \(itemIdentifier.rawValue): \(error.getErrorDescription())")
                 
+                if let trackingObjectId = trackingObjectId {
+                    activityManager.updateActivityEntryStatus(id: trackingObjectId, filename: itemIdentifier.rawValue, kind: .download, status: .failed)
+                }
                 completionHandler(nil, nil, NSError(domain: NSFileProviderErrorDomain, code: NSFileProviderError.cannotSynchronize.rawValue))
             }
         }

--- a/SyncExtension/UseCases/Files/UploadFileUseCase.swift
+++ b/SyncExtension/UseCases/Files/UploadFileUseCase.swift
@@ -8,6 +8,7 @@
 import Foundation
 import FileProvider
 import InternxtSwiftCore
+import RealmSwift
 
 enum UploadFileUseCaseError: Error {
     case InvalidParentId
@@ -82,6 +83,10 @@ struct UploadFileUseCase {
         self.logger.info("Creating file")
         
         Task {
+          
+            let inProgressId = ObjectId.generate()
+            activityManager.saveActivityEntry(entry: ActivityEntry(_id: inProgressId, filename: item.filename, kind: .upload, status: .inProgress))
+            
             do {
                 let parentIdIsRootFolder = FileProviderItem.parentIdIsRootFolder(identifier: item.parentItemIdentifier)
 
@@ -183,11 +188,12 @@ struct UploadFileUseCase {
                 }
                 
                 completionHandler(fileProviderItem, [], false, nil )
-                activityManager.saveActivityEntry(entry: ActivityEntry(filename: FileProviderItem.getFilename(name: createdFile.plain_name ?? createdFile.name, itemExtension: createdFile.type), kind: .upload, status: .finished))
+                activityManager.updateActivityEntryStatus(id: inProgressId, filename: FileProviderItem.getFilename(name: createdFile.plain_name ?? createdFile.name, itemExtension: createdFile.type), kind: .upload, status: .finished)
+
                 
             } catch {
                 error.reportToSentry()
-
+                activityManager.updateActivityEntryStatus(id: inProgressId, filename: item.filename, kind: .upload, status: .failed)
                 self.logger.error("❌ Failed to create file: \(error.getErrorDescription())")
                 
                

--- a/SyncExtension/UseCases/Files/Workspaces/DownloadFileWorkspaceUseCase.swift
+++ b/SyncExtension/UseCases/Files/Workspaces/DownloadFileWorkspaceUseCase.swift
@@ -53,6 +53,14 @@ struct DownloadFileWorkspaceUseCase {
         
         Task {
            
+            let uuidString = itemIdentifier.rawValue.replacingOccurrences(of: "-", with: "").prefix(24)
+            let trackingObjectId = try? ObjectId(string: String(uuidString))
+            
+          
+            if let trackingObjectId = trackingObjectId {
+                activityManager.saveActivityEntry(entry: ActivityEntry(_id: trackingObjectId, filename: itemIdentifier.rawValue, kind: .download, status: .inProgress))
+            }
+            
             do {
                 
                 func progressHandler(completedProgress: Double) {
@@ -96,9 +104,9 @@ struct DownloadFileWorkspaceUseCase {
                     completionHandler(destinationURL, fileProviderItem, nil)
                     progressHandler(completedProgress: 1)
                     
-                    let uuidString = fileProviderItem.itemIdentifier.rawValue.replacingOccurrences(of: "-", with: "").prefix(24)
-                    let objectId = try ObjectId(string: String(uuidString))
-                    activityManager.saveActivityEntry(entry: ActivityEntry(_id: objectId, filename: filename + "- Workspace", kind: .download, status: .finished))
+                    if let trackingObjectId = trackingObjectId {
+                        activityManager.updateActivityEntryStatus(id: trackingObjectId, filename: filename + "- Workspace", kind: .download, status: .finished)
+                    }
                     
                     self.logger.info("✅ Created empty file with identifier \(itemIdentifier.rawValue)")
                     return
@@ -137,15 +145,18 @@ struct DownloadFileWorkspaceUseCase {
                 completionHandler(decryptedFileURL, fileProviderItem , nil)
 
                 progressHandler(completedProgress: 1)
-                let uuidString = fileProviderItem.itemIdentifier.rawValue.replacingOccurrences(of: "-", with: "").prefix(24)
-                let objectId = try ObjectId(string: String(uuidString))
-                activityManager.saveActivityEntry(entry: ActivityEntry(_id: objectId, filename: filename + "- Workspace", kind: .download, status: .finished))
+                if let trackingObjectId = trackingObjectId {
+                    activityManager.updateActivityEntryStatus(id: trackingObjectId, filename: filename + "- Workspace", kind: .download, status: .finished)
+                }
                 self.logger.info("✅ Downloaded and decrypted file correctly with identifier \(itemIdentifier.rawValue)")
             } catch {
 
                 error.reportToSentry()
                 self.logger.error("❌ Failed to fetch file content for file with identifier \(itemIdentifier.rawValue): \(error.getErrorDescription())")
                 
+                if let trackingObjectId = trackingObjectId {
+                    activityManager.updateActivityEntryStatus(id: trackingObjectId, filename: itemIdentifier.rawValue, kind: .download, status: .failed)
+                }
                 completionHandler(nil, nil, NSError(domain: NSFileProviderErrorDomain, code: NSFileProviderError.cannotSynchronize.rawValue))
             }
         }

--- a/SyncExtension/UseCases/Files/Workspaces/UploadFileWorkspaceUseCase.swift
+++ b/SyncExtension/UseCases/Files/Workspaces/UploadFileWorkspaceUseCase.swift
@@ -8,6 +8,7 @@
 import Foundation
 import FileProvider
 import InternxtSwiftCore
+import RealmSwift
 
 
 struct UploadFileWorkspaceUseCase {
@@ -120,6 +121,10 @@ struct UploadFileWorkspaceUseCase {
         self.logger.info("Creating file")
         
         Task {
+           
+            let inProgressId = ObjectId.generate()
+            activityManager.saveActivityEntry(entry: ActivityEntry(_id: inProgressId, filename: item.filename, kind: .upload, status: .inProgress))
+            
             do {
                 let parentIdIsRootFolder = FileProviderItem.parentIdIsRootFolder(identifier: item.parentItemIdentifier)
                 
@@ -223,12 +228,12 @@ struct UploadFileWorkspaceUseCase {
                 }
                 
                 completionHandler(fileProviderItem, [], false, nil )
-                activityManager.saveActivityEntry(entry: ActivityEntry(filename: FileProviderItem.getFilename(name: createdFile.plain_name ?? createdFile.name, itemExtension: createdFile.type), kind: .upload, status: .finished))
+                activityManager.updateActivityEntryStatus(id: inProgressId, filename: FileProviderItem.getFilename(name: createdFile.plain_name ?? createdFile.name, itemExtension: createdFile.type), kind: .upload, status: .finished)
                 
             } catch {
                 self.trackError(processIdentifier: trackId, error: error)
                 error.reportToSentry()
-
+                activityManager.updateActivityEntryStatus(id: inProgressId, filename: item.filename, kind: .upload, status: .failed)
                 self.logger.error("❌ Failed to create file: \(error.getErrorDescription())")
                 
                 if let apiClientError = error as? APIClientError, apiClientError.statusCode == 402 {


### PR DESCRIPTION
Fixed an issue where the "Syncing..." status was never displayed in the widget footer. The root cause was that the isSyncing property was an in-memory variable that wasn't synchronized between the main app process and the sync extension process.