### PR TITLE
Fix Antivirus Crashes, Concurrency Issues, and Scalability Limits

### DIFF
--- a/InternxtDesktop/Services/AntivirusManager.swift
+++ b/InternxtDesktop/Services/AntivirusManager.swift
@@ -37,6 +37,7 @@ class AntivirusManager: ObservableObject {
         }
     }
     
+    @MainActor
     func startScan(path: String) {
         infectedFiles = []
         currentState = .scanning
@@ -104,15 +105,13 @@ class AntivirusManager: ObservableObject {
         )
     }
     
+    @MainActor
     func cancelScan(isLocked: Bool = false) {
         isCancelled = true
         scanner.cancelAll()
-        DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
-            self.currentState = isLocked ? .locked : .results(noThreats: (self.detectedFiles == 0))
-            if let resolvedURL = BookmarkManager.shared.resolveBookmark() {
-                BookmarkManager.shared.stopAccessing(url: resolvedURL)
-            }
+        self.currentState = isLocked ? .locked : .results(noThreats: (self.detectedFiles == 0))
+        if let resolvedURL = BookmarkManager.shared.resolveBookmark() {
+            BookmarkManager.shared.stopAccessing(url: resolvedURL)
         }
     }
     
@@ -145,6 +144,7 @@ class AntivirusManager: ObservableObject {
         return FileItem(iconName: iconName, fileName: fileName, extensionType: fileExtension, fullPath: filePath)
     }
     
+    @MainActor
     func showAlert(message: String, informativeText: String? = nil, style: NSAlert.Style = .informational, buttonTitle: String = "OK") {
         let alert = NSAlert()
         alert.messageText = message

--- a/InternxtDesktop/Services/ClamAVScannerService.swift
+++ b/InternxtDesktop/Services/ClamAVScannerService.swift
@@ -46,104 +46,121 @@ class ClamAVScannerService {
             }
             
             let totalWorkers = self.calculateOptimalWorkers(pathCount: paths.count)
-            appLogger.info("Antivirus: Starting Scan with \(totalWorkers) parallel clamscan processes")
-            
+            appLogger.info("Antivirus: Starting scan with \(totalWorkers) workers for \(paths.count) files")
+
             var batches: [[String]] = Array(repeating: [], count: totalWorkers)
-            for (index, pathStr) in paths.enumerated() {
-                batches[index % totalWorkers].append(pathStr)
+            for (index, path) in paths.enumerated() {
+                batches[index % totalWorkers].append(path)
             }
-            
+
             let dispatchGroup = DispatchGroup()
+            let successLock = NSLock()
+            let tempFilesLock = NSLock()
             var allSuccessful = true
+            var tempFilesToClean: [URL] = []
 
             self.processQueue.sync { self._scanProcesses.removeAll() }
-            
-            var tempFilesToClean: [URL] = []
-            
-            for batch in batches {
-                if batch.isEmpty { continue }
-                
+
+            for batch in batches where !batch.isEmpty {
+                let listURL = FileManager.default.temporaryDirectory
+                    .appendingPathComponent("clamscan-\(UUID().uuidString).txt")
+
+                do {
+                    try batch.joined(separator: "\n").write(to: listURL, atomically: true, encoding: .utf8)
+                    tempFilesLock.withLock {
+                        tempFilesToClean.append(listURL)
+                    }
+                } catch {
+                    appLogger.error("Cannot write file-list, skipping batch: \(error)")
+                    successLock.withLock { allSuccessful = false }
+                    continue
+                }
+
                 let process = Process()
                 process.executableURL = clamscanURL
-                
-                var arguments = ["--database=\(databaseDir.path)", "--no-summary", "-v", "-r"]
-                
-                let listURL = FileManager.default.temporaryDirectory.appendingPathComponent("clamscan-\(UUID().uuidString).txt")
-                let listContent = batch.joined(separator: "\n")
-                
-                do {
-                    try listContent.write(to: listURL, atomically: true, encoding: .utf8)
-                    arguments.append("--file-list=\(listURL.path)")
-                    tempFilesToClean.append(listURL)
-                } catch {
-                    appLogger.error("Failed to write to file-list, falling back to arguments: \(error)")
-                    arguments.append(contentsOf: batch)
-                }
-                
-                process.arguments = arguments
-                
+                process.arguments = [
+                    "--database=\(databaseDir.path)",
+                    "--no-summary",
+                    "-v",
+                    "-r",
+                    "--file-list=\(listURL.path)"
+                ]
+
                 let pipe = Pipe()
                 process.standardOutput = pipe
                 process.standardError = pipe
-                
-                var lastUpdate = Date.distantPast
-                var chunkScanned = 0
-                var currentLineInfo = ""
-                
-                pipe.fileHandleForReading.readabilityHandler = { fileHandle in
+
+                let bufferLock = NSLock()
+                var lineBuffer = ""
+                var lastProgressUpdate = Date.distantPast
+                var pendingScanned = 0
+                var pendingLineInfo = ""
+
+                pipe.fileHandleForReading.readabilityHandler = { [weak self] fileHandle in
                     let data = fileHandle.availableData
-                    guard !data.isEmpty else { return }
                     
-                    let outputChunk = String(data: data, encoding: .utf8) ?? ""
-                    let lines = outputChunk.components(separatedBy: .newlines)
-                    
-                    var newInfected: [String] = []
-                    var localScanned = 0
-                    var lastLineInfo: String?
-                    
-                    for line in lines {
-                        guard !line.isEmpty else { continue }
-                        if line.contains("FOUND") {
-                            localScanned += 1
-                            newInfected.append(line)
-                            lastLineInfo = line
-                        } else if line.contains(": ") {
-                            localScanned += 1
-                            lastLineInfo = line
+                    guard !data.isEmpty else {
+                        fileHandle.readabilityHandler = nil
+                        return
+                    }
+
+                    bufferLock.withLock {
+                        lineBuffer += String(data: data, encoding: .utf8) ?? ""
+
+                        while let newlineRange = lineBuffer.range(of: "\n") {
+                            let line = String(lineBuffer[lineBuffer.startIndex..<newlineRange.lowerBound])
+                            lineBuffer.removeSubrange(lineBuffer.startIndex...newlineRange.lowerBound)
+
+                            let trimmed = line.trimmingCharacters(in: .whitespaces)
+                            guard !trimmed.isEmpty else { continue }
+
+                            if line.hasSuffix(": FOUND") {
+                                pendingScanned += 1
+                                pendingLineInfo = line
+                                DispatchQueue.main.async { onInfected(line) }
+                            } else if line.hasSuffix(": OK") || line.hasSuffix(": Empty file") || line.hasSuffix(": Symbolic link") {
+                                pendingScanned += 1
+                                pendingLineInfo = line
+                            }
                         }
-                    }
-                    
-                    for infected in newInfected {
-                        onInfected(infected)
-                    }
-                    
-                    let now = Date()
-                    if now.timeIntervalSince(lastUpdate) > 0.1 || !newInfected.isEmpty {
-                        lastUpdate = now
-                        let infoToPass = lastLineInfo ?? ""
-                        let totalChunk = chunkScanned + localScanned
-                        chunkScanned = 0
-                        onProgress(totalChunk, infoToPass)
-                    } else {
-                        chunkScanned += localScanned
-                        if let lInfo = lastLineInfo {
-                            currentLineInfo = lInfo
+                        let now = Date()
+                        if now.timeIntervalSince(lastProgressUpdate) >= 0.1 && pendingScanned > 0 {
+                            lastProgressUpdate = now
+                            let count = pendingScanned
+                            let info = pendingLineInfo
+                            pendingScanned = 0
+                            DispatchQueue.main.async { onProgress(count, info) }
                         }
                     }
                 }
                 
                 dispatchGroup.enter()
-                process.terminationHandler = { _ in
+                process.terminationHandler = { [weak self] proc in
+        
                     pipe.fileHandleForReading.readabilityHandler = nil
+                    
+                    bufferLock.withLock {
+                        if !lineBuffer.trimmingCharacters(in: .whitespaces).isEmpty {
+                            let remaining = lineBuffer
+                            if remaining.hasSuffix(": FOUND") {
+                                DispatchQueue.main.async { onInfected(remaining) }
+                            }
+                            pendingScanned += 1
+                            pendingLineInfo = remaining
+                        }
 
-                    if chunkScanned > 0 {
-                        onProgress(chunkScanned, currentLineInfo)
+                        if pendingScanned > 0 {
+                            let count = pendingScanned
+                            let info = pendingLineInfo
+                            DispatchQueue.main.async { onProgress(count, info) }
+                        }
                     }
 
-                   
-                    if process.terminationStatus == 2 {
-                        allSuccessful = false
+                    if proc.terminationStatus == 2 {
+                        appLogger.error("clamscan exited with error (status 2)")
+                        successLock.withLock { allSuccessful = false }
                     }
+
                     dispatchGroup.leave()
                 }
 
@@ -152,19 +169,23 @@ class ClamAVScannerService {
                     self.processQueue.sync { self._scanProcesses.append(process) }
                     try process.run()
                 } catch {
-                    appLogger.error("Error executing parallel clamscan: \(error.localizedDescription)")
-                    allSuccessful = false  // safe: only mutated from background thread
+                    appLogger.error("Failed to launch clamscan: \(error.localizedDescription)")
+                    pipe.fileHandleForReading.readabilityHandler = nil
+                    successLock.withLock { allSuccessful = false }
                     dispatchGroup.leave()
                 }
             }
             
-            dispatchGroup.notify(queue: .main) {
+            dispatchGroup.notify(queue: .main) { [weak self] in
                 appLogger.info("Antivirus: All ClamAV parallel workers finished")
+                guard let self = self else { return }
+                
                 self.processQueue.async { self._scanProcesses.removeAll() }
                 
+                let urlsToClean = tempFilesLock.withLock { tempFilesToClean }
                 DispatchQueue.global(qos: .background).async {
-                    for tempURL in tempFilesToClean {
-                        try? FileManager.default.removeItem(at: tempURL)
+                    for url in urlsToClean {
+                        try? FileManager.default.removeItem(at: url)
                     }
                 }
                 

--- a/InternxtDesktop/Services/ClamAVScannerService.swift
+++ b/InternxtDesktop/Services/ClamAVScannerService.swift
@@ -58,6 +58,8 @@ class ClamAVScannerService {
 
             self.processQueue.sync { self._scanProcesses.removeAll() }
             
+            var tempFilesToClean: [URL] = []
+            
             for batch in batches {
                 if batch.isEmpty { continue }
                 
@@ -65,7 +67,19 @@ class ClamAVScannerService {
                 process.executableURL = clamscanURL
                 
                 var arguments = ["--database=\(databaseDir.path)", "--no-summary", "-v", "-r"]
-                arguments.append(contentsOf: batch)
+                
+                let listURL = FileManager.default.temporaryDirectory.appendingPathComponent("clamscan-\(UUID().uuidString).txt")
+                let listContent = batch.joined(separator: "\n")
+                
+                do {
+                    try listContent.write(to: listURL, atomically: true, encoding: .utf8)
+                    arguments.append("--file-list=\(listURL.path)")
+                    tempFilesToClean.append(listURL)
+                } catch {
+                    appLogger.error("Failed to write to file-list, falling back to arguments: \(error)")
+                    arguments.append(contentsOf: batch)
+                }
+                
                 process.arguments = arguments
                 
                 let pipe = Pipe()
@@ -147,6 +161,13 @@ class ClamAVScannerService {
             dispatchGroup.notify(queue: .main) {
                 appLogger.info("Antivirus: All ClamAV parallel workers finished")
                 self.processQueue.async { self._scanProcesses.removeAll() }
+                
+                DispatchQueue.global(qos: .background).async {
+                    for tempURL in tempFilesToClean {
+                        try? FileManager.default.removeItem(at: tempURL)
+                    }
+                }
+                
                 onComplete(allSuccessful)
             }
         }

--- a/InternxtDesktop/Services/ClamAVScannerService.swift
+++ b/InternxtDesktop/Services/ClamAVScannerService.swift
@@ -10,8 +10,13 @@ import InternxtSwiftCore
 
 class ClamAVScannerService {
     
-    private(set) var scanProcesses: [Process] = []
-    
+    private let processQueue = DispatchQueue(label: "com.internxt.clamav.processQueue")
+    private var _scanProcesses: [Process] = []
+
+    var scanProcesses: [Process] {
+        processQueue.sync { _scanProcesses }
+    }
+
 
     func scanPathsInParallel(
         paths: [String],
@@ -50,8 +55,8 @@ class ClamAVScannerService {
             
             let dispatchGroup = DispatchGroup()
             var allSuccessful = true
-            
-            DispatchQueue.main.sync { self.scanProcesses.removeAll() }
+
+            self.processQueue.sync { self._scanProcesses.removeAll() }
             
             for batch in batches {
                 if batch.isEmpty { continue }
@@ -116,40 +121,46 @@ class ClamAVScannerService {
                 dispatchGroup.enter()
                 process.terminationHandler = { _ in
                     pipe.fileHandleForReading.readabilityHandler = nil
-                    
+
                     if chunkScanned > 0 {
                         onProgress(chunkScanned, currentLineInfo)
                     }
-                    
+
+                   
                     if process.terminationStatus == 2 {
-                        DispatchQueue.main.sync { allSuccessful = false }
+                        allSuccessful = false
                     }
                     dispatchGroup.leave()
                 }
-                
+
                 do {
-                    DispatchQueue.main.sync { self.scanProcesses.append(process) }
+                  
+                    self.processQueue.sync { self._scanProcesses.append(process) }
                     try process.run()
                 } catch {
                     appLogger.error("Error executing parallel clamscan: \(error.localizedDescription)")
-                    DispatchQueue.main.sync { allSuccessful = false }
+                    allSuccessful = false  // safe: only mutated from background thread
                     dispatchGroup.leave()
                 }
             }
             
             dispatchGroup.notify(queue: .main) {
                 appLogger.info("Antivirus: All ClamAV parallel workers finished")
-                self.scanProcesses.removeAll()
+                self.processQueue.async { self._scanProcesses.removeAll() }
                 onComplete(allSuccessful)
             }
         }
     }
     
     func cancelAll() {
-        for process in scanProcesses where process.isRunning {
+        let toTerminate: [Process] = processQueue.sync {
+            let list = _scanProcesses
+            _scanProcesses.removeAll()
+            return list
+        }
+        for process in toTerminate where process.isRunning {
             process.terminate()
         }
-        scanProcesses.removeAll()
     }
 
     


### PR DESCRIPTION
This PR introduces critical stability and performance improvements to the scanning service (ClamAVScannerService), addressing several bugs reported during large-scale scans and process cancellation.

Key Fixes:

Argument List Limit Crash (ARG_MAX):

Issue: When attempting to scan thousands of files, the application crashed because it exceeded the macOS limit for command-line arguments.
Solution: Implemented the --file-list strategy. File paths are now written to a secure temporary file which ClamAV reads internally, allowing for unlimited files to be scanned without risk of crashing.

Output Parsing Race Conditions:

Issue: A race condition existed between the terminal output reading thread and the process termination thread, leading to potential data corruption or intermittent crashes.
Solution: Integrated NSLock (bufferLock) to synchronize access to the line buffer and progress counters across different threads.

Crash on Scan Cancellation:

Issue: Cancelling a scan often lead to crashes because closures held strong references to the service or accessed invalid memory addresses after the processes were terminated.
Solution: Refactored process handlers using [weak self] and implemented a thread-safe cleanup mechanism for active processes using a dedicated serial queue.