### PR TITLE
fix: resolve deadlock and memory exhaustion during large-scale backups

### DIFF
--- a/Shared/Utils/AsyncOperation.swift
+++ b/Shared/Utils/AsyncOperation.swift
@@ -69,6 +69,9 @@ class AsyncOperation: Operation {
     
     func finish() {
         isExecuting = false
+        // Setting isFinished = true triggers KVO, which Foundation uses
+        // to execute the completionBlock. This guarantees that completionBlock
+        // is always called regardless of success, failure, or cancellation.
         isFinished = true
     }
 }

--- a/XPCBackupService/Entities/BackupTreeNode.swift
+++ b/XPCBackupService/Entities/BackupTreeNode.swift
@@ -140,26 +140,19 @@ class BackupTreeNode {
            return syncedNode
        }
     
-    func syncBelowNodes(withOperationQueue: OperationQueue, dependingOfOperation: BackupTreeNodeSyncOperation? = nil, onError: @escaping (Error) -> Void) throws -> Void {
-        let operation = BackupTreeNodeSyncOperation(backupTreeNode: self)
+    func syncBelowNodes(withOperationQueue: OperationQueue, syncGroup: DispatchGroup, onError: @escaping (Error) -> Void) throws -> Void {
+        syncGroup.enter()
+        let operation = BackupTreeNodeSyncOperation(backupTreeNode: self, operationQueue: withOperationQueue, syncGroup: syncGroup)
         
         operation.onError = { error in
             onError(error)
-           
         }
-        if(dependingOfOperation != nil) {
-            operation.addDependency(dependingOfOperation!)
+        
+        operation.completionBlock = {
+            syncGroup.leave()
         }
         
         withOperationQueue.addOperation(operation)
-        
-        for child in self.childs {
-            if(self.type == .folder) {
-                try child.syncBelowNodes(withOperationQueue: withOperationQueue, dependingOfOperation: operation, onError: onError)
-            } else {
-                try child.syncBelowNodes(withOperationQueue: withOperationQueue, onError: onError)
-            }
-        }
     }
     
     private func isRetryable(error: Error) -> Bool {
@@ -176,7 +169,6 @@ class BackupTreeNode {
         return true
     }
    
-    @MainActor
     func syncNode() async throws -> Void {
         
         guard let nodeURL = self.url else {

--- a/XPCBackupService/Entities/BackupTreeNodeSyncOperation.swift
+++ b/XPCBackupService/Entities/BackupTreeNodeSyncOperation.swift
@@ -9,15 +9,23 @@ import Foundation
 
 class BackupTreeNodeSyncOperation: AsyncOperation {
     private let backupTreeNode: BackupTreeNode
+    private let operationQueue: OperationQueue
+    private let syncGroup: DispatchGroup
     var onError: ((Error) -> Void)?
 
-      init(backupTreeNode: BackupTreeNode) {
-          self.backupTreeNode = backupTreeNode
-      }
+    init(backupTreeNode: BackupTreeNode, operationQueue: OperationQueue, syncGroup: DispatchGroup) {
+        self.backupTreeNode = backupTreeNode
+        self.operationQueue = operationQueue
+        self.syncGroup = syncGroup
+    }
     
     override func performAsyncTask() async throws -> Void {
         do {
             try await self.backupTreeNode.syncNode()
+            
+            for child in self.backupTreeNode.childs {
+                try child.syncBelowNodes(withOperationQueue: self.operationQueue, syncGroup: self.syncGroup, onError: self.onError ?? { _ in })
+            }
         } catch {
             onError?(error)
             throw error

--- a/XPCBackupService/Entities/BackupTreeNodeSyncOperation.swift
+++ b/XPCBackupService/Entities/BackupTreeNodeSyncOperation.swift
@@ -23,10 +23,21 @@ class BackupTreeNodeSyncOperation: AsyncOperation {
         do {
             try await self.backupTreeNode.syncNode()
             
+            guard !self.isCancelled else { return }
+            
+            // Children are enqueued dynamically ONLY AFTER the parent successfully syncs.
+            // This temporal causality guarantees that child nodes will always have the
+            // required remoteParentId populated before they execute, preserving the
+            // strict parent-child order without needing explicit KVO dependencies.
             for child in self.backupTreeNode.childs {
                 try child.syncBelowNodes(withOperationQueue: self.operationQueue, syncGroup: self.syncGroup, onError: self.onError ?? { _ in })
             }
         } catch {
+            // Error handling policy:
+            // 1. If syncNode() fails, we catch the error here and do NOT enqueue children.
+            //    (Files in a failed folder cannot be synced anyway).
+            // 2. Fatal errors (e.g. storageFull) will trigger cancelAllOperations() at the XPC layer.
+            // 3. Non-fatal errors are counted as failures, but sibling branches will continue processing.
             onError?(error)
             throw error
         }

--- a/XPCBackupService/XPCBackupService.swift
+++ b/XPCBackupService/XPCBackupService.swift
@@ -123,13 +123,15 @@ public class XPCBackupService: NSObject, XPCBackupServiceProtocol {
 
             logger.info("⏱️ About to start node sync process for \(trees.count) BackupTrees...")
             var hasErrorOccurred = false
+            let syncGroup = DispatchGroup()
+            
             for backupTree in trees {
                 if hasErrorOccurred {
                     break
                 }
                 do {
                     logger.info("Adding nodes sync operations")
-                    try backupTree.syncBelowNodes(withOperationQueue: self.uploadOperationQueue) { error in
+                    try backupTree.syncBelowNodes(withOperationQueue: self.uploadOperationQueue, syncGroup: syncGroup) { error in
                         
                         
                         if let backupUploadError = error as? BackupError, backupUploadError == .storageFull {
@@ -152,7 +154,7 @@ public class XPCBackupService: NSObject, XPCBackupServiceProtocol {
                 }
             }
             
-            self.uploadOperationQueue.addBarrierBlock {
+            syncGroup.notify(queue: .global()) {
                 logger.info("Sync nodes operations completed")
                 
                 let successCount = totalNodesCount - failedNodesCount


### PR DESCRIPTION
Problem

When processing large file trees, the XPCBackupService could stall and consume excessive memory, eventually causing the backup process to hang indefinitely.

Root causes:

**Queue saturation**: The entire file tree was enqueued upfront, creating too many concurrent operations.
**Thread starvation**: Use of the Main Actor for synchronization introduced bottlenecks and potential deadlocks.
**Inaccurate completion tracking**: Dynamically added tasks were not properly accounted for, leading to inconsistent completion states.
Solution

In this PR, the following improvements were implemented:

**Dynamic scheduling**:
Replaced eager traversal with a lazy strategy. Only root nodes are enqueued initially, and children are scheduled after their parent completes, reducing memory usage.
**Background executio**n:
Removed Main Actor dependency for synchronization. Processing now runs on a background thread pool, avoiding deadlocks and improving responsiveness.
**Robust completion tracking**:
Introduced DispatchGroup to correctly track dynamically added tasks and ensure accurate completion reporting.