### PR TITLE
fix: preserve unsynced files on logout or token expiration

### DIFF
--- a/InternxtDesktop/AppDelegate.swift
+++ b/InternxtDesktop/AppDelegate.swift
@@ -492,15 +492,7 @@ class AppDelegate: NSObject, NSApplicationDelegate , PKPushRegistryDelegate {
         // Nothing to do here in preview mode
     }
     
-    private func removeDomain(domain: NSFileProviderDomain, completionHandler: @escaping (URL?, Error?) -> Void) {
-        if #available(macOS 12.0, *) {
-            NSFileProviderManager.remove(domain, mode: NSFileProviderManager.DomainRemovalMode.removeAll, completionHandler:completionHandler)
-        } else {
-            NSFileProviderManager.remove(domain, completionHandler: {error in
-                completionHandler(nil, error)
-            })
-        }
-    }
+
     
     private func destroyWidget() {
         if let statusBarItemUnwrapped = self.statusBarItem {

--- a/InternxtDesktop/Services/FileProviderDomainManager.swift
+++ b/InternxtDesktop/Services/FileProviderDomainManager.swift
@@ -54,12 +54,22 @@ class FileProviderDomainManager: ObservableObject {
     
     public func exitDomain() async {
         self.logger.info("🧹 Cleaning up FileProvider domain")
-        if let domain = self.managerDomain {
-            try? await NSFileProviderManager.remove(domain)
+        do {
+            let activeDomains = try await NSFileProviderManager.domains()
+            for domain in activeDomains {
+                do {
+                    let preservedURL = try await NSFileProviderManager.remove(domain, mode: .preserveDirtyUserData)
+                    self.logger.info("📁 Domain '\(domain.displayName)' removed — unsynced files preserved at: \(preservedURL)")
+                } catch {
+                    self.logger.error("❌ Failed to remove domain '\(domain.displayName)'")
+                    try? await NSFileProviderManager.remove(domain)
+                }
+            }
+        } catch {
+            self.logger.error("❌ Failed to enumerate domains during exitDomain: \(error)")
         }
         self.manager = nil
         self.managerDomain = nil
-        try? await NSFileProviderManager.removeAllDomains()
     }
     
     


### PR DESCRIPTION
This PR addresses a critical data loss issue that occurs when a user **moves** a file to the FileProvider and the session is terminated (either manually or via a 401 token expiration) before the upload finishes. 
Previously, `NSFileProviderManager.removeAllDomains()` was called, which blindly destroyed the local `~/Library/CloudStorage/` directory, permanently losing any unsynced local changes.
##  Changes Made
- Replaced `removeAllDomains()` with a loop that iterates over all active domains.
- Domains are now safely removed using the `mode: .preserveDirtyUserData` flag.
