### PR TITLE
Fix: Add spinning progress icon for active file transfers in Widget

### DIFF
--- a/InternxtDesktop/Views/Widget/WidgetSyncEntryView.swift
+++ b/InternxtDesktop/Views/Widget/WidgetSyncEntryView.swift
@@ -46,13 +46,13 @@ struct WidgetSyncEntryView: View {
     var EntryStatusSubtitle: some View {
         switch self.operationKind {
         case .backupDownload:
-            AppText("SYNC_ENTRY_KIND_DOWNLOADED").font(.XSMedium).foregroundColor(.Gray50)
+            AppText(status == .inProgress ? "SYNC_ENTRY_KIND_DOWNLOADING" : "SYNC_ENTRY_KIND_DOWNLOADED").font(.XSMedium).foregroundColor(.Gray50)
         case .trash:
             AppText("SYNC_ENTRY_KIND_TRASHED").font(.XSMedium).foregroundColor(.Gray50)
         case .download:
-            AppText("SYNC_ENTRY_KIND_DOWNLOADED").font(.XSMedium).foregroundColor(.Gray50)
+            AppText(status == .inProgress ? "SYNC_ENTRY_KIND_DOWNLOADING" : "SYNC_ENTRY_KIND_DOWNLOADED").font(.XSMedium).foregroundColor(.Gray50)
         case .upload:
-            AppText("SYNC_ENTRY_KIND_UPLOADED").font(.XSMedium).foregroundColor(.Gray50)
+            AppText(status == .inProgress ? "SYNC_ENTRY_KIND_UPLOADING" : "SYNC_ENTRY_KIND_UPLOADED").font(.XSMedium).foregroundColor(.Gray50)
         default:
             EmptyView()
         }
@@ -63,6 +63,10 @@ struct WidgetSyncEntryView: View {
         switch self.status {
         case .finished:
             AppIcon(iconName: .Check, size: 24, color: .GreenDark)
+        case .inProgress:
+            ProgressView()
+                .scaleEffect(0.7)
+                .frame(width: 24, height: 24)
         default:
             EmptyView()
         }

--- a/Shared/en.lproj/Localizable.strings
+++ b/Shared/en.lproj/Localizable.strings
@@ -36,6 +36,8 @@
 "SYNC_ENTRY_KIND_TRASHED" = "Moved to trash";
 "SYNC_ENTRY_KIND_DOWNLOADED" = "Downloaded";
 "SYNC_ENTRY_KIND_UPLOADED" = "Uploaded";
+"SYNC_ENTRY_KIND_DOWNLOADING" = "Downloading...";
+"SYNC_ENTRY_KIND_UPLOADING" = "Uploading...";
 
 // Widget backup banner
 "INTERNXT_BACKUPS" = "INTERNXT BACKUPS";

--- a/Shared/es.lproj/Localizable.strings
+++ b/Shared/es.lproj/Localizable.strings
@@ -37,6 +37,8 @@
 "SYNC_ENTRY_KIND_TRASHED" = "Movido a la papelera";
 "SYNC_ENTRY_KIND_DOWNLOADED" = "Descargado";
 "SYNC_ENTRY_KIND_UPLOADED" = "Subido";
+"SYNC_ENTRY_KIND_DOWNLOADING" = "Descargando...";
+"SYNC_ENTRY_KIND_UPLOADING" = "Subiendo...";
 
 // Widget backup banner
 "INTERNXT_BACKUPS" = "INTERNXT BACKUPS";

--- a/Shared/fr.lproj/Localizable.strings
+++ b/Shared/fr.lproj/Localizable.strings
@@ -37,6 +37,8 @@
 "SYNC_ENTRY_KIND_TRASHED" = "Déplacé vers la corbeille";
 "SYNC_ENTRY_KIND_DOWNLOADED" = "Téléchargé";
 "SYNC_ENTRY_KIND_UPLOADED" = "Téléchargé";
+"SYNC_ENTRY_KIND_DOWNLOADING" = "Téléchargement...";
+"SYNC_ENTRY_KIND_UPLOADING" = "Téléversement...";
 
 // Widget backup banner
 "INTERNXT_BACKUPS" = "INTERNXT BACKUPS";


### PR DESCRIPTION
This PR  adding a visual indicator (a spinning icon) to the Desktop Widget. This allows users to easily see when files are actively syncing (uploading or downloading) in the background without needing to open the main application.