### PR TITLE
feat: Basic Network Connection Status Indicator

### DIFF
--- a/InternxtDesktop.xcodeproj/project.pbxproj
+++ b/InternxtDesktop.xcodeproj/project.pbxproj
@@ -144,6 +144,8 @@
 		AAAD0DA02CE12D71003F27BB /* GetFileOrFolderMetaWorkspaceUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAD0D9F2CE12D71003F27BB /* GetFileOrFolderMetaWorkspaceUseCase.swift */; };
 		AAAD0DA22CE17457003F27BB /* RenameFileWorkspaceUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAD0DA12CE17457003F27BB /* RenameFileWorkspaceUseCase.swift */; };
 		AAAD0DA42CE18678003F27BB /* TrashFileWorkspaceUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAD0DA32CE18678003F27BB /* TrashFileWorkspaceUseCase.swift */; };
+		AAAEF87D2FC78A7F006B0F24 /* NetworkStatusMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAEF87C2FC78A7F006B0F24 /* NetworkStatusMessage.swift */; };
+		AAAEF8802FC78AAA006B0F24 /* NetworkStatusChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAEF87F2FC78AAA006B0F24 /* NetworkStatusChecker.swift */; };
 		AAC188E62C222EB3007E321A /* InternxtSwiftCore in Frameworks */ = {isa = PBXBuildFile; productRef = AAC188E52C222EB3007E321A /* InternxtSwiftCore */; };
 		AAC188E92C222EFF007E321A /* DecryptUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31ED949C2B7151E200EF699F /* DecryptUtils.swift */; };
 		AAC188EA2C222F1F007E321A /* XPCBackupService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31DEAEB02B75139400E76D53 /* XPCBackupService.swift */; };
@@ -576,6 +578,8 @@
 		AAAD0D9F2CE12D71003F27BB /* GetFileOrFolderMetaWorkspaceUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetFileOrFolderMetaWorkspaceUseCase.swift; sourceTree = "<group>"; };
 		AAAD0DA12CE17457003F27BB /* RenameFileWorkspaceUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenameFileWorkspaceUseCase.swift; sourceTree = "<group>"; };
 		AAAD0DA32CE18678003F27BB /* TrashFileWorkspaceUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrashFileWorkspaceUseCase.swift; sourceTree = "<group>"; };
+		AAAEF87C2FC78A7F006B0F24 /* NetworkStatusMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkStatusMessage.swift; sourceTree = "<group>"; };
+		AAAEF87F2FC78AAA006B0F24 /* NetworkStatusChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkStatusChecker.swift; sourceTree = "<group>"; };
 		AAC188EE2C2231B1007E321A /* MockBackupRealm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBackupRealm.swift; sourceTree = "<group>"; };
 		AAC188F02C2231E7007E321A /* MockBackupUploadService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBackupUploadService.swift; sourceTree = "<group>"; };
 		AACC83A32F7E06770084FFB6 /* ClamAVDatabaseService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClamAVDatabaseService.swift; sourceTree = "<group>"; };
@@ -976,6 +980,14 @@
 			path = Workspaces;
 			sourceTree = "<group>";
 		};
+		AAAEF87E2FC78A8E006B0F24 /* Network */ = {
+			isa = PBXGroup;
+			children = (
+				AAAEF87F2FC78AAA006B0F24 /* NetworkStatusChecker.swift */,
+			);
+			path = Network;
+			sourceTree = "<group>";
+		};
 		AAC188ED2C223183007E321A /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
@@ -1332,6 +1344,7 @@
 				E18300AD2AA230A600AD023C /* WidgetSyncEntryView.swift */,
 				31EBEF722B32006F0017590F /* WidgetBackupBannerView.swift */,
 				E1EEB5902C21963400370D77 /* WidgetBackupDownloadEntryView.swift */,
+				AAAEF87C2FC78A7F006B0F24 /* NetworkStatusMessage.swift */,
 			);
 			path = Widget;
 			sourceTree = "<group>";
@@ -1410,6 +1423,7 @@
 		E1FB2D522A76C01B00473AE1 /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				AAAEF87E2FC78A8E006B0F24 /* Network */,
 				E17AA0222A8A70C100C7EE6E /* Auth */,
 				E16310562A8E66F70072989E /* URLDictionary.swift */,
 				E18300A12AA161ED00AD023C /* FileProviderDomainManager.swift */,
@@ -1929,6 +1943,7 @@
 				E17C84B02AB225CD00A58414 /* WelcomeSlideView.swift in Sources */,
 				E1A0AC772AB8AAFE005E71D6 /* ThumbnailGenerator.swift in Sources */,
 				31DEAEC22B7514F400E76D53 /* XPCBackupServiceProtocol.swift in Sources */,
+				AAAEF8802FC78AAA006B0F24 /* NetworkStatusChecker.swift in Sources */,
 				E17C84CA2AB31E0400A58414 /* OnboardingFinishView.swift in Sources */,
 				E18300A22AA161ED00AD023C /* FileProviderDomainManager.swift in Sources */,
 				AA94CA6E2E99E8CE007CEBDF /* NotificationsManager.swift in Sources */,
@@ -1952,6 +1967,7 @@
 				AA628F2A2D4BF73000421CB7 /* OnboardingSlide6View.swift in Sources */,
 				AA9B1BA12FB4094D000E582A /* FileSizeLimitDialogView.swift in Sources */,
 				AA40B3BD2D3B298600FC1FC3 /* AntivirusTabView.swift in Sources */,
+				AAAEF87D2FC78A7F006B0F24 /* NetworkStatusMessage.swift in Sources */,
 				AA93BEBA2E720E8200F12334 /* CleaningView.swift in Sources */,
 				AAA666682D402F2900C2B9DF /* CustomModalView.swift in Sources */,
 				AA919D762E4FCC0600287FAE /* CleanupView.swift in Sources */,

--- a/InternxtDesktop/AppDelegate.swift
+++ b/InternxtDesktop/AppDelegate.swift
@@ -29,7 +29,13 @@ extension AppDelegate: NSPopoverDelegate {
     }
 }
 
-class AppDelegate: NSObject, NSApplicationDelegate , PKPushRegistryDelegate {
+class NetworkStatusObservable: ObservableObject {
+    @Published var networkStatus: NetworkStatus = .unknown
+}
+
+class AppDelegate: NSObject, NSApplicationDelegate , PKPushRegistryDelegate, NetworkStatusCheckerDelegate, UNUserNotificationCenterDelegate {
+    let notificationsCenter = UNUserNotificationCenter.current()
+    let networkStatusChecker = NetworkStatusChecker()
     let logger = LogService.shared.createLogger(subsystem: .InternxtDesktop, category: "App")
     let config = ConfigLoader()
     private let updaterController = SPUStandardUpdaterController(startingUpdater: true, updaterDelegate: nil, userDriverDelegate: nil)
@@ -59,6 +65,9 @@ class AppDelegate: NSObject, NSApplicationDelegate , PKPushRegistryDelegate {
     var notificationsTimer: AnyCancellable?
     let fileSizeLimitState = FileSizeLimitState()
     var usageUpdateDebouncer = Debouncer(delay: 15.0)
+    var networkStatusCheckTimer: Timer? = nil
+    let networkStatusCheckTestURL =  URL(string: "https://link.testfile.org/15MB")!
+    let networkStatusObservable = NetworkStatusObservable()
     private let driveNewAPI: DriveAPI = APIFactory.DriveNew
     private let notificationsPollingInterval: TimeInterval = 30 * 60
     
@@ -68,7 +77,9 @@ class AppDelegate: NSObject, NSApplicationDelegate , PKPushRegistryDelegate {
     
     override init() {
         super.init()
+        self.notificationsCenter.delegate = self
         self.scheduledManager = ScheduledBackupManager(backupsService: backupsService)
+        self.setupNetworkStatusChecker()
         self.requestNotificationsPermissions()
     }
     
@@ -545,6 +556,7 @@ class AppDelegate: NSObject, NSApplicationDelegate , PKPushRegistryDelegate {
                 .environmentObject(self.backupsService)
                 .environmentObject(self.domainManager)
                 .environmentObject(self.antivirusManager)
+                .environmentObject(self.networkStatusObservable)
         )
     }
     
@@ -666,7 +678,7 @@ class AppDelegate: NSObject, NSApplicationDelegate , PKPushRegistryDelegate {
         } else {
             display()
         }
-       
+        self.networkStatusChecker.startTest(url: self.networkStatusCheckTestURL)
         usageUpdateDebouncer.debounce { [weak self] in
             self?.updateUsage()
         }
@@ -761,4 +773,28 @@ class AppDelegate: NSObject, NSApplicationDelegate , PKPushRegistryDelegate {
         logger.info("========================================")
     }
 
+    func callWhileNetworkStatusChange(networkStatus: NetworkStatus) {
+         
+        if self.networkStatusObservable.networkStatus != networkStatus {
+            self.logger.info("🛜 Network status changed \(self.networkStatusObservable.networkStatus.rawValue) -> \(networkStatus.rawValue)")
+            DispatchQueue.main.async {
+                self.networkStatusObservable.networkStatus = networkStatus
+            }
+        }
+    }
+    
+    func setupNetworkStatusChecker() {
+        self.networkStatusChecker.delegate = self
+        self.logger.info("🛜 Setting up network status check test")
+        
+        self.networkStatusChecker.startTest(url:  networkStatusCheckTestURL)
+        
+        DispatchQueue.main.async {
+            self.networkStatusCheckTimer = Timer.scheduledTimer(timeInterval: 60 * 5, target: self, selector: #selector(self.runNetworkStatusTest), userInfo: nil, repeats: true)
+        }
+    }
+    
+    @objc func runNetworkStatusTest() {
+        self.networkStatusChecker.startTest(url: self.networkStatusCheckTestURL)
+    }
 }

--- a/InternxtDesktop/Services/Network/NetworkStatusChecker.swift
+++ b/InternxtDesktop/Services/Network/NetworkStatusChecker.swift
@@ -1,0 +1,94 @@
+//
+//  NetworkStatusChecker.swift
+//  InternxtDesktop
+//
+//  Created by Robert Garcia on 7/8/24.
+//
+
+import Foundation
+
+
+public enum NetworkStatus:String {
+    case unknown;
+    case poor;
+    case good;
+    case notConnected
+}
+
+protocol NetworkStatusCheckerDelegate: AnyObject {
+    func callWhileNetworkStatusChange(networkStatus: NetworkStatus)
+}
+
+class NetworkStatusChecker: NSObject {
+    
+    var testURL: URL?
+    weak var delegate: NetworkStatusCheckerDelegate?
+    private var startTime = CFAbsoluteTime()
+    private var stopTime = CFAbsoluteTime()
+    private var bytesReceived: CGFloat = 0
+    var speedTestCompletionHandler: ((_ megabytesPerSecond: CGFloat, _ error: Error?) -> Void)? = nil    
+    
+    func startTest(url: URL){
+        testURL = url
+        self.testForSpeed()
+    }
+
+    func networkStatusChange(networkStatus: NetworkStatus) {
+        self.delegate?.callWhileNetworkStatusChange(networkStatus: networkStatus)
+    }
+    
+    @objc func testForSpeed()
+    {
+        testDownloadSpeed(withTimout: 2.0, completionHandler: {(_ megabytesPerSecond: CGFloat, _ error: Error?) -> Void in
+            print("%0.1f; KbPerSec = \(megabytesPerSecond)")
+            if (error as NSError?)?.code == -1009 {
+                self.networkStatusChange(networkStatus: .notConnected)
+                
+            }
+            else if megabytesPerSecond == -1.0 {
+                self.networkStatusChange(networkStatus: .poor)
+            }
+            else {
+                self.networkStatusChange(networkStatus: .good)
+            }
+        })
+    }
+}
+
+extension NetworkStatusChecker: URLSessionDataDelegate, URLSessionDelegate {
+    
+    func testDownloadSpeed(withTimout timeout: TimeInterval, completionHandler: @escaping (_ megabytesPerSecond: CGFloat, _ error: Error?) -> Void) {
+        
+        // you set any relevant string with any file
+        let urlForSpeedTest = testURL
+        
+        startTime = CFAbsoluteTimeGetCurrent()
+        stopTime = startTime
+        bytesReceived = 0
+        speedTestCompletionHandler = completionHandler
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.timeoutIntervalForResource = timeout
+        let session = URLSession(configuration: configuration, delegate: self, delegateQueue: nil)
+        
+        guard let checkedUrl = urlForSpeedTest else { return }
+        
+        session.dataTask(with: checkedUrl).resume()
+    }
+    
+    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+        bytesReceived += CGFloat(data.count)
+        stopTime = CFAbsoluteTimeGetCurrent()
+    }
+    
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        let elapsed = (stopTime - startTime) //as? CFAbsoluteTime
+        let speed: CGFloat = elapsed != 0 ? bytesReceived / (CGFloat(CFAbsoluteTimeGetCurrent() - startTime)) / 1024.0 : -1.0
+        // treat timeout as no error (as we're testing speed, not worried about whether we got entire resource or not
+        if error == nil || ((((error as NSError?)?.domain) == NSURLErrorDomain) && (error as NSError?)?.code == NSURLErrorTimedOut) {
+            speedTestCompletionHandler?(speed, nil)
+        }
+        else {
+            speedTestCompletionHandler?(speed, error)
+        }
+    }
+}

--- a/InternxtDesktop/Views/UIKit/AppIcon.swift
+++ b/InternxtDesktop/Views/UIKit/AppIcon.swift
@@ -23,6 +23,8 @@ enum AppIconName: String {
     case WarningCircle = "EDBF"
     case Shield = "ECD5"
     case Cleaner = "ED2B"
+    case WifiMedium = "EDD3"
+    case WifiNone = "EDD5"
 }
 
 

--- a/InternxtDesktop/Views/Widget/NetworkStatusMessage.swift
+++ b/InternxtDesktop/Views/Widget/NetworkStatusMessage.swift
@@ -1,0 +1,68 @@
+//
+//  NetworkStatusMessage.swift
+//  InternxtDesktop
+//
+//  Created by Robert Garcia on 8/8/24.
+//
+
+import SwiftUI
+
+struct NetworkStatusMessage: View {
+    @Binding var status: NetworkStatus
+    @Environment(\.colorScheme) var colorScheme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            
+            HStack(alignment: .center, spacing: 0) {
+                DisplayStatus()
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 0)
+            .frame(maxWidth: .infinity, minHeight: 40, maxHeight: 40, alignment: .leading)
+        }.background(Color.Gray5)
+    }
+    
+    func DisplayStatus() -> some View {
+        
+        
+        return HStack(alignment: .center, spacing: 8){
+            ZStack {
+                //Circle().foregroundColor(.Gray10).frame(height: 22 )
+                if status == .notConnected {
+                    AppIcon(iconName: .WifiNone, size: 20, color: .Gray40)
+                }
+                
+                if status == .poor {
+                    AppIcon(iconName: .WifiMedium, size: 20, color: .Gray40)
+                }
+            }.padding(2)
+            
+            if status == .notConnected {
+                VStack(alignment: .leading) {
+                    AppText("NETWORK_CONNECTION_NONE_TITLE").font(.XSMedium)
+                    AppText("NETWORK_CONNECTION_NONE_SUBTITLE").font(.XSRegular).foregroundColor(.Gray50)
+                }
+                
+            }
+            
+            if status == .poor {
+                VStack(alignment: .leading) {
+                    AppText("NETWORK_CONNECTION_SLOW_TITLE").font(.XSMedium)
+                    AppText("NETWORK_CONNECTION_SLOW_SUBTITLE").font(.XSRegular).foregroundColor(.Gray50)
+                }
+                
+            }
+            
+            
+        }
+    }
+}
+
+#Preview {
+    VStack {
+        NetworkStatusMessage(status: .constant(.notConnected))
+        NetworkStatusMessage(status: .constant(.poor))
+    }
+    
+}

--- a/InternxtDesktop/Views/Widget/WidgetView.swift
+++ b/InternxtDesktop/Views/Widget/WidgetView.swift
@@ -18,6 +18,7 @@ struct WidgetView: View {
     @EnvironmentObject var backupsService: BackupsService
     @EnvironmentObject var domainManager: FileProviderDomainManager
     @EnvironmentObject var antivirusManager: AntivirusManager
+    @EnvironmentObject var networkStatusObservable: NetworkStatusObservable
     
     @State private var showBackupBanner = false
     var isEmpty: Bool = true
@@ -103,6 +104,9 @@ struct WidgetView: View {
                             WidgetContentView(activityEntries: $activityManager.activityEntries).environmentObject(backupsService)
                         }
                     }.frame(maxWidth: .infinity,maxHeight: .infinity)
+                    if self.networkStatusObservable.networkStatus != NetworkStatus.good {
+                        NetworkStatusMessage(status: self.$networkStatusObservable.networkStatus)
+                    }
                     WidgetFooterView(isSyncing: $activityManager.isSyncing)
                 } else {
                     Spacer()
@@ -111,7 +115,7 @@ struct WidgetView: View {
                 }
                 
             }
-            .frame(width: 330, height: 400)
+            .frame(width: 330, height: 440)
             .background(Color.Surface)
             .cornerRadius(10)
         }

--- a/Shared/en.lproj/Localizable.strings
+++ b/Shared/en.lproj/Localizable.strings
@@ -102,6 +102,12 @@
 "BACKUP_DOWNLOAD_IN_PROGRESS_ALERT_TITLE" = "Backup download in progress";
 "BACKUP_DOWNLOAD_IN_PROGRESS_ALERT_MESSAGE" = "A backup download is already in progress, please wait until it is finished.";
 
+// NETWORK STATUS
+"NETWORK_CONNECTION_SLOW_TITLE" = "Weak connection.";
+"NETWORK_CONNECTION_SLOW_SUBTITLE" = "Your experience may be slow or interrupted.";
+"NETWORK_CONNECTION_NONE_TITLE" = "No internet connection.";
+"NETWORK_CONNECTION_NONE_SUBTITLE" = "Please check your connection and try again.";
+
 // Settings
 "SETTINGS_TAB_GENERAL_TITLE" = "General";
 "SETTINGS_TAB_ACCOUNT_TITLE" = "Account";

--- a/Shared/es.lproj/Localizable.strings
+++ b/Shared/es.lproj/Localizable.strings
@@ -86,7 +86,7 @@
 
 // Network status
 "NETWORK_CONNECTION_SLOW_TITLE" = "Conexión débil.";
-"NETWORK_CONNECTION_SLOW_SUBTITLE" = "Tu experiencia puede ser lenta o interrumpida";
+"NETWORK_CONNECTION_SLOW_SUBTITLE" = "Tu experiencia puede ser lenta o verse interrumpida";
 "NETWORK_CONNECTION_NONE_TITLE" = "Sin conexión a internet.";
 "NETWORK_CONNECTION_NONE_SUBTITLE" = "Por favor, revisa tu conexión e inténtalo de nuevo.";
 

--- a/Shared/es.lproj/Localizable.strings
+++ b/Shared/es.lproj/Localizable.strings
@@ -84,6 +84,11 @@
 "BACKUP_DOWNLOAD_IN_PROGRESS_ALERT_TITLE" = "Descarga de Backup ya en progreso";
 "BACKUP_DOWNLOAD_IN_PROGRESS_ALERT_MESSAGE" = "Ya hay una descarga de un Backup en progreso, debes esperar hasta que finalice";
 
+// Network status
+"NETWORK_CONNECTION_SLOW_TITLE" = "Conexión débil.";
+"NETWORK_CONNECTION_SLOW_SUBTITLE" = "Tu experiencia puede ser lenta o interrumpida";
+"NETWORK_CONNECTION_NONE_TITLE" = "Sin conexión a internet.";
+"NETWORK_CONNECTION_NONE_SUBTITLE" = "Por favor, revisa tu conexión e inténtalo de nuevo.";
 
 // Settings
 "SETTINGS_TAB_GENERAL_TITLE" = "General";

--- a/Shared/fr.lproj/Localizable.strings
+++ b/Shared/fr.lproj/Localizable.strings
@@ -82,6 +82,11 @@
 "BACKUP_DOWNLOAD_IN_PROGRESS_ALERT_TITLE" = "Le téléchargement de la sauvegarde est déjà en cours";
 "BACKUP_DOWNLOAD_IN_PROGRESS_ALERT_MESSAGE" = "Un téléchargement de sauvegarde est déjà en cours, veuillez patienter jusqu'à ce qu'il soit terminé" ;
 
+// Network status
+"NETWORK_CONNECTION_SLOW_TITLE" = "Connexion faible.";
+"NETWORK_CONNECTION_SLOW_SUBTITLE" = "Votre expérience peut être lente ou interrompue.";
+"NETWORK_CONNECTION_NONE_TITLE" = "Pas de connexion Internet.";
+"NETWORK_CONNECTION_NONE_SUBTITLE" = "Veuillez vérifier votre connexion et réessayer.";
 
 // Settings
 "SETTINGS_TAB_GENERAL_TITLE" = "Général";


### PR DESCRIPTION
This PR cleanly integrates the "Network Quality Watcher" feature originally proposed in PR #90, avoiding direct cherry-picking to prevent merge conflicts with the current release branch. 
It introduces a background network monitor that displays a visual warning banner in the Internxt Widget if the user's internet connection is slow, unstable, or offline.
**Key Changes:**
- **Service:** Added `NetworkStatusChecker` to periodically test connection speed and reliability.
- **UI:** Implemented `NetworkStatusMessage` banner in `WidgetView` to alert users of poor connections.
- **Lifecycle:** Updated `AppDelegate` to poll network status every 5 minutes in the background, and immediately upon opening the widget popover.
- **Localization & Assets:** Added alert translations (EN, ES, FR) and required Wi-Fi icons.