### PR TITLE
feat: Integrate "Copy Internxt Link" action in Finder Extension

### DIFF
--- a/InternxtDesktop.xcodeproj/project.pbxproj
+++ b/InternxtDesktop.xcodeproj/project.pbxproj
@@ -165,6 +165,7 @@
 		AAF71A6A2CDF16C300476000 /* UploadFileOrUpdateContentWorkspaceUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF71A692CDF16C300476000 /* UploadFileOrUpdateContentWorkspaceUseCase.swift */; };
 		AAF71A6C2CDF17EA00476000 /* UpdateFileContentWorkspaceUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF71A6B2CDF17EA00476000 /* UpdateFileContentWorkspaceUseCase.swift */; };
 		AAF71A6E2CDF180100476000 /* UploadFileWorkspaceUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF71A6D2CDF180100476000 /* UploadFileWorkspaceUseCase.swift */; };
+		AAFF86C42FAB8895008466D1 /* CopyInternxtLinkUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFF86C32FAB8895008466D1 /* CopyInternxtLinkUseCase.swift */; };
 		AAFFBE292C50AC4F00C76528 /* GenericRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFFBE282C50AC4F00C76528 /* GenericRepository.swift */; };
 		AAFFBE2C2C50B23D00C76528 /* GenericRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFFBE282C50AC4F00C76528 /* GenericRepository.swift */; };
 		E106D45C2AB9DB9300E3BF7A /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = E106D45B2AB9DB9300E3BF7A /* Sparkle */; };
@@ -582,6 +583,7 @@
 		AAF71A692CDF16C300476000 /* UploadFileOrUpdateContentWorkspaceUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadFileOrUpdateContentWorkspaceUseCase.swift; sourceTree = "<group>"; };
 		AAF71A6B2CDF17EA00476000 /* UpdateFileContentWorkspaceUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateFileContentWorkspaceUseCase.swift; sourceTree = "<group>"; };
 		AAF71A6D2CDF180100476000 /* UploadFileWorkspaceUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadFileWorkspaceUseCase.swift; sourceTree = "<group>"; };
+		AAFF86C32FAB8895008466D1 /* CopyInternxtLinkUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopyInternxtLinkUseCase.swift; sourceTree = "<group>"; };
 		AAFFBE282C50AC4F00C76528 /* GenericRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericRepository.swift; sourceTree = "<group>"; };
 		E106D45D2AB9DD8200E3BF7A /* CheckForUpdatesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckForUpdatesView.swift; sourceTree = "<group>"; };
 		E106D45F2AB9FBDC00E3BF7A /* Phosphor-Light.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Phosphor-Light.ttf"; sourceTree = "<group>"; };
@@ -1141,6 +1143,7 @@
 				E1581DD92A9654930051DD46 /* GetFileOrFolderMetaUseCase.swift */,
 				E1CC52092A97DE85009DEEAA /* DeleteFileOrFolderUseCase.swift */,
 				E198D7DB2AA9E76900107753 /* GetRemoteChangesUseCase.swift */,
+				AAFF86C32FAB8895008466D1 /* CopyInternxtLinkUseCase.swift */,
 			);
 			path = All;
 			sourceTree = "<group>";
@@ -2095,6 +2098,7 @@
 				AAAD0DA22CE17457003F27BB /* RenameFileWorkspaceUseCase.swift in Sources */,
 				E140C3302AC3778200A88B9F /* DriveFile.swift in Sources */,
 				E19136992AA108D200CAF0FA /* View.swift in Sources */,
+				AAFF86C42FAB8895008466D1 /* CopyInternxtLinkUseCase.swift in Sources */,
 				AAE717DC2CE05DD70023E9A4 /* TrashFolderWorkspaceUseCase.swift in Sources */,
 				316DC7EB2B597BD000FDC746 /* BackupsDeviceService.swift in Sources */,
 				E10971822A828BC900ABED41 /* ConfigLoader.swift in Sources */,

--- a/Shared/en.lproj/Localizable.strings
+++ b/Shared/en.lproj/Localizable.strings
@@ -159,6 +159,7 @@
 "CONTEXT_MENU_AVAILABLE_ONLINE_ONLY" = "Make Online Only";
 "CONTEXT_MENU_REFRESH_CONTENT" = "Refresh content";
 "CONTEXT_MENU_OPEN_WEB_BROWSER" = "Open in web browser";
+"CONTEXT_MENU_OPEN_INTERNXT_LINK" = "Copy Internxt link";
 // Decorations
 "AvailableOfflineLabel" = "Available offline";
 

--- a/Shared/es.lproj/Localizable.strings
+++ b/Shared/es.lproj/Localizable.strings
@@ -139,6 +139,7 @@
 "CONTEXT_MENU_AVAILABLE_ONLINE_ONLY" = "Cambiar a disponible sólo online";
 "CONTEXT_MENU_REFRESH_CONTENT" = "Refrescar contenido";
 "CONTEXT_MENU_OPEN_WEB_BROWSER" = "Abrir en navegador web";
+"CONTEXT_MENU_OPEN_INTERNXT_LINK" = "Copiar enlace de Internxt";
 
 // Decorations
 "AvailableOfflineLabel" = "Disponible sin conexión";

--- a/Shared/fr.lproj/Localizable.strings
+++ b/Shared/fr.lproj/Localizable.strings
@@ -140,6 +140,7 @@
 "CONTEXT_MENU_AVAILABLE_ONLINE_ONLY" = "Rendre disponible en ligne uniquement";
 "CONTEXT_MENU_REFRESH_CONTENT" = "Actualiser le contenu";
 "CONTEXT_MENU_OPEN_WEB_BROWSER" = "Ouvrir dans un navigateur Web";
+"CONTEXT_MENU_OPEN_INTERNXT_LINK" = "Copier le lien Internxt";
 
 // Decorations
 "AvailableOfflineLabel" = "Disponible hors ligne";

--- a/SyncExtension/FileProviderExtension.swift
+++ b/SyncExtension/FileProviderExtension.swift
@@ -755,6 +755,15 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension, NSFile
             return Progress()
         }
         
+        if actionIdentifier == FileProviderItemActionsManager.CopyInternxtLink {
+            return CopyInternxtLinkUseCase(
+                driveAPI: driveNewAPI,
+                mnemonic: mnemonic,
+                itemIdentifiers: itemIdentifiers,
+                completionHandler: completionHandler
+            ).run()
+        }
+        
         return Progress()
     }
     

--- a/SyncExtension/FileProviderItemActionsManager.swift
+++ b/SyncExtension/FileProviderItemActionsManager.swift
@@ -13,6 +13,7 @@ class FileProviderItemActionsManager{
     static let MakeAvailableOffline = NSFileProviderExtensionActionIdentifier(rawValue: "internxt.InternxtDesktop.sync.Action.AvailableOffline")
     static let RefreshContent = NSFileProviderExtensionActionIdentifier(rawValue: "internxt.InternxtDesktop.sync.Action.RefreshContent")
     static let OpenWebBrowser = NSFileProviderExtensionActionIdentifier(rawValue: "internxt.InternxtDesktop.sync.Action.OpenWebBrowser")
+    static let CopyInternxtLink = NSFileProviderExtensionActionIdentifier(rawValue: "internxt.InternxtDesktop.sync.Action.CopyInternxtLink")
     let userDefaults = UserDefaults.standard
 
         

--- a/SyncExtension/Info.plist
+++ b/SyncExtension/Info.plist
@@ -51,6 +51,14 @@
 				<key>NSExtensionFileProviderActionName</key>
 				<string>CONTEXT_MENU_OPEN_WEB_BROWSER</string>
 			</dict>
+			<dict>
+				<key>NSExtensionFileProviderActionActivationRule</key>
+				<string>TRUEPREDICATE</string>
+				<key>NSExtensionFileProviderActionIdentifier</key>
+				<string>internxt.InternxtDesktop.sync.Action.CopyInternxtLink</string>
+				<key>NSExtensionFileProviderActionName</key>
+				<string>CONTEXT_MENU_OPEN_INTERNXT_LINK</string>
+			</dict>
 		</array>
 		<key>NSExtensionFileProviderDocumentGroup</key>
 		<string>$(TeamIdentifierPrefix)group.internxt.desktop</string>

--- a/SyncExtension/UseCases/All/CopyInternxtLinkUseCase.swift
+++ b/SyncExtension/UseCases/All/CopyInternxtLinkUseCase.swift
@@ -1,0 +1,108 @@
+//
+//  CopyInternxtLinkUseCase.swift
+//  SyncExtension
+//
+//  Created by Patricio Tovar on 6/5/26.
+//
+
+import Foundation
+
+import InternxtSwiftCore
+import FileProvider
+import AppKit
+
+
+struct CopyInternxtLinkUseCase {
+
+    let logger = syncExtensionLogger
+
+   
+
+    private let driveAPI: DriveAPI
+    private let mnemonic: String
+    private let itemIdentifiers: [NSFileProviderItemIdentifier]
+    private let completionHandler: (Error?) -> Void
+
+  
+ 
+    private static let shareBaseURL = "https://drive.internxt.com"
+
+
+    init(
+        driveAPI: DriveAPI,
+        mnemonic: String,
+        itemIdentifiers: [NSFileProviderItemIdentifier],
+        completionHandler: @escaping (Error?) -> Void
+    ) {
+        self.driveAPI          = driveAPI
+        self.mnemonic          = mnemonic
+        self.itemIdentifiers   = itemIdentifiers
+        self.completionHandler = completionHandler
+    }
+
+
+
+    func run() -> Progress {
+        Task {
+            do {
+                for identifier in itemIdentifiers {
+                    try await processItem(identifier: identifier)
+                }
+                completionHandler(nil)
+            } catch {
+                logger.error("❌ CopyInternxtLinkUseCase failed: \(error.localizedDescription)")
+                completionHandler(error)
+            }
+        }
+        return Progress()
+    }
+
+
+
+    private func processItem(identifier: NSFileProviderItemIdentifier) async throws {
+        let uuid = identifier.rawValue
+        logger.info("Generating Internxt sharing link for item: \(uuid)")
+
+        let cipher = InternxtAESCipher()
+
+       
+        let plainCode = cipher.generateRandomUrlSafeString(length: 8)
+
+
+        let encryptionKey = try cipher.encrypt(plaintext: mnemonic, password: plainCode)
+
+  
+        let encryptedCode = try cipher.encrypt(plaintext: plainCode, password: mnemonic)
+
+
+        let itemType = UUID(uuidString: uuid) != nil ? "file" : "folder"
+
+
+        let payload = CreateSharingPayload(
+            itemId: uuid,
+            itemType: itemType,
+            encryptionKey: encryptionKey,
+            encryptionAlgorithm: "inxt-v2",
+            encryptedCode: encryptedCode,
+            encryptedPassword: "",
+            persistPreviousSharing: true
+        )
+
+
+        _ = try await driveAPI.createSharing(payload: payload)
+
+        logger.info("✅ Sharing created for item \(uuid)")
+
+
+        logger.info("⚠️ Link generation pending: CreateSharingResponse fields not yet defined.")
+    }
+
+
+
+    private func copyToClipboard(_ text: String) {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(text, forType: .string)
+        logger.info("📋 Internxt share link copied to clipboard: \(text)")
+    }
+}

--- a/SyncExtension/UseCases/All/CopyInternxtLinkUseCase.swift
+++ b/SyncExtension/UseCases/All/CopyInternxtLinkUseCase.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-
 import InternxtSwiftCore
 import FileProvider
 import AppKit
@@ -142,6 +141,14 @@ struct CopyInternxtLinkUseCase {
     private func copyToClipboard(_ text: String) {
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(text, forType: .string)
+        
+        let alert = NSAlert()
+        alert.messageText = "Link copied"
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: "OK")
+        
+        NSApp.activate(ignoringOtherApps: true)
+        alert.runModal()
     }
 }
 

--- a/SyncExtension/UseCases/All/CopyInternxtLinkUseCase.swift
+++ b/SyncExtension/UseCases/All/CopyInternxtLinkUseCase.swift
@@ -23,11 +23,6 @@ struct CopyInternxtLinkUseCase {
     private let itemIdentifiers: [NSFileProviderItemIdentifier]
     private let completionHandler: (Error?) -> Void
 
-  
- 
-    private static let shareBaseURL = "https://drive.internxt.com"
-
-
     init(
         driveAPI: DriveAPI,
         mnemonic: String,
@@ -45,7 +40,8 @@ struct CopyInternxtLinkUseCase {
     func run() -> Progress {
         Task {
             do {
-                for identifier in itemIdentifiers {
+               
+                if let identifier = itemIdentifiers.first {
                     try await processItem(identifier: identifier)
                 }
                 completionHandler(nil)
@@ -60,49 +56,107 @@ struct CopyInternxtLinkUseCase {
 
 
     private func processItem(identifier: NSFileProviderItemIdentifier) async throws {
-        let uuid = identifier.rawValue
-        logger.info("Generating Internxt sharing link for item: \(uuid)")
+        let internxtUUID: String
+        let itemType: String
+        
+        if UUID(uuidString: identifier.rawValue) != nil {
+            internxtUUID = identifier.rawValue
+            itemType = "file"
+        } else {
+           
+            let meta = try await driveAPI.getFolderOrFileMetaById(id: identifier.rawValue)
+            guard let uuid = meta.uuid else {
+                throw CopyInternxtLinkError.missingUUID(identifier.rawValue)
+            }
+            internxtUUID = uuid
+            itemType = meta.isFolder ? "folder" : "file"
+        }
 
         let cipher = InternxtAESCipher()
-
-       
+        let selectedDomain = try await fetchRandomDomain()
         let plainCode = cipher.generateRandomUrlSafeString(length: 8)
-
-
         let encryptionKey = try cipher.encrypt(plaintext: mnemonic, password: plainCode)
 
-  
+       
         let encryptedCode = try cipher.encrypt(plaintext: plainCode, password: mnemonic)
-
-
-        let itemType = UUID(uuidString: uuid) != nil ? "file" : "folder"
-
-
         let payload = CreateSharingPayload(
-            itemId: uuid,
+            itemId: internxtUUID,
             itemType: itemType,
             encryptionKey: encryptionKey,
             encryptionAlgorithm: "inxt-v2",
             encryptedCode: encryptedCode,
-            encryptedPassword: "",
+            encryptedPassword: nil,
             persistPreviousSharing: true
         )
 
+        let response = try await driveAPI.createSharing(payload: payload)
 
-        _ = try await driveAPI.createSharing(payload: payload)
+        let recoveredCode = try cipher.decrypt(
+            cipherBase64: response.encryptedCode,
+            password: mnemonic
+        )
 
-        logger.info("✅ Sharing created for item \(uuid)")
+        let encodedSharingId = encodeV4Uuid(response.id)
+        let shareLink = "\(selectedDomain)/sh/\(itemType)/\(encodedSharingId)/\(recoveredCode)"
+        await copyToClipboard(shareLink)
+    }
 
+    private func encodeV4Uuid(_ uuid: String) -> String {
+        let hex = uuid.replacingOccurrences(of: "-", with: "")
+        guard hex.count == 32 else { return uuid }
 
-        logger.info("⚠️ Link generation pending: CreateSharingResponse fields not yet defined.")
+        var bytes = [UInt8]()
+        bytes.reserveCapacity(16)
+        var idx = hex.startIndex
+        for _ in 0..<16 {
+            let end = hex.index(idx, offsetBy: 2)
+            if let byte = UInt8(hex[idx..<end], radix: 16) {
+                bytes.append(byte)
+            }
+            idx = end
+        }
+
+        return Data(bytes).base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
     }
 
 
+    private func fetchRandomDomain() async throws -> String {
+        do {
+            let response = try await driveAPI.getShareDomains()
+            guard !response.list.isEmpty else {
+                logger.error("⚠️ Share domains list is empty")
+                throw CopyInternxtLinkError.noDomainsAvailable
+            }
+            return response.list[Int.random(in: 0..<response.list.count)]
+        } catch {
+            logger.error("⚠️ Failed to fetch share domains: \(error.localizedDescription)")
+            throw CopyInternxtLinkError.noDomainsAvailable
+        }
+    }
 
+
+    @MainActor
     private func copyToClipboard(_ text: String) {
-        let pasteboard = NSPasteboard.general
-        pasteboard.clearContents()
-        pasteboard.setString(text, forType: .string)
-        logger.info("📋 Internxt share link copied to clipboard: \(text)")
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
+    }
+}
+
+
+
+enum CopyInternxtLinkError: Error, LocalizedError {
+    case missingUUID(String)
+    case noDomainsAvailable
+
+    var errorDescription: String? {
+        switch self {
+        case .missingUUID(let id):
+            return "Could not resolve Internxt UUID for FileProvider identifier: \(id)"
+        case .noDomainsAvailable:
+            return "No share domains available from the gateway API"
+        }
     }
 }

--- a/SyncExtension/UseCases/All/CopyInternxtLinkUseCase.swift
+++ b/SyncExtension/UseCases/All/CopyInternxtLinkUseCase.swift
@@ -77,7 +77,7 @@ struct CopyInternxtLinkUseCase {
 
         let cipher = InternxtAESCipher()
         let selectedDomain = try await fetchRandomDomain()
-        let plainCode = cipher.generateRandomUrlSafeString(length: 8)
+        let plainCode = try cipher.generateRandomUrlSafeString(length: 8)
         let encryptionKey = try cipher.encrypt(plaintext: mnemonic, password: plainCode)
 
        

--- a/SyncExtension/UseCases/All/CopyInternxtLinkUseCase.swift
+++ b/SyncExtension/UseCases/All/CopyInternxtLinkUseCase.swift
@@ -55,6 +55,10 @@ struct CopyInternxtLinkUseCase {
 
 
     private func processItem(identifier: NSFileProviderItemIdentifier) async throws {
+        guard CryptoUtils().validate(mnemonic: mnemonic) else {
+            throw CopyInternxtLinkError.invalidMnemonic
+        }
+        
         let internxtUUID: String
         let itemType: String
         
@@ -157,6 +161,7 @@ struct CopyInternxtLinkUseCase {
 enum CopyInternxtLinkError: Error, LocalizedError {
     case missingUUID(String)
     case noDomainsAvailable
+    case invalidMnemonic
 
     var errorDescription: String? {
         switch self {
@@ -164,6 +169,8 @@ enum CopyInternxtLinkError: Error, LocalizedError {
             return "Could not resolve Internxt UUID for FileProvider identifier: \(id)"
         case .noDomainsAvailable:
             return "No share domains available from the gateway API"
+        case .invalidMnemonic:
+            return "The user's mnemonic phrase is invalid or malformed"
         }
     }
 }


### PR DESCRIPTION
This Pull Request introduces the complete end-to-end functionality allowing macOS users to generate and copy public share links directly from the Finder contextual menu.
-Implemented the use case that orchestrates the public link generation. This flow fully replicates the web client's behavior: it generates a secure random URL-safe code, encrypts the share data using the inxt-v2 (AES-256-GCM) standard, registers the link via the API, and builds the final public URL using a dynamic gateway domain.