### PR TITLE
Fix: Free up physical disk space when selecting "Make Available Online"

### DIFF
--- a/SyncExtension/FileProviderExtension.swift
+++ b/SyncExtension/FileProviderExtension.swift
@@ -711,9 +711,10 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension, NSFile
                     try? await manager.requestModification(of: [.extendedAttributes], forItemWithIdentifier: identifier)
                     
                     do {
+                        // Notify macOS of policy change to .inherited and wait for the async update to process.
+                        // This prevents -2008 (nonEvictable) errors when calling evictItem to physically free disk space.
                         try await Task.sleep(nanoseconds: 2_000_000_000)
                         try await manager.evictItem(identifier: identifier)
-                        
                     } catch {
                         logger.error("❌ Failed to evict \(identifier.rawValue): \(error.localizedDescription)")
                     }

--- a/SyncExtension/FileProviderExtension.swift
+++ b/SyncExtension/FileProviderExtension.swift
@@ -706,11 +706,16 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension, NSFile
         if actionIdentifier == FileProviderItemActionsManager.MakeAvailableOnline {
             Task {
                 for identifier in itemIdentifiers {
+                    
                     fileProviderItemActions.makeAvailableOnlineOnly(identifier: identifier)
-                    if #available(macOSApplicationExtension 13.0, *) {
-                        try await manager.requestModification(of: [.extendedAttributes], forItemWithIdentifier: identifier)
-                    } else {
-                        // Nothing we can do here
+                    try? await manager.requestModification(of: [.extendedAttributes], forItemWithIdentifier: identifier)
+                    
+                    do {
+                        try await Task.sleep(nanoseconds: 2_000_000_000)
+                        try await manager.evictItem(identifier: identifier)
+                        
+                    } catch {
+                        logger.error("❌ Failed to evict \(identifier.rawValue): \(error.localizedDescription)")
                     }
                 }
                 


### PR DESCRIPTION
This PR resolves an issue where using the "Make Available Online" contextual action in Finder updated the visual state to "cloud-only" but failed to actually free up the physical disk space on the user's hard drive.