### PR TITLE
fix : add features to polling to keep updated

### DIFF
--- a/InternxtDesktop/AppDelegate.swift
+++ b/InternxtDesktop/AppDelegate.swift
@@ -333,6 +333,8 @@ class AppDelegate: NSObject, NSApplicationDelegate , PKPushRegistryDelegate {
             .sink { _ in
                 Task {
                     await self.notificationsManager.getNotifications()
+                    // to keep features updated 
+                    await FeaturesService.shared.fetchFeaturesStatus()
                 }
             }
     }


### PR DESCRIPTION
Added FeaturesService.shared.fetchFeaturesStatus() to the recurring notification polling task in AppDelegate.
Ensures that even if the initial fetch fails, the app will retry and eventually synchronize the user's pro features every 30 minutes.