### PR TITLE
refactor: remove name reference from upload files flow

### DIFF
--- a/SyncExtension/UseCases/Files/UploadFileUseCase.swift
+++ b/SyncExtension/UseCases/Files/UploadFileUseCase.swift
@@ -168,7 +168,7 @@ struct UploadFileUseCase {
                 let uploadDuration = self.trackEnd(processIdentifier: trackId, startedAt: startedAt)
                 
                 self.logger.info("⏱️ Upload completed in \(uploadDuration) seconds")
-                self.logger.info("✅ Created file correctly with identifier \(fileProviderItem.itemIdentifier.rawValue)")
+                self.logger.info("✅ Created file correctly with identifier \(fileProviderItem.itemIdentifier.rawValue) -  \(item.filename)")
                 
                 self.logger.info("🖼️ Processing thumbnail...")
                 
@@ -188,13 +188,13 @@ struct UploadFileUseCase {
                 }
                 
                 completionHandler(fileProviderItem, [], false, nil )
-                activityManager.updateActivityEntryStatus(id: inProgressId, filename: FileProviderItem.getFilename(name: createdFile.plain_name ?? createdFile.name, itemExtension: createdFile.type), kind: .upload, status: .finished)
+                activityManager.updateActivityEntryStatus(id: inProgressId, filename: FileProviderItem.getFilename(name: createdFile.plain_name, itemExtension: createdFile.type), kind: .upload, status: .finished)
 
                 
             } catch {
                 error.reportToSentry()
                 activityManager.updateActivityEntryStatus(id: inProgressId, filename: item.filename, kind: .upload, status: .failed)
-                self.logger.error("❌ Failed to create file: \(error.getErrorDescription())")
+                self.logger.error("❌ Failed to create file \(item.filename) : \(error.getErrorDescription())")
                 
                
                 if let apiClientError = error as? APIClientError, apiClientError.statusCode == 402 {

--- a/SyncExtension/UseCases/Files/Workspaces/UploadFileWorkspaceUseCase.swift
+++ b/SyncExtension/UseCases/Files/Workspaces/UploadFileWorkspaceUseCase.swift
@@ -228,7 +228,7 @@ struct UploadFileWorkspaceUseCase {
                 }
                 
                 completionHandler(fileProviderItem, [], false, nil )
-                activityManager.updateActivityEntryStatus(id: inProgressId, filename: FileProviderItem.getFilename(name: createdFile.plain_name ?? createdFile.name, itemExtension: createdFile.type), kind: .upload, status: .finished)
+                activityManager.updateActivityEntryStatus(id: inProgressId, filename: FileProviderItem.getFilename(name: createdFile.plain_name, itemExtension: createdFile.type), kind: .upload, status: .finished)
                 
             } catch {
                 self.trackError(processIdentifier: trackId, error: error)


### PR DESCRIPTION

Some users were reporting file sync errors. After analyzing the error , it was found that in some cases the API response returns `null` for the `name` field, which caused a decoding failure since the field was declared as a non-optional `String`, interrupting the sync flow.

- Made `name` optional (`String?`) in the relevant response structs to handle cases where the API returns `null` for this field
- Removed the reference to `name` in the file creation flow since it was not being used