### PR TITLE
Fix: Backup sync failures with custom macOS directories

### DIFF
--- a/XPCBackupService/Services/BackupTreeGenerator.swift
+++ b/XPCBackupService/Services/BackupTreeGenerator.swift
@@ -137,7 +137,7 @@ class BackupTreeGenerator: BackupTreeGeneration {
          let isDirectory = resourceValues.isDirectory == true
          let ext = url.pathExtension.lowercased()
          let extensionMatch = isDirectory && Self.knownBundleExtensions.contains(ext)
-         let isPackage = utTypeConforms || isPackageResource || extensionMatch
+         let isPackage = isDirectory || utTypeConforms || isPackageResource || extensionMatch
 
          let effectiveType: BackupTreeNodeType = isPackage ? .folder : type
 


### PR DESCRIPTION
### What is the problem?
Backups were failing to complete and logging multiple `CryptoError error 3` and "Missing parent folderId" exceptions. 
The system was incorrectly classifying macOS special directories (like Xcode's `.xcassets`, `.colorset`, `.appiconset` or `.imageset`) as standard files. Because these custom extensions don't conform to `UTType.package` and weren't strictly registered in our known bundles list, the `doSync()` router passed them to `syncNodeFile()`. Trying to read a directory as a byte stream for encryption triggered `CryptoError 3`. 
Consequently, child nodes inside these directories were unable to resolve their `remoteParentId`.
### What changed?
*   Modified `BackupTreeGenerator.insertInTree` to include `isDirectory` as a primary condition when evaluating `isPackage`.
*   Any node that the filesystem identifies as a directory (`isDirectory == true`) is now strictly routed as `.folder`, bypassing custom `UTType` edge cases.