### PR TITLE
feat: add file size limit enforcement and SwiftUI dialog

### DIFF
--- a/InternxtDesktop.xcodeproj/project.pbxproj
+++ b/InternxtDesktop.xcodeproj/project.pbxproj
@@ -111,6 +111,12 @@
 		AA93BEC42E72328900F12334 /* CleanupOperationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA93BEC32E72328900F12334 /* CleanupOperationService.swift */; };
 		AA93BEC62E7233BA00F12334 /* ProgressPollingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA93BEC52E7233BA00F12334 /* ProgressPollingService.swift */; };
 		AA94CA6E2E99E8CE007CEBDF /* NotificationsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA94CA6D2E99E8CE007CEBDF /* NotificationsManager.swift */; };
+		AA9B1B9A2FB2D327000E582A /* FileLimitsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA9B1B992FB2D327000E582A /* FileLimitsService.swift */; };
+		AA9B1B9C2FB2D342000E582A /* FileSizeLimitNotifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA9B1B9B2FB2D342000E582A /* FileSizeLimitNotifier.swift */; };
+		AA9B1B9D2FB2D342000E582A /* FileSizeLimitNotifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA9B1B9B2FB2D342000E582A /* FileSizeLimitNotifier.swift */; };
+		AA9B1B9E2FB2D342000E582A /* FileSizeLimitNotifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA9B1B9B2FB2D342000E582A /* FileSizeLimitNotifier.swift */; };
+		AA9B1B9F2FB2D342000E582A /* FileSizeLimitNotifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA9B1B9B2FB2D342000E582A /* FileSizeLimitNotifier.swift */; };
+		AA9B1BA12FB4094D000E582A /* FileSizeLimitDialogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA9B1BA02FB4094D000E582A /* FileSizeLimitDialogView.swift */; };
 		AA9DF5452EDF6B2E00D1FE52 /* PackageFileHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA9DF5442EDF6B2E00D1FE52 /* PackageFileHandle.swift */; };
 		AAA424962C51FFC100EEFD69 /* GenericRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFFBE282C50AC4F00C76528 /* GenericRepository.swift */; };
 		AAA666682D402F2900C2B9DF /* CustomModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA666672D402F2900C2B9DF /* CustomModalView.swift */; };
@@ -549,6 +555,9 @@
 		AA93BEC32E72328900F12334 /* CleanupOperationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CleanupOperationService.swift; sourceTree = "<group>"; };
 		AA93BEC52E7233BA00F12334 /* ProgressPollingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressPollingService.swift; sourceTree = "<group>"; };
 		AA94CA6D2E99E8CE007CEBDF /* NotificationsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsManager.swift; sourceTree = "<group>"; };
+		AA9B1B992FB2D327000E582A /* FileLimitsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileLimitsService.swift; sourceTree = "<group>"; };
+		AA9B1B9B2FB2D342000E582A /* FileSizeLimitNotifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSizeLimitNotifier.swift; sourceTree = "<group>"; };
+		AA9B1BA02FB4094D000E582A /* FileSizeLimitDialogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSizeLimitDialogView.swift; sourceTree = "<group>"; };
 		AA9DF5442EDF6B2E00D1FE52 /* PackageFileHandle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackageFileHandle.swift; sourceTree = "<group>"; };
 		AAA666672D402F2900C2B9DF /* CustomModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomModalView.swift; sourceTree = "<group>"; };
 		AAA666692D40380800C2B9DF /* FileSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSelectionView.swift; sourceTree = "<group>"; };
@@ -1028,6 +1037,7 @@
 				E1D24AF32C0468AF0009EC83 /* AsyncOperation.swift */,
 				AAED64A02C23E85000CD971B /* JWTDecoder.swift */,
 				AA2019662C53F8B700901B93 /* Debouncer.swift */,
+				AA9B1B9B2FB2D342000E582A /* FileSizeLimitNotifier.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -1053,6 +1063,7 @@
 			isa = PBXGroup;
 			children = (
 				E13B83962AFBBCD7009F6684 /* AppSettingsManagerView.swift */,
+				AA9B1BA02FB4094D000E582A /* FileSizeLimitDialogView.swift */,
 			);
 			path = App;
 			sourceTree = "<group>";
@@ -1410,6 +1421,7 @@
 				AA94CA6D2E99E8CE007CEBDF /* NotificationsManager.swift */,
 				AACC83A32F7E06770084FFB6 /* ClamAVDatabaseService.swift */,
 				AACC83A52F7E068E0084FFB6 /* ClamAVScannerService.swift */,
+				AA9B1B992FB2D327000E582A /* FileLimitsService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -1821,6 +1833,7 @@
 				E15F8C412B762EFF00C60EFA /* BackupTreeNodeSyncStatus.swift in Sources */,
 				319436922B9B8293006F4600 /* SyncedNodeRepository.swift in Sources */,
 				31DEAEB52B75139400E76D53 /* main.swift in Sources */,
+				AA9B1B9D2FB2D342000E582A /* FileSizeLimitNotifier.swift in Sources */,
 				3120B5762B85185C00F524F1 /* AuthManager.swift in Sources */,
 				3120B55B2B84F12A00F524F1 /* BackupUploadService.swift in Sources */,
 				AAFFBE2C2C50B23D00C76528 /* GenericRepository.swift in Sources */,
@@ -1881,6 +1894,7 @@
 				31F9EF2B2B867E16007DAD86 /* ConfigLoader.swift in Sources */,
 				AAC188F12C2231E7007E321A /* MockBackupUploadService.swift in Sources */,
 				31F9EF2E2B867FE9007DAD86 /* APIFactory.swift in Sources */,
+				AA9B1B9E2FB2D342000E582A /* FileSizeLimitNotifier.swift in Sources */,
 				AA0B47AB2C24D9E90036FE1A /* BackupDownloadItemOperation.swift in Sources */,
 				E1D24AFA2C0DA4100009EC83 /* SyncedNode.swift in Sources */,
 				E15F8C352B762BAF00C60EFA /* BackupTreeGeneratorTests.swift in Sources */,
@@ -1936,6 +1950,7 @@
 				E1581DCA2A95221D0051DD46 /* FileProvider.swift in Sources */,
 				AA7FC5A42E450CAA0018C333 /* CleanerTabView.swift in Sources */,
 				AA628F2A2D4BF73000421CB7 /* OnboardingSlide6View.swift in Sources */,
+				AA9B1BA12FB4094D000E582A /* FileSizeLimitDialogView.swift in Sources */,
 				AA40B3BD2D3B298600FC1FC3 /* AntivirusTabView.swift in Sources */,
 				AA93BEBA2E720E8200F12334 /* CleaningView.swift in Sources */,
 				AAA666682D402F2900C2B9DF /* CustomModalView.swift in Sources */,
@@ -1983,6 +1998,7 @@
 				E1A0AC5C2AB85131005E71D6 /* Windows.swift in Sources */,
 				E1ADD04F2AA8D54E00D95694 /* RealtimeService.swift in Sources */,
 				316D24782B4D8B94007DE91A /* BackupFrequencySelectorView.swift in Sources */,
+				AA9B1B9C2FB2D342000E582A /* FileSizeLimitNotifier.swift in Sources */,
 				E1CAB6782AFC3F740006EA1E /* AppSelector.swift in Sources */,
 				E19136942AA101DE00CAF0FA /* WidgetIconButtonView.swift in Sources */,
 				E1F616072A8D7DF8008C9E62 /* SignInWithBrowserView.swift in Sources */,
@@ -2004,6 +2020,7 @@
 				3104526E2B4B1C5C00984716 /* StopBackupDialogView.swift in Sources */,
 				E1DB29612A7D6B80009036B8 /* WidgetContentView.swift in Sources */,
 				E1A0AC562AB48B7F005E71D6 /* WindowsManager.swift in Sources */,
+				AA9B1B9A2FB2D327000E582A /* FileLimitsService.swift in Sources */,
 				E1581DCF2A9629620051DD46 /* Generic.swift in Sources */,
 				E145E16C2A82A21500B07E0B /* Time.swift in Sources */,
 				E1DB29542A7D56C4009036B8 /* AppTextInput.swift in Sources */,
@@ -2061,6 +2078,7 @@
 				E16ECC152A9508B10093D3ED /* ErrorUtils.swift in Sources */,
 				AA825F982CF9049E0058B30A /* GetRemoteChangesUseCaseWorkspace.swift in Sources */,
 				AACE1FE62CE1AED10039ABF4 /* MoveFolderWorkspaceUseCase.swift in Sources */,
+				AA9B1B9F2FB2D342000E582A /* FileSizeLimitNotifier.swift in Sources */,
 				E140C32D2AC376AE00A88B9F /* Drive.swift in Sources */,
 				AA8D9AEF2E7CC2370068B333 /* FeaturesService.swift in Sources */,
 				E1581DDE2A9678000051DD46 /* MoveFolderUseCase.swift in Sources */,

--- a/InternxtDesktop.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/InternxtDesktop.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -88,7 +88,7 @@
       "location" : "https://github.com/internxt/swift-core",
       "state" : {
         "branch" : "main",
-        "revision" : "80e3e1041171a6ff5f86a5fa8972b81e4f96762b"
+        "revision" : "2c47fc31e439440b19fe6acffc527898949b20f0"
       }
     },
     {

--- a/InternxtDesktop/AppDelegate.swift
+++ b/InternxtDesktop/AppDelegate.swift
@@ -57,6 +57,7 @@ class AppDelegate: NSObject, NSApplicationDelegate , PKPushRegistryDelegate {
     var refreshTokensTimer: AnyCancellable?
     var signalEnumeratorTimer: AnyCancellable?
     var notificationsTimer: AnyCancellable?
+    let fileSizeLimitState = FileSizeLimitState()
     var usageUpdateDebouncer = Debouncer(delay: 15.0)
     private let driveNewAPI: DriveAPI = APIFactory.DriveNew
     private let notificationsPollingInterval: TimeInterval = 30 * 60
@@ -97,10 +98,19 @@ class AppDelegate: NSObject, NSApplicationDelegate , PKPushRegistryDelegate {
             NotificationCenter.default.post(name: .userDidLogout, object: nil)
         }
 
+       
+        DistributedNotificationCenter.default().addObserver(
+            forName: NSNotification.Name(NOTIFICATION_FILE_SIZE_EXCEEDED),
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            self?.handleFileSizeExceeded(notification)
+        }
+
         checkVolumeAndEjectIfNeeded()
         
         self.windowsManager = WindowsManager(
-            initialWindows: defaultWindows(settingsManager: settingsManager, authManager: authManager, usageManager: usageManager, backupsService: backupsService, scheduleManager: scheduledManager, antivirusManager: antivirusManager, cleanerService: cleanerService, updater: updaterController.updater,closeSendFeedbackWindow: closeSendFeedbackWindow, finishOrSkipOnboarding: self.finishOrSkipOnboarding),
+            initialWindows: defaultWindows(settingsManager: settingsManager, authManager: authManager, usageManager: usageManager, backupsService: backupsService, scheduleManager: scheduledManager, antivirusManager: antivirusManager, cleanerService: cleanerService, updater: updaterController.updater, closeSendFeedbackWindow: closeSendFeedbackWindow, finishOrSkipOnboarding: self.finishOrSkipOnboarding, fileSizeLimitState: fileSizeLimitState),
             onWindowClose: receiveOnWindowClose
         )
         self.windowsManager.loadInitialWindows()
@@ -350,6 +360,7 @@ class AppDelegate: NSObject, NSApplicationDelegate , PKPushRegistryDelegate {
     private func loginSuccess() {
         self.windowsManager.hideDockIcon()
         self.windowsManager.closeWindow(id: "auth")
+        FileLimitsService.shared.startPolling()
         
         Task {
             do {
@@ -456,6 +467,8 @@ class AppDelegate: NSObject, NSApplicationDelegate , PKPushRegistryDelegate {
     
     private func logoutSuccess() {
         FeaturesService.shared.clearCachedFeatures()
+        FileLimitsService.shared.stopPolling()
+        FileLimitsService.shared.clearCache()
         self.windowsManager.displayDockIcon()
         self.openAuthWindow()
         self.windowsManager.closeAll(except: ["auth"])
@@ -590,6 +603,46 @@ class AppDelegate: NSObject, NSApplicationDelegate , PKPushRegistryDelegate {
         self.refreshTokensTimer?.cancel()
         self.notificationsTimer?.cancel()
     }
+
+  
+    private let fileSizeBatchDebounceInterval: TimeInterval = 0.6
+
+  
+    private var fileSizePendingAlert: DispatchWorkItem?
+
+  
+    private var fileSizeAlertIsShowing = false
+
+    private func handleFileSizeExceeded(_ notification: Notification) {
+       
+        fileSizePendingAlert?.cancel()
+
+    
+        guard !fileSizeAlertIsShowing else { return }
+
+     
+        let work = DispatchWorkItem { [weak self] in
+            self?.presentFileSizeAlert()
+        }
+        fileSizePendingAlert = work
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + fileSizeBatchDebounceInterval,
+            execute: work
+        )
+    }
+
+    private func presentFileSizeAlert() {
+        let batch = FileSizeLimitNotifier.readAndResetBatch()
+        fileSizeLimitState.isBatch    = batch.rejectedCount > 1
+        fileSizeLimitState.filename   = batch.filename
+        fileSizeLimitState.fileSize   = batch.fileBytes
+        fileSizeLimitState.limitBytes = batch.limitBytes
+        fileSizeLimitState.isVisible  = true
+
+        windowsManager.openWindow(id: "file-size-limit")
+        fileSizeAlertIsShowing = false
+    }
+
     
     
     private func openWidget(delayed: Bool = false) {

--- a/InternxtDesktop/Services/FileLimitsService.swift
+++ b/InternxtDesktop/Services/FileLimitsService.swift
@@ -1,0 +1,81 @@
+//
+//  FileLimitsService.swift
+//  InternxtDesktop
+//
+//  Created by Patricio Tovar on 11/5/26.
+//
+
+import Foundation
+import InternxtSwiftCore
+import Combine
+
+class FileLimitsService: ObservableObject {
+
+    static let shared = FileLimitsService()
+
+    private let config   = ConfigLoader()
+    private let logger   = LogService.shared.createLogger(
+        subsystem: .InternxtDesktop, category: "FileLimitsService")
+
+
+    @Published private(set) var maxUploadFileSizeBytes: Int64 = Int64.max
+
+    // MARK: Private
+
+    private var refreshTimer: AnyCancellable?
+    private let refreshInterval: TimeInterval = 5 * 60   // 5 minutes
+
+    private init() {
+        maxUploadFileSizeBytes = config.getMaxFileSizeBytes()
+    }
+
+
+    func startPolling() {
+        Task { await fetchIfNeeded() }
+
+        refreshTimer = Timer
+            .publish(every: refreshInterval, on: .main, in: .common)
+            .autoconnect()
+            .sink { [weak self] _ in
+                Task { await self?.fetchIfNeeded() }
+            }
+    }
+
+ 
+    func stopPolling() {
+        refreshTimer?.cancel()
+        refreshTimer = nil
+    }
+
+ 
+    func clearCache() {
+        config.clearMaxFileSize()
+        maxUploadFileSizeBytes = Int64.max
+    }
+
+ 
+
+    @MainActor
+    private func fetchIfNeeded() async {
+        guard config.fileSizeLimitNeedsRefresh() else {
+           
+            return
+        }
+        await fetchLimits()
+    }
+
+    @MainActor
+    private func fetchLimits() async {
+        do {
+           
+            let response = try await APIFactory.DriveNew.getFileLimits()
+            let rawBytes = Int64(response.maxUploadFileSize ?? 0)
+            config.setMaxFileSizeBytes(rawBytes)
+            maxUploadFileSizeBytes = config.getMaxFileSizeBytes()
+          
+        } catch {
+      
+            logger.error("❌ Failed to fetch file limits: \(error.localizedDescription)")
+        }
+    }
+}

--- a/InternxtDesktop/Views/App/FileSizeLimitDialogView.swift
+++ b/InternxtDesktop/Views/App/FileSizeLimitDialogView.swift
@@ -1,0 +1,168 @@
+//
+//  FileSizeLimitDialogView.swift
+//  InternxtDesktop
+//
+//  Created by Patricio Tovar on 12/5/26.
+//
+
+import Foundation
+import SwiftUI
+
+
+class FileSizeLimitState: ObservableObject {
+    @Published var isBatch:    Bool   = false
+    @Published var filename:   String = ""
+    @Published var fileSize:   Int64  = 0
+    @Published var limitBytes: Int64  = 0
+    @Published var isVisible:  Bool   = false
+}
+
+
+struct FileSizeLimitDialogView: View {
+
+    @Environment(\.colorScheme) var colorScheme
+
+    let isBatch:      Bool
+    let filename:     String
+    let fileSize:     Int64
+    let limitBytes:   Int64
+    var onClose:      () -> Void
+    var onUpgrade:    () -> Void
+
+  
+
+    private var limitMB: String {
+        formatBytes(limitBytes)
+    }
+
+    private var fileSizeMB: String {
+        formatBytes(fileSize)
+    }
+
+    private func formatBytes(_ bytes: Int64) -> String {
+        guard bytes > 0 else { return "0 MB" }
+        let mb = Double(bytes) / (1024 * 1024)
+        if mb >= 1024 {
+            return String(format: "%.0f GB", mb / 1024)
+        }
+        return String(format: mb >= 10 ? "%.0f MB" : "%.1f MB", mb)
+    }
+
+    private let planTiers: [(name: String, limit: String, highlighted: Bool)] = [
+        ("Essential", "10 GB",  false),
+        ("Premium",   "50 GB",  true),
+        ("Ultimate",  "100 GB", false),
+    ]
+
+  
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+
+          
+            Group {
+                if isBatch {
+                    Text("Some files are too large for your current plan")
+                } else {
+                    Text("This file is too large for your current plan")
+                }
+            }
+            .font(.XLMedium)
+            .foregroundColor(.DefaultTextStrong)
+            .fixedSize(horizontal: false, vertical: true)
+            .padding(.bottom, 12)
+
+
+            Group {
+                if isBatch {
+                    Text("Your plan allows uploads up to \(limitMB). Upgrade your plan to upload larger files.")
+                } else {
+                    Text("Your plan allows uploads up to \(limitMB). This file is \(fileSizeMB). Upgrade your plan to upload larger files.")
+                }
+            }
+            .font(.SMRegular)
+            .foregroundColor(.Gray60)
+            .fixedSize(horizontal: false, vertical: true)
+            .padding(.bottom, 12)
+
+     
+            VStack(alignment: .leading, spacing: 6) {
+                ForEach(planTiers, id: \.name) { tier in
+                    HStack(alignment: .center, spacing: 8) {
+                    
+                        Circle()
+                            .fill(tier.highlighted ? Color.DefaultTextStrong : Color.Gray40)
+                            .frame(width: 5, height: 5)
+
+                 
+                        HStack(spacing: 0) {
+                            Text(tier.name)
+                                .font(tier.highlighted ? .SMBold : .SMRegular)
+                                .foregroundColor(tier.highlighted ? .DefaultTextStrong : .Gray80)
+                            Text(" → up to \(tier.limit)")
+                                .font(tier.highlighted ? .SMBold : .SMRegular)
+                                .foregroundColor(tier.highlighted ? .DefaultTextStrong : .Gray80)
+                        }
+                    }
+                }
+            }
+            .padding(.bottom, 24)
+
+            HStack(spacing: 8) {
+                Spacer()
+                AppButton(
+                    title: "Close",
+                    onClick: { onClose() },
+                    type: .secondary,
+                    size: .MD
+                )
+                AppButton(
+                    title: "Upgrade plan",
+                    onClick: { onUpgrade() },
+                    type: .primary,
+                    size: .MD
+                )
+            }
+        }
+        .padding(24)
+        .background(colorScheme == .dark ? Color.Gray1 : Color.white)
+        .cornerRadius(12)
+        .frame(width: 370)
+        .frame(height: 220)
+        .shadow(color: .black.opacity(0.08), radius: 16, x: 0, y: 4)
+        .shadow(color: .black.opacity(0.04), radius:  2, x: 0, y: 1)
+    }
+}
+
+
+
+struct FileSizeLimitWindowView: View {
+    @EnvironmentObject var state: FileSizeLimitState
+    @Environment(\.colorScheme) var colorScheme
+
+    var body: some View {
+        ZStack {
+         
+            (colorScheme == .dark ? Color.Gray1 : Color.Surface)
+                .ignoresSafeArea()
+
+            FileSizeLimitDialogView(
+                isBatch:    state.isBatch,
+                filename:   state.filename,
+                fileSize:   state.fileSize,
+                limitBytes: state.limitBytes,
+                onClose: {
+                    state.isVisible = false
+                
+                    NSApp.hide(nil)
+                },
+                onUpgrade: {
+                    URL(string: "https://internxt.com/pricing")?.open()
+                    state.isVisible = false
+                    NSApp.hide(nil)
+                }
+            )
+            .padding(24)
+        }
+    }
+}

--- a/InternxtDesktop/Windows.swift
+++ b/InternxtDesktop/Windows.swift
@@ -14,7 +14,8 @@ import Sparkle
 /// windows will be available without needing to explicitly
 /// creating them
 func defaultWindows(settingsManager: SettingsTabManager, authManager: AuthManager, usageManager: UsageManager, backupsService: BackupsService, scheduleManager: ScheduledBackupManager,antivirusManager : AntivirusManager ,
-                    cleanerService: CleanerService,updater: SPUUpdater, closeSendFeedbackWindow: @escaping () -> Void, finishOrSkipOnboarding: @escaping () -> Void) -> [WindowConfig] {
+                    cleanerService: CleanerService,updater: SPUUpdater, closeSendFeedbackWindow: @escaping () -> Void, finishOrSkipOnboarding: @escaping () -> Void,
+                    fileSizeLimitState: FileSizeLimitState) -> [WindowConfig] {
     let windows = [
         WindowConfig(
             view: AnyView(AppSettingsManagerView{SignInWithBrowserView().environmentObject(authManager)}),
@@ -52,6 +53,18 @@ func defaultWindows(settingsManager: SettingsTabManager, authManager: AuthManage
             id: "send-feedback",
             width: 380,
             height: 320
+        ),
+        WindowConfig(
+            view: AnyView(
+                FileSizeLimitWindowView()
+                    .environmentObject(fileSizeLimitState)
+            ),
+            title: nil,
+            id: "file-size-limit",
+            width: 300,
+            height: 150,
+            fixedToFront: true,
+            backgroundColor: Color.Surface
         )
     ]
     

--- a/Shared/Services/ConfigLoader.swift
+++ b/Shared/Services/ConfigLoader.swift
@@ -394,6 +394,42 @@ public struct ConfigLoader {
             throw ConfigLoaderError.CannotRemoveKey
         }
     }
+
+ 
+
+    private let kMaxFileSizeBytes    = "MaxFileSizeBytes"
+    private let kMaxFileSizeFetchedAt = "MaxFileSizeFetchedAt"
+    private let fileSizeCacheTTL: TimeInterval = 5 * 60  // 5 minutes
+
+ 
+    public func getMaxFileSizeBytes() -> Int64 {
+        let stored = UserDefaults(suiteName: SUITE_NAME)?
+            .object(forKey: kMaxFileSizeBytes) as? Int64 ?? 0
+        return stored > 0 ? stored : Int64.max
+    }
+
+ 
+    public func setMaxFileSizeBytes(_ bytes: Int64) {
+        let defaults = UserDefaults(suiteName: SUITE_NAME)
+        defaults?.set(bytes, forKey: kMaxFileSizeBytes)
+        defaults?.set(Date().timeIntervalSince1970, forKey: kMaxFileSizeFetchedAt)
+    }
+
+   
+    public func fileSizeLimitNeedsRefresh() -> Bool {
+        guard let fetchedAt = UserDefaults(suiteName: SUITE_NAME)?
+            .object(forKey: kMaxFileSizeFetchedAt) as? TimeInterval else {
+            return true
+        }
+        return Date().timeIntervalSince1970 - fetchedAt > fileSizeCacheTTL
+    }
+
+  
+    public func clearMaxFileSize() {
+        let defaults = UserDefaults(suiteName: SUITE_NAME)
+        defaults?.removeObject(forKey: kMaxFileSizeBytes)
+        defaults?.removeObject(forKey: kMaxFileSizeFetchedAt)
+    }
 }
 
 

--- a/Shared/Utils/FileSizeLimitNotifier.swift
+++ b/Shared/Utils/FileSizeLimitNotifier.swift
@@ -1,0 +1,95 @@
+//
+//  FileSizeLimitNotifier.swift
+//  InternxtDesktop
+//
+//  Created by Patricio Tovar on 11/5/26.
+//
+
+import Foundation
+import FileProvider
+
+public let NOTIFICATION_FILE_SIZE_EXCEEDED = "com.internxt.drive.fileSizeExceeded"
+private let kFileSizeExceeded_filename    = "FileSizeExceeded_filename"
+private let kFileSizeExceeded_fileBytes   = "FileSizeExceeded_fileBytes"
+private let kFileSizeExceeded_limitBytes  = "FileSizeExceeded_limitBytes"
+private let kFileSizeExceeded_count       = "FileSizeExceeded_count"
+
+
+private let _lock = NSLock()
+
+
+
+public enum FileSizeLimitNotifier {
+    
+    
+    public static func postExceeded(filename: String,
+                                    fileBytes: Int64,
+                                    limitBytes: Int64) {
+        _lock.lock()
+        defer { _lock.unlock() }
+        
+        let defaults = UserDefaults(suiteName: INTERNXT_GROUP_NAME)
+        
+        
+        let previousCount = defaults?.integer(forKey: kFileSizeExceeded_count) ?? 0
+        let newCount = previousCount + 1
+        defaults?.set(newCount, forKey: kFileSizeExceeded_count)
+        
+        if previousCount == 0 {
+            defaults?.set(filename,   forKey: kFileSizeExceeded_filename)
+            defaults?.set(fileBytes,  forKey: kFileSizeExceeded_fileBytes)
+            defaults?.set(limitBytes, forKey: kFileSizeExceeded_limitBytes)
+        }
+        
+        defaults?.synchronize()
+        
+        
+        DistributedNotificationCenter.default().postNotificationName(
+            NSNotification.Name(NOTIFICATION_FILE_SIZE_EXCEEDED),
+            object: nil,
+            userInfo: nil,
+            deliverImmediately: true
+        )
+    }
+    
+    
+    public static func readAndResetBatch() -> (
+        rejectedCount: Int,
+        filename: String,
+        fileBytes: Int64,
+        limitBytes: Int64
+    ) {
+        let defaults = UserDefaults(suiteName: INTERNXT_GROUP_NAME)
+        
+        let count      = defaults?.integer(forKey: kFileSizeExceeded_count)              ?? 0
+        let filename   = defaults?.string(forKey: kFileSizeExceeded_filename)             ?? "Unknown"
+        let fileBytes  = defaults?.object(forKey: kFileSizeExceeded_fileBytes)  as? Int64 ?? 0
+        let limitBytes = defaults?.object(forKey: kFileSizeExceeded_limitBytes) as? Int64 ?? 0
+        
+        defaults?.set(0,  forKey: kFileSizeExceeded_count)
+        defaults?.removeObject(forKey: kFileSizeExceeded_filename)
+        defaults?.synchronize()
+        
+        return (count, filename, fileBytes, limitBytes)
+    }
+}
+
+
+
+public extension NSError {
+    
+    static func fileSizeExceededError() -> NSError {
+        NSError(
+            domain: "NSFileProviderErrorDomain",
+            code: NSFileProviderError.cannotSynchronize.rawValue,
+            userInfo: [
+                NSLocalizedDescriptionKey: NSLocalizedString(
+                    "file_size_exceeded_error",
+                    value: "The file exceeds the maximum upload size allowed by your current plan.",
+                    comment: "Error shown when a file is larger than the plan limit"
+                )
+            ]
+        )
+    }
+}
+

--- a/SyncExtension/FileProviderExtension.swift
+++ b/SyncExtension/FileProviderExtension.swift
@@ -388,6 +388,21 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension, NSFile
                     }
                     let fileSize = attributesSize ?? templateSize ?? 0
 
+                 
+                    if !checkFileSizeLimit(
+                        filename: itemTemplate.filename,
+                        fileBytes: fileSize,
+                        config: self.config
+                    ) {
+                        completionHandler(nil, [], false, NSError.fileSizeExceededError())
+                      
+                        try? FileManager.default.removeItem(at: fileCopy)
+                        if let zipURL = zipURL {
+                            try? FileManager.default.removeItem(at: zipURL)
+                        }
+                        return
+                    }
+
                     let encryptedFileDestination = self.makeTemporaryURL("encrypted", "enc")
                     let thumbnailFileDestination = self.makeTemporaryURL("thumbnail", "jpg")
                     let encryptedThumbnailFileDestination = self.makeTemporaryURL("encrypted_thumbnail", "enc")
@@ -587,6 +602,18 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension, NSFile
                 return Progress()
             }
             let encryptedFileDestination = makeTemporaryURL("enc-\(item.itemIdentifier.rawValue)")
+
+            let contentFileSize = (try? FileManager.default
+                .attributesOfItem(atPath: newContents.path)[.size] as? Int64) ?? 0
+            if !checkFileSizeLimit(
+                filename: item.filename,
+                fileBytes: contentFileSize,
+                config: self.config
+            ) {
+                completionHandler(nil, [], false, NSError.fileSizeExceededError())
+                return Progress()
+            }
+       
             
             func completionHandlerInternal(item: NSFileProviderItem?, fields: NSFileProviderItemFields, shouldFetch: Bool, error: Error?) -> Void{
                 completionHandler(item, fields, shouldFetch, error)

--- a/SyncExtension/Utils.swift
+++ b/SyncExtension/Utils.swift
@@ -35,3 +35,20 @@ func generateDriveWebURL(isFile:Bool, uuid: String) -> URL{
     }
     return URL(string: "\(URLDictionary.DRIVE_WEB_FOLDER)\(uuid)")!
 }
+
+
+@discardableResult
+func checkFileSizeLimit(filename: String, fileBytes: Int64, config: ConfigLoader) -> Bool {
+    let limitBytes = config.getMaxFileSizeBytes()
+    guard limitBytes < Int64.max, fileBytes > limitBytes else {
+        return true
+    }
+
+    logger.warning("⛔ File '\(filename)' (\(fileBytes) bytes) exceeds limit (\(limitBytes) bytes) — rejecting upload")
+    FileSizeLimitNotifier.postExceeded(
+        filename: filename,
+        fileBytes: fileBytes,
+        limitBytes: limitBytes
+    )
+    return false
+}


### PR DESCRIPTION
This PR implements file size limit enforcement for the macOS Sync Extension. It intercepts uploads exceeding user limits, tracks whether the block is a single-file or multi-file (batch) operation using a debounce mechanism, and presents a SwiftUI warning dialog matching the official designs.

##  Changes
* **`FileProviderExtension.swift` / `Utils.swift`**:
  * Intercepts `createItem` and `modifyItem` to validate file size.
  * Rejects uploads with `NSFileProviderError.cannotSynchronize` to prevent Finder auto-retries.
* **`FileSizeLimitNotifier.swift`**:
  * Uses `NSLock` for atomic counter increments during concurrent uploads.
  * Persists metadata (`filename`, `fileBytes`, `limitBytes`, `count`) in Shared App Group UserDefaults.
  * Posts distributed notification signal to trigger AppDelegate.
* **`AppDelegate.swift`**:
  * Implemented a `600ms` debounce timer (`fileSizeBatchDebounceInterval`) to group concurrent rejections.
  * Populates `fileSizeLimitState` and opens the `"file-size-limit"` window via `WindowsManager`.
  * `FileSizeLimitWindowView`: Environment wrapper that manages window hide/close callbacks.
