### PR TITLE
Fix Stale Local Backup Cache & Enrich Error Diagnostics

### DIFF
--- a/Shared/Extensions/Error.swift
+++ b/Shared/Extensions/Error.swift
@@ -15,6 +15,18 @@ extension Error {
     }
     
     func getErrorDescription() -> String {
+        if let enrichedError = self as? EnrichedError {
+            var parts = ["[\(enrichedError.code.rawValue)]", "Step: \(enrichedError.step.rawValue)"]
+            if !enrichedError.context.isEmpty {
+                let contextStr = enrichedError.context.map { "\($0.key): \($0.value)" }.joined(separator: ", ")
+                parts.append("| \(contextStr)")
+            }
+            if let cause = enrichedError.cause {
+                parts.append("| Cause: \(cause.getErrorDescription())")
+            }
+            return parts.joined(separator: " ")
+        }
+        
         if let apiClientError = self as? APIClientError {
             let parts = [
                 "APIClientError \(apiClientError.statusCode)",

--- a/Shared/Models/SyncedNode.swift
+++ b/Shared/Models/SyncedNode.swift
@@ -34,7 +34,7 @@ class SyncedNode: Object {
         self.remoteId = remoteId
         self.remoteUuid = remoteUuid
         self.url = url.absoluteString
-        self.rootBackupFolder = url.absoluteString
+        self.rootBackupFolder = rootBackupFolder.absoluteString
         self.parentId = parentId
         self.remoteParentId = remoteParentId
         self.createdAt = Date()

--- a/Shared/Services/Backups/BackupsService.swift
+++ b/Shared/Services/Backups/BackupsService.swift
@@ -134,6 +134,8 @@ class BackupsService: ObservableObject {
                 throw BackupError.folderToBackupRealmObjectNotFound
             }
             
+            let folderUrl = folderToBackupRealmObject.url
+            
             try realm.write {
                 realm.delete(folderToBackupRealmObject)
             }
@@ -141,7 +143,7 @@ class BackupsService: ObservableObject {
             
             self.loadFoldersToBackup()
             
-            //try await self.cleanBackupLocalData(folderUrl: folderToBackupRealmObject.url, realm: realm)
+            try self.cleanBackupLocalData(folderUrl: folderUrl)
             //try await backupAPI.deleteBackupFolder(folderId: folderToBackupRealmObject.id, debug: true)
             
             await self.loadAllDevices()
@@ -366,16 +368,12 @@ class BackupsService: ObservableObject {
         return true
     }
 
-    @MainActor private func cleanBackupLocalData(folderUrl: String, realm: Realm) async throws -> Void {
-        // TODO: Make sure we clean all the RealmDB local data
-        /* guard let syncedNode = realm.objects(SyncedNode.self).first(where: { node in
-            node.url == folderUrl
-        }) else {
-            
-            return true
+    private func cleanBackupLocalData(folderUrl: String) throws -> Void {
+        let realm = getRealm()
+        let syncedNodesToDelete = realm.objects(SyncedNode.self).filter("url BEGINSWITH[c] %@", folderUrl)
+        try realm.write {
+            realm.delete(syncedNodesToDelete)
         }
-
-        return false */
     }
 
     func getDeviceFolders(deviceId: Int) async throws -> [GetFolderFoldersResult] {


### PR DESCRIPTION
In this PR, the following changes are introduced:
1. **Local Cache Cleanup:** Solves the issue where backups completed instantly with no files. Now, when removing a folder in the desktop app, its associated `SyncedNode` records are cleared from the local Realm database.
2. **Realm Thread-Safety:** Re-structured `cleanBackupLocalData` to be synchronous using a thread-local Realm instance. This prevents the `Realm accessed from incorrect thread` crash when invoked from background threads.
3. **Database Entity Fix:** Corrected a bug in `SyncedNode.swift` where `rootBackupFolder` was incorrectly initialized with the individual file URL instead of the root backup folder URL.
4. **Enriched Error Mapping:** Updated `Error.swift` to extract `context` and `cause` inside `getErrorDescription()`. This improves diagnostic logs and simplifies mapping API failures.