### PR TITLE
Fix Persistent Backup Failure on Stale Folder 404

### DIFF
--- a/Shared/Services/Backups/BackupsService.swift
+++ b/Shared/Services/Backups/BackupsService.swift
@@ -298,13 +298,13 @@ class BackupsService: ObservableObject {
                 logger.info("Added current device \(currentDeviceName)")
             }
         } catch {
-            error.reportToSentry()
+          
             guard let apiError = error as? APIClientError else {
                 return logger.error("Error adding device \(error)")
             }
             
-            if(apiError.statusCode == 409) {
-                logger.info("Device already registered, received a 409 status code from backend while registering the device")
+            if(apiError.statusCode != 409) {
+                error.reportToSentry()
             }
             
             

--- a/XPCBackupService/Services/BackupUploadService.swift
+++ b/XPCBackupService/Services/BackupUploadService.swift
@@ -175,6 +175,11 @@ class BackupUploadService:  BackupUploadServiceProtocol, ObservableObject {
         } catch {
             self.logger.error("❌ Failed to create folder: \(error.getErrorDescription())")
 
+            if let apiClientError = error as? APIClientError, apiClientError.statusCode == 404 {
+                self.logger.error("❌ Folder parent \(safeRemoteParentId) not found in server . Deleting local reference from Realm")
+                try? await SyncedNodeRepository.shared.deleteSyncedNodeByRemoteIdAsync(remoteId: safeRemoteParentId)
+                return .failure(BackupUploadError.MissingParentFolder)
+            }
 
             if let apiClientError = error as? APIClientError, apiClientError.statusCode == 409 {
                 // Handle duplicated folder error
@@ -357,9 +362,21 @@ class BackupUploadService:  BackupUploadServiceProtocol, ObservableObject {
                 }
             }
 
-            
             if encryptedContentURL != nil {
                 try? FileManager.default.removeItem(at: encryptedContentURL!)
+            }
+
+            var is404 = false
+            if let apiClientError = error as? APIClientError, apiClientError.statusCode == 404 {
+                is404 = true
+            } else if let startUploadError = error as? StartUploadError, let apiClientError = startUploadError.apiError, apiClientError.statusCode == 404 {
+                is404 = true
+            }
+
+            if is404 {
+                self.logger.error("❌ Folder parent \(remoteParentId) not found in server (404). Deleting local reference from Realm so it can be re-created.")
+                try? await SyncedNodeRepository.shared.deleteSyncedNodeByRemoteIdAsync(remoteId: remoteParentId)
+                return .failure(BackupUploadError.MissingParentFolder)
             }
 
             if let apiClientError = error as? APIClientError, apiClientError.statusCode == 409 {

--- a/XPCBackupService/Services/SyncedNodeRepository.swift
+++ b/XPCBackupService/Services/SyncedNodeRepository.swift
@@ -16,6 +16,7 @@ protocol SyncedNodeRepositoryProtocol: GenericRepositoryProtocol {
     func findSyncedNode(url: URL, deviceId: Int) -> SyncedNode?
     func editSyncedNodeDate(remoteUuid: String, date: Date) throws
     func editSyncedNodeDateAsync(remoteUuid: String, date: Date) async throws
+    func deleteSyncedNodeByRemoteIdAsync(remoteId: Int) async throws
     func resolveSyncedNode(reference: ThreadSafeReference<SyncedNode>) -> SyncedNode?
 }
 
@@ -210,6 +211,23 @@ final class SyncedNodeRepository : SyncedNodeRepositoryProtocol {
                     
                     try realm.write {
                         node.updatedAt = date
+                    }
+                    continuation.resume()
+                } catch {
+                    continuation.resume(throwing: BackupUploadError.CannotEditNodeToRealm)
+                }
+            }
+        }
+    }
+    
+    func deleteSyncedNodeByRemoteIdAsync(remoteId: Int) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            realmQueue.async { [self] in
+                do {
+                    let realm = try getRealm()
+                    let nodes = realm.objects(SyncedNode.self).filter("remoteId == %@", remoteId)
+                    try realm.write {
+                        realm.delete(nodes)
                     }
                     continuation.resume()
                 } catch {

--- a/XPCBackupServiceTests/Backups/Mocks/MockBackupRealm.swift
+++ b/XPCBackupServiceTests/Backups/Mocks/MockBackupRealm.swift
@@ -36,21 +36,19 @@ class MockBackupRealm: SyncedNodeRepositoryProtocol {
         }
     }
     
-    func findSyncedNode(url: URL, deviceId: Int) -> ThreadSafeReference<SyncedNode>? {
-        do{
+    func addSyncedNodeAsync(_ node: SyncedNode) async throws {
+        try addSyncedNode(node)
+    }
+    
+    func findSyncedNode(url: URL, deviceId: Int) -> SyncedNode? {
+        do {
             let realm = try getRealm()
-            let syncedNode = realm?.objects(SyncedNode.self).first { syncedNode in
+            return realm?.objects(SyncedNode.self).first { syncedNode in
                 url.absoluteString == syncedNode.url && deviceId == syncedNode.deviceId
             }
-            if let syncedNode = syncedNode {
-                return ThreadSafeReference(to: syncedNode)
-            }
+        } catch {
             return nil
         }
-        catch {
-            return nil
-        }
-        
     }
     
     func editSyncedNodeDate(remoteUuid: String, date: Date) throws {
@@ -59,6 +57,17 @@ class MockBackupRealm: SyncedNodeRepositoryProtocol {
         }
         try inMemoryRealm.write {
             node.updatedAt = date
+        }
+    }
+    
+    func editSyncedNodeDateAsync(remoteUuid: String, date: Date) async throws {
+        try editSyncedNodeDate(remoteUuid: remoteUuid, date: date)
+    }
+    
+    func deleteSyncedNodeByRemoteIdAsync(remoteId: Int) async throws {
+        let nodes = inMemoryRealm.objects(SyncedNode.self).filter("remoteId == %@", remoteId)
+        try inMemoryRealm.write {
+            inMemoryRealm.delete(nodes)
         }
     }
     


### PR DESCRIPTION
This PR fixes a persistent backup failure that occurs when a folder is deleted from the web app, leaving a stale remote ID in the desktop app's local database.
If a 404 Not Found error is encountered during folder or file sync, the app now reactively deletes the stale folder entry from the local Realm database. This ensures the missing folder is cleanly recreated in the cloud during the next backup session.
Additionally, this PR removes a noisy log generated during backup device creation that was causing unnecessary log noise.