### PR TITLE
Authentication race condition on re-login and noisy logs

### DIFF
--- a/InternxtDesktop/AppDelegate.swift
+++ b/InternxtDesktop/AppDelegate.swift
@@ -479,10 +479,7 @@ class AppDelegate: NSObject, NSApplicationDelegate , PKPushRegistryDelegate {
         } catch {
             error.reportToSentry()
         }
-        
-        Task {
-            await domainManager.exitDomain()
-        }
+        domainManager.scheduleExitDomain()
         
     }
     

--- a/InternxtDesktop/Services/Auth/AuthManager.swift
+++ b/InternxtDesktop/Services/Auth/AuthManager.swift
@@ -69,9 +69,9 @@ class AuthManager: ObservableObject {
             let credentials = try await APIFactory.DriveNew.getCredentialsWorkspaces(workspaceId: workspaces.availableWorkspaces[0].workspaceUser.workspaceId)
                 try config.setWorkspaceCredentials(credentials: credentials)
             saveWorkspaceMnemonic(key: workspaces.availableWorkspaces[0].workspaceUser.key)
-            DispatchQueue.main.async{ self.workspaceCredentials = credentials}
+            await MainActor.run { self.workspaceCredentials = credentials }
         }
-        DispatchQueue.main.async{
+        await MainActor.run {
             self.user = refreshUserResponse.user
             self.availableWorkspaces = workspaces.availableWorkspaces
         }
@@ -87,7 +87,8 @@ class AuthManager: ObservableObject {
             let credentials = try await APIFactory.DriveNew.getCredentialsWorkspaces(workspaceId: workspaces.availableWorkspaces[0].workspaceUser.workspaceId)
                 try config.setWorkspaceCredentials(credentials: credentials)
             saveWorkspaceMnemonic(key: workspaces.availableWorkspaces[0].workspaceUser.key)
-            DispatchQueue.main.async{ self.workspaceCredentials = credentials
+            await MainActor.run { 
+                self.workspaceCredentials = credentials
                 self.availableWorkspaces = workspaces.availableWorkspaces
             }
         }
@@ -128,6 +129,7 @@ class AuthManager: ObservableObject {
         try config.removeWorkspaces()
         try config.removeWorkspaceCredentials()
         try config.removeWorkspaceMnemonicInfo()
+        try config.removeUser()
         user = nil
         isLoggedIn = false
         self.logger.info("Auth details removed correctly, user is logged out")

--- a/InternxtDesktop/Services/FileProviderDomainManager.swift
+++ b/InternxtDesktop/Services/FileProviderDomainManager.swift
@@ -39,7 +39,7 @@ class FileProviderDomainManager: ObservableObject {
             let existingDomains = (try? await NSFileProviderManager.domains()) ?? []
             if let stale = existingDomains.first(where: { $0.identifier == identifier }) {
                 self.logger.info("⚠️ Stale domain found for \(identifier.rawValue), removing before re-adding")
-                try? await NSFileProviderManager.remove(stale)
+                try? await NSFileProviderManager.remove(stale, mode: .preserveDirtyUserData)
             }
 
             try await NSFileProviderManager.add(domain)

--- a/InternxtDesktop/Services/FileProviderDomainManager.swift
+++ b/InternxtDesktop/Services/FileProviderDomainManager.swift
@@ -22,17 +22,26 @@ class FileProviderDomainManager: ObservableObject {
     lazy var manager: NSFileProviderManager? = nil
     var managerDomain: NSFileProviderDomain? = nil
     @Published var domainStatus: FileProviderDomainStatus = .Idle
+    private var exitDomainTask: Task<Void, Never>? = nil
     
     private func getDomains() async throws -> [NSFileProviderDomain] {
         try await NSFileProviderManager.domains()
     }
     
     public func initFileProviderForUser(user: DriveUser) async throws {
+        await exitDomainTask?.value
+
         do {
             self.updateStatus(newStatus: .Initializing)
             let identifier = NSFileProviderDomainIdentifier(rawValue: user.uuid)
             let domain = NSFileProviderDomain(identifier: identifier, displayName: "")
-            
+            // Remove any pre-existing domain with the same identifier
+            let existingDomains = (try? await NSFileProviderManager.domains()) ?? []
+            if let stale = existingDomains.first(where: { $0.identifier == identifier }) {
+                self.logger.info("⚠️ Stale domain found for \(identifier.rawValue), removing before re-adding")
+                try? await NSFileProviderManager.remove(stale)
+            }
+
             try await NSFileProviderManager.add(domain)
                     
             self.manager = NSFileProviderManager(for: domain)
@@ -52,7 +61,17 @@ class FileProviderDomainManager: ObservableObject {
     }
     
     
+    public func scheduleExitDomain() {
+        exitDomainTask = Task {
+            await exitDomainInternal()
+        }
+    }
+
     public func exitDomain() async {
+        await exitDomainInternal()
+    }
+
+    private func exitDomainInternal() async {
         self.logger.info("🧹 Cleaning up FileProvider domain")
         do {
             let activeDomains = try await NSFileProviderManager.domains()
@@ -70,6 +89,7 @@ class FileProviderDomainManager: ObservableObject {
         }
         self.manager = nil
         self.managerDomain = nil
+        exitDomainTask = nil
     }
     
     

--- a/SyncExtension/UseCases/Files/UploadFileOrUpdateContentUseCase.swift
+++ b/SyncExtension/UseCases/Files/UploadFileOrUpdateContentUseCase.swift
@@ -62,7 +62,11 @@ struct UploadFileOrUpdateContentUseCase {
             return try await self.driveNewAPI.getFileInFolderByPlainName(folderId: folderIdInt, plainName: filename.deletingPathExtension, type:filename.pathExtension)
             
         } catch {
-            error.reportToSentry()
+            if let apiClientError = error as? APIClientError, apiClientError.statusCode == 404 {
+                // Ignore 404 errors to avoid noise logs
+            } else {
+                error.reportToSentry()
+            }
             return nil
         }
         


### PR DESCRIPTION
Fixed a bug where logging out and re-logging in would fail to start the FileProvider extension. Users had to manually restart the app to see the Internxt folder in Finder.

This was caused by a race condition (AuthError error 3 / noUserFound) where the extension was initialized before the new user credentials were fully loaded.

Changes:

AuthManager: Used await MainActor.run to ensure user initialization is synchronous and added removeUser() on signOut to clear stale data.
FileProviderDomainManager: Ensured the app waits for the previous domain teardown to complete before registering a new one on re-login.
UploadFileOrUpdateContentUseCase: Removed 404 errors from Sentry when checking if a file already exists, as this is expected behavior for new uploads and caused unnecessary log noise.