### PR TITLE
Cleaner Helper Permissions & Refactor

### DIFF
--- a/InternxtDesktop.xcodeproj/project.pbxproj
+++ b/InternxtDesktop.xcodeproj/project.pbxproj
@@ -90,6 +90,7 @@
 		AA40B3BD2D3B298600FC1FC3 /* AntivirusTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA40B3BC2D3B298600FC1FC3 /* AntivirusTabView.swift */; };
 		AA40B3C12D3ED74400FC1FC3 /* AntivirusManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA40B3C02D3ED74400FC1FC3 /* AntivirusManager.swift */; };
 		AA4395702C174B52003AA905 /* ScheduledBackupManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA43956F2C174B52003AA905 /* ScheduledBackupManager.swift */; };
+		AA44C9C42F7CBA7800261D14 /* CleanerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA44C9C32F7CBA7800261D14 /* CleanerViewModel.swift */; };
 		AA5EABE62BFD761F00BA0145 /* NetworkAnalyticsEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16D3E892AF141540026C504 /* NetworkAnalyticsEvents.swift */; };
 		AA5EABE82BFD762D00BA0145 /* ProcessInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A0AC6C2AB88B5A005E71D6 /* ProcessInfo.swift */; };
 		AA5EABE92BFD770200BA0145 /* AnalyticsEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D0D4162AF55C1500CF1F7F /* AnalyticsEvents.swift */; };
@@ -530,6 +531,7 @@
 		AA40B3BC2D3B298600FC1FC3 /* AntivirusTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AntivirusTabView.swift; sourceTree = "<group>"; };
 		AA40B3C02D3ED74400FC1FC3 /* AntivirusManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AntivirusManager.swift; sourceTree = "<group>"; };
 		AA43956F2C174B52003AA905 /* ScheduledBackupManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduledBackupManager.swift; sourceTree = "<group>"; };
+		AA44C9C32F7CBA7800261D14 /* CleanerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CleanerViewModel.swift; sourceTree = "<group>"; };
 		AA628F292D4BF73000421CB7 /* OnboardingSlide6View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingSlide6View.swift; sourceTree = "<group>"; };
 		AA628F2B2D4BFBA800421CB7 /* OnboardingSlide7View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingSlide7View.swift; sourceTree = "<group>"; };
 		AA642CAD2C62B26B0015BBB9 /* BackupConfigurationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupConfigurationManager.swift; sourceTree = "<group>"; };
@@ -1246,6 +1248,7 @@
 			isa = PBXGroup;
 			children = (
 				E17DB7092C539A1F0031B465 /* BackupContentNavigatorViewModel.swift */,
+				AA44C9C32F7CBA7800261D14 /* CleanerViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -1981,6 +1984,7 @@
 				E1880BA22AA63CF2001FC171 /* AccountTabView.swift in Sources */,
 				E1880B9C2AA625D6001FC171 /* DeviceNameView.swift in Sources */,
 				E18300A42AA1FC7700AD023C /* SettingsMenuView.swift in Sources */,
+				AA44C9C42F7CBA7800261D14 /* CleanerViewModel.swift in Sources */,
 				E1DB29592A7D5D86009036B8 /* ConfigLoader.swift in Sources */,
 				E1880B992AA611D3001FC171 /* GeneralTabView.swift in Sources */,
 				317EE5C92BABC221008CDBD1 /* SettingsTabManager.swift in Sources */,

--- a/InternxtDesktop/ViewModels/CleanerViewModel.swift
+++ b/InternxtDesktop/ViewModels/CleanerViewModel.swift
@@ -1,0 +1,8 @@
+//
+//  CleanerViewModel.swift
+//  InternxtDesktop
+//
+//  Created by Patricio Tovar on 31/3/26.
+//
+
+import Foundation

--- a/InternxtDesktop/ViewModels/CleanerViewModel.swift
+++ b/InternxtDesktop/ViewModels/CleanerViewModel.swift
@@ -6,3 +6,457 @@
 //
 
 import Foundation
+
+@MainActor
+class CleanupViewModel: ObservableObject {
+   
+   
+    @Published var selectedCategories: Set<String> = []
+    @Published var selectedCategoryForPreview: CleanupCategory? = nil
+    @Published var selectedFilesByCategory: [String: Set<String>] = [:]
+    @Published var isLoadingFiles = false
+    @Published var currentCategoryFiles: [CleanupFile] = []
+    
+   
+    private let cleanerService: CleanerService
+    private var filesCache: [String: [CleanupFile]] = [:]
+    private var displayedFilesCache: [String: [CleanupFile]] = [:]
+    private var loadedItemsCount: [String: Int] = [:]
+    
+   
+    private struct Constants {
+        static let itemsPerBatch = 100
+        static let initialBatchSize = 20
+        static let loadMoreThreshold = 10
+        static let maxCategoriesInMemory = 3
+        static let maxItemsPerCategory = 5000
+        static let defaultSelectedCategoryIds = ["app_cache", "web_cache", "trash"]
+    }
+
+    init(cleanerService: CleanerService) {
+        self.cleanerService = cleanerService
+    }
+
+  
+    var categories: [CleanupCategory] {
+        let allCategories = cleanerService.scanResult?.categories ?? []
+        
+        return allCategories.sorted { category1, category2 in
+            category1.name.localizedCaseInsensitiveCompare(category2.name) == .orderedAscending
+        }
+    }
+    
+    var selectedCategorySize: UInt64 {
+        guard let selectedCategory = selectedCategoryForPreview else { return 0 }
+        return selectedCategory.size
+    }
+    
+    var selectedTotalSize: UInt64 {
+        var totalSize: UInt64 = 0
+        
+        for categoryId in selectedCategories {
+            if let category = categories.first(where: { $0.id == categoryId }) {
+                totalSize += category.size
+            }
+        }
+        
+        for (categoryId, filePaths) in selectedFilesByCategory {
+            guard !filePaths.isEmpty else { continue }
+            
+            if selectedCategories.contains(categoryId) {
+                continue
+            }
+            
+            if let cachedFiles = filesCache[categoryId] {
+                let selectedFiles = cachedFiles.filter { filePaths.contains($0.path) }
+                totalSize += selectedFiles.reduce(0) { $0 + $1.size }
+            } else if let category = categories.first(where: { $0.id == categoryId }) {
+                let allFiles = getAllCachedFiles(for: categoryId)
+                if !allFiles.isEmpty {
+                    if filePaths.count == allFiles.count {
+                        totalSize += category.size
+                    } else {
+                        let ratio = Double(filePaths.count) / Double(allFiles.count)
+                        totalSize += UInt64(Double(category.size) * ratio)
+                    }
+                }
+            }
+        }
+        
+        return totalSize
+    }
+    
+    var selectedFiles: Set<String> {
+        guard let categoryId = selectedCategoryForPreview?.id else { return [] }
+        return selectedFilesByCategory[categoryId] ?? []
+    }
+    
+    var hasMoreItems: Bool {
+        guard let categoryId = selectedCategoryForPreview?.id,
+              let totalFiles = filesCache[categoryId]?.count,
+              let currentLoaded = loadedItemsCount[categoryId] else {
+            return false
+        }
+        return currentLoaded < totalFiles
+    }
+    
+    var hasAnySelections: Bool {
+        return !selectedCategories.isEmpty ||
+               selectedFilesByCategory.values.contains { !$0.isEmpty }
+    }
+    
+    var categoriesSelectAllState: SelectionState {
+        let states = categories.map { getCategorySelectionState($0) }
+        
+        if states.allSatisfy({ $0 == .full }) {
+            return .full
+        } else if states.allSatisfy({ $0 == .none }) {
+            return .none
+        } else {
+            return .partial
+        }
+    }
+    
+    var filesSelectAllState: SelectionState {
+        let totalFiles = currentCategoryFiles.count
+        let selectedFilesCount = currentCategoryFiles.filter { isFileSelected($0.path) }.count
+        
+        switch selectedFilesCount {
+        case 0: return .none
+        case totalFiles: return .full
+        default: return .partial
+        }
+    }
+
+    func selectCategoryForPreview(_ category: CleanupCategory) async {
+        selectedCategoryForPreview = category
+        isLoadingFiles = true
+        
+        await loadCategoryFiles(category)
+        updateCurrentCategoryFiles()
+        
+        isLoadingFiles = false
+    }
+    
+    @MainActor
+    private func loadCategoryFiles(_ category: CleanupCategory) async {
+        if let cachedFiles = filesCache[category.id] {
+            cleanerService.currentFiles = cachedFiles
+        } else {
+            await cleanerService.loadFilesForCategory(category)
+            filesCache[category.id] = cleanerService.currentFiles
+        }
+
+        if selectedCategories.contains(category.id) {
+            selectedFilesByCategory[category.id] = Set(cleanerService.currentFiles.map { $0.path })
+        }
+        
+        loadInitialBatch(for: category.id)
+    }
+
+    func getCategorySelectionState(_ category: CleanupCategory) -> SelectionState {
+        let isFullySelected = selectedCategories.contains(category.id)
+        let individualFiles = selectedFilesByCategory[category.id]
+        
+        if isFullySelected && individualFiles == nil {
+            return .full
+        }
+        
+        if let selectedFiles = individualFiles, !selectedFiles.isEmpty {
+            if selectedCategoryForPreview?.id == category.id {
+                let totalFiles = currentCategoryFiles.count
+                return selectedFiles.count == totalFiles ? .full : .partial
+            } else {
+                return .partial
+            }
+        }
+        
+        return isFullySelected ? .full : .none
+    }
+
+    func toggleCategorySelection(_ categoryId: String, to newState: SelectionState) {
+        switch newState {
+        case .full:
+            selectedCategories.insert(categoryId)
+            selectedFilesByCategory.removeValue(forKey: categoryId)
+            
+        case .none:
+            selectedCategories.remove(categoryId)
+            selectedFilesByCategory.removeValue(forKey: categoryId)
+            
+        case .partial:
+            selectedCategories.insert(categoryId)
+            selectedFilesByCategory.removeValue(forKey: categoryId)
+        }
+    }
+
+    func toggleAllCategories() {
+        let newState: SelectionState = categoriesSelectAllState == .full ? .none : .full
+        
+        switch newState {
+        case .full:
+            selectedCategories = Set(categories.map { $0.id })
+            selectedFilesByCategory.removeAll()
+        case .none:
+            selectedCategories.removeAll()
+            selectedFilesByCategory.removeAll()
+        case .partial:
+            break
+        }
+    }
+
+   
+    func isFileSelected(_ filePath: String) -> Bool {
+        guard let categoryId = selectedCategoryForPreview?.id else { return false }
+        if selectedCategories.contains(categoryId) {
+            return true
+        }
+        return selectedFilesByCategory[categoryId]?.contains(filePath) ?? false
+    }
+
+    func toggleFileSelection(_ filePath: String, to newState: SelectionState) {
+        guard let categoryId = selectedCategoryForPreview?.id else { return }
+        
+        if selectedCategories.contains(categoryId) {
+            moveToIndividualFileSelection(for: categoryId)
+        }
+        
+        var categoryFiles = selectedFilesByCategory[categoryId] ?? []
+        
+        switch newState {
+        case .full:
+            categoryFiles.insert(filePath)
+        case .none:
+            categoryFiles.remove(filePath)
+        case .partial:
+           
+            if categoryFiles.contains(filePath) {
+                categoryFiles.remove(filePath)
+            } else {
+                categoryFiles.insert(filePath)
+            }
+        }
+        
+        if categoryFiles.isEmpty {
+            selectedFilesByCategory.removeValue(forKey: categoryId)
+        } else {
+            selectedFilesByCategory[categoryId] = categoryFiles
+        }
+    }
+
+    func toggleAllFiles() {
+        guard let categoryId = selectedCategoryForPreview?.id else { return }
+        
+        let newState: SelectionState = filesSelectAllState == .full ? .none : .full
+        
+        switch newState {
+        case .full:
+            selectedCategories.insert(categoryId)
+            selectedFilesByCategory.removeValue(forKey: categoryId)
+        case .none:
+            selectedCategories.remove(categoryId)
+            selectedFilesByCategory.removeValue(forKey: categoryId)
+        case .partial:
+            break
+        }
+    }
+    
+    private func moveToIndividualFileSelection(for categoryId: String) {
+        if selectedCategories.contains(categoryId) {
+            selectedCategories.remove(categoryId)
+            let allFilePaths = Set(getAllCachedFiles(for: categoryId).map { $0.path })
+            selectedFilesByCategory[categoryId] = allFilePaths
+        }
+    }
+    
+    private func getAllCachedFiles(for categoryId: String) -> [CleanupFile] {
+        if selectedCategoryForPreview?.id == categoryId {
+            return filesCache[categoryId] ?? cleanerService.currentFiles
+        } else {
+            return filesCache[categoryId] ?? []
+        }
+    }
+
+ 
+    private func loadInitialBatch(for categoryId: String) {
+        guard let allFiles = filesCache[categoryId] else {
+            return
+        }
+        
+        let batchSize = min(Constants.initialBatchSize, allFiles.count)
+        displayedFilesCache[categoryId] = Array(allFiles.prefix(batchSize))
+        loadedItemsCount[categoryId] = batchSize
+        
+    }
+    
+    func loadMoreIfNeeded(currentIndex: Int) {
+        guard let categoryId = selectedCategoryForPreview?.id,
+              let allFiles = filesCache[categoryId],
+              let currentLoaded = loadedItemsCount[categoryId] else {
+            return
+        }
+        
+        let shouldLoadMore = currentIndex >= currentLoaded - Constants.loadMoreThreshold &&
+                           currentLoaded < allFiles.count
+        
+        guard shouldLoadMore else { return }
+        
+        let newBatchSize = min(Constants.itemsPerBatch, allFiles.count - currentLoaded)
+        let newItems = Array(allFiles[currentLoaded..<(currentLoaded + newBatchSize)])
+        
+        displayedFilesCache[categoryId]?.append(contentsOf: newItems)
+        loadedItemsCount[categoryId] = currentLoaded + newBatchSize
+        
+        updateCurrentCategoryFiles()
+        
+    }
+    
+    private func updateCurrentCategoryFiles() {
+        guard let categoryId = selectedCategoryForPreview?.id else {
+            currentCategoryFiles = []
+            return
+        }
+        
+        currentCategoryFiles = displayedFilesCache[categoryId] ?? []
+    }
+
+    
+    func closeFilePreview() {
+        selectedCategoryForPreview = nil
+        currentCategoryFiles = []
+        limitMemoryUsage()
+    }
+    
+    private func limitMemoryUsage() {
+        if displayedFilesCache.count > Constants.maxCategoriesInMemory {
+            let keysToRemove = Array(displayedFilesCache.keys.prefix(
+                displayedFilesCache.count - Constants.maxCategoriesInMemory
+            ))
+            keysToRemove.forEach { key in
+                displayedFilesCache.removeValue(forKey: key)
+                loadedItemsCount.removeValue(forKey: key)
+            }
+        }
+        
+        for (categoryId, items) in displayedFilesCache {
+            if items.count > Constants.maxItemsPerCategory {
+                displayedFilesCache[categoryId] = Array(items.prefix(Constants.maxItemsPerCategory))
+                loadedItemsCount[categoryId] = Constants.maxItemsPerCategory
+            }
+        }
+    }
+
+ 
+    @MainActor
+    func performCleanup() async throws {
+        let cleanupData = prepareCleanupData()
+
+        switch cleanupData.type {
+        case .categoriesOnly(let categories):
+            let categoriesToClean = categories.map { category in
+                var mutableCategory = category
+                mutableCategory.isSelected = true
+                return mutableCategory
+            }
+            
+            _ = try await cleanerService.cleanupCategories(categoriesToClean) { progress in
+                await MainActor.run {
+                }
+            }
+
+        case .filesOnly(_):
+            _ = try await cleanerService.cleanupSpecificFiles(cleanupData) { progress in
+                await MainActor.run {
+                }
+            }
+
+        case .hybrid(_, _):
+            _ = try await cleanerService.cleanupSpecificFiles(cleanupData) { progress in
+                await MainActor.run {
+                }
+            }
+        }
+        
+        resetAfterCleanup()
+    }
+    
+    private func prepareCleanupData() -> CleanupData {
+        var fullCategoriesIds = selectedCategories
+        var specificFilesByCategory: [String: [CleanupFile]] = [:]
+
+        for (categoryId, filePaths) in selectedFilesByCategory {
+            guard !filePaths.isEmpty else { continue }
+
+            let selectedCategoryFiles = getSelectedFilesForCategory(categoryId, filePaths: filePaths)
+            
+            let allFiles = getAllCachedFiles(for: categoryId)
+            let allFilesSelected = filePaths.count == allFiles.count
+            
+            if allFilesSelected {
+                fullCategoriesIds.insert(categoryId)
+            } else {
+                fullCategoriesIds.remove(categoryId)
+                specificFilesByCategory[categoryId] = selectedCategoryFiles
+            }
+        }
+
+        let fullCategories = categories.filter { fullCategoriesIds.contains($0.id) }
+
+        if !fullCategories.isEmpty && !specificFilesByCategory.isEmpty {
+            return CleanupData(type: .hybrid(fullCategories, specificFilesByCategory))
+        } else if !fullCategories.isEmpty {
+            return CleanupData(type: .categoriesOnly(fullCategories))
+        } else {
+            return CleanupData(type: .filesOnly(specificFilesByCategory))
+        }
+    }
+    
+    private func getSelectedFilesForCategory(_ categoryId: String, filePaths: Set<String>) -> [CleanupFile] {
+        if let cachedFiles = filesCache[categoryId] {
+            return cachedFiles.filter { filePaths.contains($0.path) }
+        } else {
+            return filePaths.map { path in
+                CleanupFile(
+                    id: UUID().uuidString,
+                    categoryId: categoryId,
+                    name: URL(fileURLWithPath: path).lastPathComponent,
+                    path: path,
+                    size: 0,
+                    isDirectory: false,
+                    canDelete: true
+                )
+            }
+        }
+    }
+    
+    @MainActor
+    func resetAfterCleanup() {
+     
+        selectedCategories.removeAll()
+        selectedFilesByCategory.removeAll()
+        selectedCategoryForPreview = nil
+        currentCategoryFiles = []
+        
+        filesCache.removeAll()
+        displayedFilesCache.removeAll()
+        loadedItemsCount.removeAll()
+        
+      
+        isLoadingFiles = false
+        
+     
+    }
+    
+    func selectDefaultCategories() {
+        selectedCategories.removeAll()
+        selectedFilesByCategory.removeAll()
+        
+        for category in categories {
+            if Constants.defaultSelectedCategoryIds.contains(category.id) {
+                if category.canAccess && category.size > 0 {
+                    selectedCategories.insert(category.id)
+                }             }
+        }
+        
+    }
+}

--- a/InternxtDesktop/Views/Cleaner/CleanupView.swift
+++ b/InternxtDesktop/Views/Cleaner/CleanupView.swift
@@ -21,460 +21,6 @@ enum SelectionState {
     }
 }
 
-// MARK: - View Model
-@MainActor
-class CleanupViewModel: ObservableObject {
-    // MARK: - Published Properties
-    @Published var selectedCategories: Set<String> = []
-    @Published var selectedCategoryForPreview: CleanupCategory? = nil
-    @Published var selectedFilesByCategory: [String: Set<String>] = [:]
-    @Published var isLoadingFiles = false
-    @Published var currentCategoryFiles: [CleanupFile] = []
-    
-    // MARK: - Private Properties
-    private let cleanerService: CleanerService
-    private var filesCache: [String: [CleanupFile]] = [:]
-    private var displayedFilesCache: [String: [CleanupFile]] = [:]
-    private var loadedItemsCount: [String: Int] = [:]
-    
-    // MARK: - Constants
-    private struct Constants {
-        static let itemsPerBatch = 100
-        static let initialBatchSize = 20
-        static let loadMoreThreshold = 10
-        static let maxCategoriesInMemory = 3
-        static let maxItemsPerCategory = 5000
-        static let defaultSelectedCategoryIds = ["app_cache", "web_cache", "trash"]
-    }
-
-    init(cleanerService: CleanerService) {
-        self.cleanerService = cleanerService
-    }
-
-    // MARK: - Computed Properties
-    var categories: [CleanupCategory] {
-        let allCategories = cleanerService.scanResult?.categories ?? []
-        
-        return allCategories.sorted { category1, category2 in
-            category1.name.localizedCaseInsensitiveCompare(category2.name) == .orderedAscending
-        }
-    }
-    
-    var selectedCategorySize: UInt64 {
-        guard let selectedCategory = selectedCategoryForPreview else { return 0 }
-        return selectedCategory.size
-    }
-    
-    var selectedTotalSize: UInt64 {
-        var totalSize: UInt64 = 0
-        
-        for categoryId in selectedCategories {
-            if let category = categories.first(where: { $0.id == categoryId }) {
-                totalSize += category.size
-            }
-        }
-        
-        for (categoryId, filePaths) in selectedFilesByCategory {
-            guard !filePaths.isEmpty else { continue }
-            
-            if selectedCategories.contains(categoryId) {
-                continue
-            }
-            
-            if let cachedFiles = filesCache[categoryId] {
-                let selectedFiles = cachedFiles.filter { filePaths.contains($0.path) }
-                totalSize += selectedFiles.reduce(0) { $0 + $1.size }
-            } else if let category = categories.first(where: { $0.id == categoryId }) {
-                let allFiles = getAllCachedFiles(for: categoryId)
-                if !allFiles.isEmpty {
-                    if filePaths.count == allFiles.count {
-                        totalSize += category.size
-                    } else {
-                        let ratio = Double(filePaths.count) / Double(allFiles.count)
-                        totalSize += UInt64(Double(category.size) * ratio)
-                    }
-                }
-            }
-        }
-        
-        return totalSize
-    }
-    
-    var selectedFiles: Set<String> {
-        guard let categoryId = selectedCategoryForPreview?.id else { return [] }
-        return selectedFilesByCategory[categoryId] ?? []
-    }
-    
-    var hasMoreItems: Bool {
-        guard let categoryId = selectedCategoryForPreview?.id,
-              let totalFiles = filesCache[categoryId]?.count,
-              let currentLoaded = loadedItemsCount[categoryId] else {
-            return false
-        }
-        return currentLoaded < totalFiles
-    }
-    
-    var hasAnySelections: Bool {
-        return !selectedCategories.isEmpty ||
-               selectedFilesByCategory.values.contains { !$0.isEmpty }
-    }
-    
-    var categoriesSelectAllState: SelectionState {
-        let states = categories.map { getCategorySelectionState($0) }
-        
-        if states.allSatisfy({ $0 == .full }) {
-            return .full
-        } else if states.allSatisfy({ $0 == .none }) {
-            return .none
-        } else {
-            return .partial
-        }
-    }
-    
-    var filesSelectAllState: SelectionState {
-        let totalFiles = currentCategoryFiles.count
-        let selectedFilesCount = currentCategoryFiles.filter { isFileSelected($0.path) }.count
-        
-        switch selectedFilesCount {
-        case 0: return .none
-        case totalFiles: return .full
-        default: return .partial
-        }
-    }
-
-    func selectCategoryForPreview(_ category: CleanupCategory) async {
-        selectedCategoryForPreview = category
-        isLoadingFiles = true
-        
-        await loadCategoryFiles(category)
-        updateCurrentCategoryFiles()
-        
-        isLoadingFiles = false
-    }
-    
-    @MainActor
-    private func loadCategoryFiles(_ category: CleanupCategory) async {
-        if let cachedFiles = filesCache[category.id] {
-            cleanerService.currentFiles = cachedFiles
-        } else {
-            await cleanerService.loadFilesForCategory(category)
-            filesCache[category.id] = cleanerService.currentFiles
-        }
-
-        if selectedCategories.contains(category.id) {
-            selectedFilesByCategory[category.id] = Set(cleanerService.currentFiles.map { $0.path })
-        }
-        
-        loadInitialBatch(for: category.id)
-    }
-
-    func getCategorySelectionState(_ category: CleanupCategory) -> SelectionState {
-        let isFullySelected = selectedCategories.contains(category.id)
-        let individualFiles = selectedFilesByCategory[category.id]
-        
-        if isFullySelected && individualFiles == nil {
-            return .full
-        }
-        
-        if let selectedFiles = individualFiles, !selectedFiles.isEmpty {
-            if selectedCategoryForPreview?.id == category.id {
-                let totalFiles = currentCategoryFiles.count
-                return selectedFiles.count == totalFiles ? .full : .partial
-            } else {
-                return .partial
-            }
-        }
-        
-        return isFullySelected ? .full : .none
-    }
-
-    func toggleCategorySelection(_ categoryId: String, to newState: SelectionState) {
-        switch newState {
-        case .full:
-            selectedCategories.insert(categoryId)
-            selectedFilesByCategory.removeValue(forKey: categoryId)
-            
-        case .none:
-            selectedCategories.remove(categoryId)
-            selectedFilesByCategory.removeValue(forKey: categoryId)
-            
-        case .partial:
-            selectedCategories.insert(categoryId)
-            selectedFilesByCategory.removeValue(forKey: categoryId)
-        }
-    }
-
-    func toggleAllCategories() {
-        let newState: SelectionState = categoriesSelectAllState == .full ? .none : .full
-        
-        switch newState {
-        case .full:
-            selectedCategories = Set(categories.map { $0.id })
-            selectedFilesByCategory.removeAll()
-        case .none:
-            selectedCategories.removeAll()
-            selectedFilesByCategory.removeAll()
-        case .partial:
-            break
-        }
-    }
-
-    // MARK: - File Selection Methods
-    func isFileSelected(_ filePath: String) -> Bool {
-        guard let categoryId = selectedCategoryForPreview?.id else { return false }
-        if selectedCategories.contains(categoryId) {
-            return true
-        }
-        return selectedFilesByCategory[categoryId]?.contains(filePath) ?? false
-    }
-
-    func toggleFileSelection(_ filePath: String, to newState: SelectionState) {
-        guard let categoryId = selectedCategoryForPreview?.id else { return }
-        
-        if selectedCategories.contains(categoryId) {
-            moveToIndividualFileSelection(for: categoryId)
-        }
-        
-        var categoryFiles = selectedFilesByCategory[categoryId] ?? []
-        
-        switch newState {
-        case .full:
-            categoryFiles.insert(filePath)
-        case .none:
-            categoryFiles.remove(filePath)
-        case .partial:
-            // Toggle
-            if categoryFiles.contains(filePath) {
-                categoryFiles.remove(filePath)
-            } else {
-                categoryFiles.insert(filePath)
-            }
-        }
-        
-        if categoryFiles.isEmpty {
-            selectedFilesByCategory.removeValue(forKey: categoryId)
-        } else {
-            selectedFilesByCategory[categoryId] = categoryFiles
-        }
-    }
-
-    func toggleAllFiles() {
-        guard let categoryId = selectedCategoryForPreview?.id else { return }
-        
-        let newState: SelectionState = filesSelectAllState == .full ? .none : .full
-        
-        switch newState {
-        case .full:
-            selectedCategories.insert(categoryId)
-            selectedFilesByCategory.removeValue(forKey: categoryId)
-        case .none:
-            selectedCategories.remove(categoryId)
-            selectedFilesByCategory.removeValue(forKey: categoryId)
-        case .partial:
-            break
-        }
-    }
-    
-    private func moveToIndividualFileSelection(for categoryId: String) {
-        if selectedCategories.contains(categoryId) {
-            selectedCategories.remove(categoryId)
-            let allFilePaths = Set(getAllCachedFiles(for: categoryId).map { $0.path })
-            selectedFilesByCategory[categoryId] = allFilePaths
-        }
-    }
-    
-    private func getAllCachedFiles(for categoryId: String) -> [CleanupFile] {
-        if selectedCategoryForPreview?.id == categoryId {
-            return filesCache[categoryId] ?? cleanerService.currentFiles
-        } else {
-            return filesCache[categoryId] ?? []
-        }
-    }
-
-    // MARK: - Pagination Methods
-    private func loadInitialBatch(for categoryId: String) {
-        guard let allFiles = filesCache[categoryId] else {
-            return
-        }
-        
-        let batchSize = min(Constants.initialBatchSize, allFiles.count)
-        displayedFilesCache[categoryId] = Array(allFiles.prefix(batchSize))
-        loadedItemsCount[categoryId] = batchSize
-        
-    }
-    
-    func loadMoreIfNeeded(currentIndex: Int) {
-        guard let categoryId = selectedCategoryForPreview?.id,
-              let allFiles = filesCache[categoryId],
-              let currentLoaded = loadedItemsCount[categoryId] else {
-            return
-        }
-        
-        let shouldLoadMore = currentIndex >= currentLoaded - Constants.loadMoreThreshold &&
-                           currentLoaded < allFiles.count
-        
-        guard shouldLoadMore else { return }
-        
-        let newBatchSize = min(Constants.itemsPerBatch, allFiles.count - currentLoaded)
-        let newItems = Array(allFiles[currentLoaded..<(currentLoaded + newBatchSize)])
-        
-        displayedFilesCache[categoryId]?.append(contentsOf: newItems)
-        loadedItemsCount[categoryId] = currentLoaded + newBatchSize
-        
-        updateCurrentCategoryFiles()
-        
-    }
-    
-    private func updateCurrentCategoryFiles() {
-        guard let categoryId = selectedCategoryForPreview?.id else {
-            currentCategoryFiles = []
-            return
-        }
-        
-        currentCategoryFiles = displayedFilesCache[categoryId] ?? []
-    }
-
-    // MARK: - Cleanup Methods
-    func closeFilePreview() {
-        selectedCategoryForPreview = nil
-        currentCategoryFiles = []
-        limitMemoryUsage()
-    }
-    
-    private func limitMemoryUsage() {
-        if displayedFilesCache.count > Constants.maxCategoriesInMemory {
-            let keysToRemove = Array(displayedFilesCache.keys.prefix(
-                displayedFilesCache.count - Constants.maxCategoriesInMemory
-            ))
-            keysToRemove.forEach { key in
-                displayedFilesCache.removeValue(forKey: key)
-                loadedItemsCount.removeValue(forKey: key)
-            }
-        }
-        
-        for (categoryId, items) in displayedFilesCache {
-            if items.count > Constants.maxItemsPerCategory {
-                displayedFilesCache[categoryId] = Array(items.prefix(Constants.maxItemsPerCategory))
-                loadedItemsCount[categoryId] = Constants.maxItemsPerCategory
-            }
-        }
-    }
-
-    // MARK: - Cleanup Execution
-    @MainActor
-    func performCleanup() async throws {
-        let cleanupData = prepareCleanupData()
-
-        switch cleanupData.type {
-        case .categoriesOnly(let categories):
-            let categoriesToClean = categories.map { category in
-                var mutableCategory = category
-                mutableCategory.isSelected = true
-                return mutableCategory
-            }
-            
-            _ = try await cleanerService.cleanupCategories(categoriesToClean) { progress in
-                await MainActor.run {
-                }
-            }
-
-        case .filesOnly(_):
-            _ = try await cleanerService.cleanupSpecificFiles(cleanupData) { progress in
-                await MainActor.run {
-                }
-            }
-
-        case .hybrid(_, _):
-            _ = try await cleanerService.cleanupSpecificFiles(cleanupData) { progress in
-                await MainActor.run {
-                }
-            }
-        }
-        
-        resetAfterCleanup()
-    }
-    
-    private func prepareCleanupData() -> CleanupData {
-        var fullCategoriesIds = selectedCategories
-        var specificFilesByCategory: [String: [CleanupFile]] = [:]
-
-        for (categoryId, filePaths) in selectedFilesByCategory {
-            guard !filePaths.isEmpty else { continue }
-
-            let selectedCategoryFiles = getSelectedFilesForCategory(categoryId, filePaths: filePaths)
-            
-            let allFiles = getAllCachedFiles(for: categoryId)
-            let allFilesSelected = filePaths.count == allFiles.count
-            
-            if allFilesSelected {
-                fullCategoriesIds.insert(categoryId)
-            } else {
-                fullCategoriesIds.remove(categoryId)
-                specificFilesByCategory[categoryId] = selectedCategoryFiles
-            }
-        }
-
-        let fullCategories = categories.filter { fullCategoriesIds.contains($0.id) }
-
-        if !fullCategories.isEmpty && !specificFilesByCategory.isEmpty {
-            return CleanupData(type: .hybrid(fullCategories, specificFilesByCategory))
-        } else if !fullCategories.isEmpty {
-            return CleanupData(type: .categoriesOnly(fullCategories))
-        } else {
-            return CleanupData(type: .filesOnly(specificFilesByCategory))
-        }
-    }
-    
-    private func getSelectedFilesForCategory(_ categoryId: String, filePaths: Set<String>) -> [CleanupFile] {
-        if let cachedFiles = filesCache[categoryId] {
-            return cachedFiles.filter { filePaths.contains($0.path) }
-        } else {
-            return filePaths.map { path in
-                CleanupFile(
-                    id: UUID().uuidString,
-                    categoryId: categoryId,
-                    name: URL(fileURLWithPath: path).lastPathComponent,
-                    path: path,
-                    size: 0,
-                    isDirectory: false,
-                    canDelete: true
-                )
-            }
-        }
-    }
-    
-    @MainActor
-    func resetAfterCleanup() {
-     
-        selectedCategories.removeAll()
-        selectedFilesByCategory.removeAll()
-        selectedCategoryForPreview = nil
-        currentCategoryFiles = []
-        
-        filesCache.removeAll()
-        displayedFilesCache.removeAll()
-        loadedItemsCount.removeAll()
-        
-      
-        isLoadingFiles = false
-        
-     
-    }
-    
-    func selectDefaultCategories() {
-        selectedCategories.removeAll()
-        selectedFilesByCategory.removeAll()
-        
-        for category in categories {
-            if Constants.defaultSelectedCategoryIds.contains(category.id) {
-                if category.canAccess && category.size > 0 {
-                    selectedCategories.insert(category.id)
-                }             }
-        }
-        
-    }
-}
-
 struct CleanupView: View {
     @ObservedObject private var viewModel: CleanupViewModel
     @StateObject var cleanerService: CleanerService
@@ -482,6 +28,7 @@ struct CleanupView: View {
     @State private var showingHelperAlert = false
     @State private var helperStatus: CleanerService.HelperStatusType?
     @State private var showModalConfirmCleanup = false
+    @State private var waitingForPermission = false
     
 
     init(cleanerService: CleanerService) {
@@ -520,6 +67,12 @@ struct CleanupView: View {
         .frame(width: 630, height: 400)
         .onAppear {
             initializeIfNeeded()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            guard waitingForPermission else { return }
+            Task {
+                await recheckPermissionAfterSettings()
+            }
         }
         .alert("CLEANER_CLEANING_SERVICE", isPresented: $showingHelperAlert) {
             if let status = helperStatus {
@@ -578,11 +131,37 @@ struct CleanupView: View {
             await MainActor.run {
                 helperStatus = status
                 showingHelperAlert = true
+                if status.shouldShowSystemSettings {
+                    waitingForPermission = true
+                }
             }
+            return
         }
         
         await cleanerService.scanCategories()
         viewModel.selectDefaultCategories()
+    }
+    
+    private func recheckPermissionAfterSettings() async {
+        let status = await cleanerService.getHelperStatus()
+     
+        if status == .enabled {
+            await MainActor.run {
+                waitingForPermission = false
+                showingHelperAlert = false
+                cleanerService.state = .idle
+                cleanerService.resetConnection()
+            }
+            await cleanerService.scanCategories()
+            viewModel.selectDefaultCategories()
+        } else if status.isError {
+            await MainActor.run {
+                helperStatus = status
+                if !status.shouldShowSystemSettings {
+                    waitingForPermission = false
+                }
+            }
+        }
     }
     
     private func retryWithStatusCheck() async {
@@ -647,8 +226,20 @@ extension CleanupView {
             
             AppButton(title: "CLEANER_CLEAN_UP") {
                 Task {
-                    self.showModalConfirmCleanup = true
-                  
+                    let status = await cleanerService.getHelperStatus()
+                    if status.isError {
+                        await MainActor.run {
+                            helperStatus = status
+                            showingHelperAlert = true
+                            if status.shouldShowSystemSettings {
+                                waitingForPermission = true
+                            }
+                        }
+                    } else {
+                        await MainActor.run {
+                            self.showModalConfirmCleanup = true
+                        }
+                    }
                 }
             }
             .disabled(!viewModel.hasAnySelections || cleanerService.isScanning || cleanerService.isCleaning)

--- a/Shared/Services/Cleaner/CleanerService.swift
+++ b/Shared/Services/Cleaner/CleanerService.swift
@@ -261,6 +261,10 @@ class CleanerService: ObservableObject {
         helperService.openSystemSettings()
     }
     
+    func resetConnection() {
+        connectionService.resetForReconnection()
+    }
+    
     // MARK: - Private Helpers - Operation Management
     private func executeOperation<T>(
         newState: CleanerState,

--- a/Shared/Services/Cleaner/XPCCleanerConnectionManager.swift
+++ b/Shared/Services/Cleaner/XPCCleanerConnectionManager.swift
@@ -8,7 +8,8 @@
 import Foundation
 import ServiceManagement
 
-protocol XPCConnectionManaging {
+protocol XPCConnectionManaging: AnyObject {
+    var onInvalidated: (() -> Void)? { get set }
     func createConnection() -> NSXPCConnection?
     func invalidateConnection()
 }
@@ -62,6 +63,7 @@ enum XPCManagerError: LocalizedError {
 class XPCCleanerConnectionManager: XPCConnectionManaging {
     private let serviceName: String
     private var connection: NSXPCConnection?
+    var onInvalidated: (() -> Void)?
     
     init(serviceName: String) {
         self.serviceName = serviceName
@@ -72,13 +74,15 @@ class XPCCleanerConnectionManager: XPCConnectionManaging {
         newConnection.remoteObjectInterface = NSXPCInterface(with: CleanerHelperXPCProtocol.self)
         
         newConnection.interruptionHandler = { [weak self] in
-            print("XPC connection interrupted")
+            cleanerLogger.warning("XPC connection interrupted")
             self?.connection = nil
+            self?.onInvalidated?()
         }
         
         newConnection.invalidationHandler = { [weak self] in
-            print("XPC connection invalidated")
+            cleanerLogger.warning("XPC connection invalidated externally")
             self?.connection = nil
+            self?.onInvalidated?()
         }
         
         newConnection.resume()

--- a/Shared/Services/Cleaner/XPCConnectionService.swift
+++ b/Shared/Services/Cleaner/XPCConnectionService.swift
@@ -28,9 +28,21 @@ class XPCConnectionService: ObservableObject {
     
     // MARK: - Initialization
     init(connectionManager: XPCConnectionManaging? = nil) {
-        self.connectionManager = connectionManager ?? XPCCleanerConnectionManager(
+        let manager = connectionManager ?? XPCCleanerConnectionManager(
             serviceName: Constants.helperServiceName
         )
+        self.connectionManager = manager
+        
+        self.connectionManager.onInvalidated = { [weak self] in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                if self.isConnected {
+                    cleanerLogger.warning("XPC connection lost externally — resetting isConnected")
+                    self.isConnected = false
+                    self.currentConnection = nil
+                }
+            }
+        }
     }
     
     deinit {
@@ -41,6 +53,13 @@ class XPCConnectionService: ObservableObject {
     func ensureConnection() async throws {
         guard !isConnected else { return }
         try await establishConnection()
+    }
+    
+    func resetForReconnection() {
+        currentConnection?.invalidate()
+        currentConnection = nil
+        isConnected = false
+        cleanerLogger.info("XPC connection reset for reconnection")
     }
     
     func getHelperProxy() -> CleanerHelperXPCProtocol? {


### PR DESCRIPTION
This PR fixes the following:

**Stuck Scanning**: Fixed infinite "Scanning" state when helper permissions are missing.
**Auto-Scan**: Added auto-scan when returning to the app from System Settings.
**XPC Stability**: Fixed XPC connection leaks and improved lifecycle handling when permissions are revoked.
**Cleanup Security:** The Clean Up button now verifies permissions before opening the confirmation modal.

Refactors the following:

**ViewModel Extraction**: Moved CleanupViewModel to its own file (CleanerViewModel.swift) for better modularity.