### PR TITLE
Refactor: Centralize 401 Unauthorized Error Handling & Global Logout Mechanism

### DIFF
--- a/InternxtDesktop/AppDelegate.swift
+++ b/InternxtDesktop/AppDelegate.swift
@@ -81,6 +81,21 @@ class AppDelegate: NSObject, NSApplicationDelegate , PKPushRegistryDelegate {
         name: .userDidLogout,
         object: nil)
 
+        APIClient.onUnauthorized = {
+            DispatchQueue.main.async {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                    NotificationCenter.default.post(name: .userDidLogout, object: nil)
+                }
+            }
+        }
+
+        DistributedNotificationCenter.default().addObserver(
+            forName: NSNotification.Name(NOTIFICATION_UNAUTHORIZED),
+            object: nil,
+            queue: .main
+        ) { _ in
+            NotificationCenter.default.post(name: .userDidLogout, object: nil)
+        }
 
         checkVolumeAndEjectIfNeeded()
         
@@ -296,14 +311,6 @@ class AppDelegate: NSObject, NSApplicationDelegate , PKPushRegistryDelegate {
             self.logger.info("Tokens refreshed correctly")
         } catch{
             AuthError.UnableToRefreshToken.reportToSentry()
-            guard let apiClientError = error as? APIClientError else {
-                return
-            }
-            
-            let tokenIsExpired = apiClientError.statusCode == 401
-            if(tokenIsExpired) {
-                try? authManager.signOut()
-            }
         }
     }
     

--- a/InternxtDesktop/Services/UsageManager.swift
+++ b/InternxtDesktop/Services/UsageManager.swift
@@ -44,7 +44,6 @@ class UsageManager: ObservableObject {
             
         } catch {
             error.reportToSentry()
-            error.checkUnauthorizedError()
             DispatchQueue.main.async {
                 self.usageError = error
                 self.loadingUsage = false

--- a/Shared/Services/ConfigLoader.swift
+++ b/Shared/Services/ConfigLoader.swift
@@ -46,6 +46,7 @@ enum ConfigLoaderError: Error {
 
 
 public let INTERNXT_GROUP_NAME = "JR4S3SY396.group.internxt.desktop"
+public let NOTIFICATION_UNAUTHORIZED = "com.internxt.drive.unauthorized"
 
 public var loadedConfig: JSONConfig? = nil
 

--- a/SyncExtension/FileProviderExtension.swift
+++ b/SyncExtension/FileProviderExtension.swift
@@ -116,6 +116,15 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension, NSFile
             logger.error("Failed to clean TMP directory before starting")
             error.reportToSentry()
         }
+
+        APIClient.onUnauthorized = {
+            DistributedNotificationCenter.default().postNotificationName(
+                NSNotification.Name(NOTIFICATION_UNAUTHORIZED),
+                object: nil,
+                userInfo: nil,
+                deliverImmediately: true
+            )
+        }
         
         manager.signalEnumerator(for: .workingSet, completionHandler: {error in
             if error != nil {

--- a/SyncExtension/UseCases/All/GetRemoteChangesUseCase.swift
+++ b/SyncExtension/UseCases/All/GetRemoteChangesUseCase.swift
@@ -82,7 +82,6 @@ class GetRemoteChangesUseCase {
                 
                 self.logger.info("✅ Changes enumerated correctly from the server")
             } catch {
-                error.checkUnauthorizedError()
                 error.reportToSentry()
                 observer.finishEnumeratingWithError(error)
                 self.logger.error(["❌ Failed to enumerate remote changes", error.getErrorDescription()])

--- a/SyncExtension/UseCases/Folders/EnumerateFolderItemsUseCase.swift
+++ b/SyncExtension/UseCases/Folders/EnumerateFolderItemsUseCase.swift
@@ -146,7 +146,6 @@ struct EnumerateFolderItemsUseCase {
                 
                 
             } catch {
-                error.checkUnauthorizedError()
                 error.reportToSentry()
                 self.logger.error("❌ Got error fetching folder content: \(error)")
                 observer.finishEnumeratingWithError(error)


### PR DESCRIPTION
This PR centralizes the handling of 401 Unauthorized errors (expired or invalid tokens) into a single point within the APIClient. This refactor eliminates the need to manually check for 401 errors in every UseCase, ViewModel, or Service across the application.