### PR TITLE
Fix inability to copy multiple share links and SyncExtension freeze

### DIFF
--- a/SyncExtension/FileProviderExtension.swift
+++ b/SyncExtension/FileProviderExtension.swift
@@ -783,9 +783,20 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension, NSFile
         }
         
         if actionIdentifier == FileProviderItemActionsManager.CopyInternxtLink {
+            let apiToUse: DriveAPI
+            let mnemonicToUse: String
+            
+            if isWorkspaceDomain() {
+                apiToUse = APIFactory.DriveWorkspace
+                mnemonicToUse = authManager.workspaceMnemonic ?? mnemonic
+            } else {
+                apiToUse = driveNewAPI
+                mnemonicToUse = mnemonic
+            }
+
             return CopyInternxtLinkUseCase(
-                driveAPI: driveNewAPI,
-                mnemonic: mnemonic,
+                driveAPI: apiToUse,
+                mnemonic: mnemonicToUse,
                 itemIdentifiers: itemIdentifiers,
                 completionHandler: completionHandler
             ).run()

--- a/SyncExtension/UseCases/All/CopyInternxtLinkUseCase.swift
+++ b/SyncExtension/UseCases/All/CopyInternxtLinkUseCase.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import UserNotifications
 import InternxtSwiftCore
 import FileProvider
 import AppKit
@@ -147,18 +146,21 @@ struct CopyInternxtLinkUseCase {
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(text, forType: .string)
 
-        let content = UNMutableNotificationContent()
-        content.title = "Link copied"
-        content.sound = .default
-        let request = UNNotificationRequest(
-            identifier: UUID().uuidString,
-            content: content,
-            trigger: nil
-        )
-        UNUserNotificationCenter.current().add(request) { [self] error in
-            if let error = error {
-                logger.error("❌ Failed to post link-copied notification: \(error.localizedDescription)")
-            }
+        Task.detached {
+            var response: CFOptionFlags = 0
+            CFUserNotificationDisplayAlert(
+                4,
+                kCFUserNotificationNoteAlertLevel,
+                nil,
+                nil,
+                nil,
+                "Link copied" as CFString,
+                nil,
+                "OK" as CFString,
+                nil,
+                nil,
+                &response
+            )
         }
     }
 }

--- a/SyncExtension/UseCases/All/CopyInternxtLinkUseCase.swift
+++ b/SyncExtension/UseCases/All/CopyInternxtLinkUseCase.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import UserNotifications
 import InternxtSwiftCore
 import FileProvider
 import AppKit
@@ -141,27 +142,23 @@ struct CopyInternxtLinkUseCase {
     }
 
 
+    @MainActor
     private func copyToClipboard(_ text: String) {
-        DispatchQueue.main.async {
-            NSPasteboard.general.clearContents()
-            NSPasteboard.general.setString(text, forType: .string)
-        }
-        Task.detached {
-            var response: CFOptionFlags = 0
-            
-            CFUserNotificationDisplayAlert(
-                4,
-                kCFUserNotificationNoteAlertLevel,
-                nil,
-                nil,
-                nil,
-                "Link copied" as CFString,
-                nil,
-                "OK" as CFString,
-                nil,
-                nil,
-                &response
-            )
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
+
+        let content = UNMutableNotificationContent()
+        content.title = "Link copied"
+        content.sound = .default
+        let request = UNNotificationRequest(
+            identifier: UUID().uuidString,
+            content: content,
+            trigger: nil
+        )
+        UNUserNotificationCenter.current().add(request) { [self] error in
+            if let error = error {
+                logger.error("❌ Failed to post link-copied notification: \(error.localizedDescription)")
+            }
         }
     }
 }

--- a/SyncExtension/UseCases/All/CopyInternxtLinkUseCase.swift
+++ b/SyncExtension/UseCases/All/CopyInternxtLinkUseCase.swift
@@ -141,18 +141,28 @@ struct CopyInternxtLinkUseCase {
     }
 
 
-    @MainActor
     private func copyToClipboard(_ text: String) {
-        NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(text, forType: .string)
-        
-        let alert = NSAlert()
-        alert.messageText = "Link copied"
-        alert.alertStyle = .informational
-        alert.addButton(withTitle: "OK")
-        
-        NSApp.activate(ignoringOtherApps: true)
-        alert.runModal()
+        DispatchQueue.main.async {
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(text, forType: .string)
+        }
+        Task.detached {
+            var response: CFOptionFlags = 0
+            
+            CFUserNotificationDisplayAlert(
+                4,
+                kCFUserNotificationNoteAlertLevel,
+                nil,
+                nil,
+                nil,
+                "Link copied" as CFString,
+                nil,
+                "OK" as CFString,
+                nil,
+                nil,
+                &response
+            )
+        }
     }
 }
 


### PR DESCRIPTION
This Pull Request fixes a bug where users could successfully copy an Internxt share link the first time, but subsequent attempts to copy links from other files would completely fail. Additionally, this issue caused ongoing network uploads and general extension interactions to freeze.

When a user clicked "Copy Internxt Link", the system displayed a confirmation dialog using NSAlert.runModal(). Because this function is synchronous and blocks the `@MainActor`, it held the FileProvider extension's main execution queue hostage until the user explicitly clicked "OK". If the alert was left open or ignored, any subsequent attempts to copy a link (or upload files) queued up indefinitely behind the blocked thread, making it impossible to copy new links and causing macOS helper communication timeouts.

Switched from AppKit's NSAlert to CoreFoundation's system-level daemon alert API. This renders the alert reliably on top of all desktop windows without relying on an active AppKit UI thread.