### PR TITLE
fix: prevent selection of root directory for backups

### DIFF
--- a/InternxtDesktop/Views/Backups/FolderSelectorView.swift
+++ b/InternxtDesktop/Views/Backups/FolderSelectorView.swift
@@ -25,6 +25,10 @@ struct FolderSelectorView: View {
     }
     
     func handleMissingFolderURLLocated(folderListItem: FolderListItem, newURL: URL) -> Void {
+        if newURL.path == "/" {
+            showErrorDialog(message: NSLocalizedString("BACKUP_SETTINGS_ROOT_FOLDER_ERROR", comment: ""))
+            return
+        }
 
         Task{
             do {
@@ -47,6 +51,10 @@ struct FolderSelectorView: View {
         let panelResponse = panel.runModal()
         if panelResponse == .OK {
             for url in panel.urls {
+                if url.path == "/" {
+                    showErrorDialog(message: NSLocalizedString("BACKUP_SETTINGS_ROOT_FOLDER_ERROR", comment: ""))
+                    continue
+                }
                 do {
                     let urls = backupsService.foldersToBackup.map { folderToBackup in
                         return folderToBackup.url

--- a/Shared/Services/Backups/BackupsService.swift
+++ b/Shared/Services/Backups/BackupsService.swift
@@ -109,6 +109,9 @@ class BackupsService: ObservableObject {
     }
 
     @MainActor func addFolderToBackup(url: URL) throws {
+        guard url.path != "/" else {
+            throw BackupError.cannotAddFolder
+        }
 
         do {
             let realm = getRealm()
@@ -236,6 +239,9 @@ class BackupsService: ObservableObject {
     }
     
     func updateFolderToBackupURL(folderId: String, newURL: URL) throws {
+        guard newURL.path != "/" else {
+            return
+        }
         let realm = getRealm()
         let folderToBackupRealmObject = realm.object(ofType: FolderToBackupRealmObject.self,
                                                      forPrimaryKey: try ObjectId(string: folderId))

--- a/Shared/en.lproj/Localizable.strings
+++ b/Shared/en.lproj/Localizable.strings
@@ -128,6 +128,7 @@
 "BACKUP_SETTINGS_ONE_FOLDER" = "1 folder";
 "BACKUP_SETTINGS_ADD_FOLDERS" = "Click + to select the folders\nyou want to back up";
 "BACKUP_SETTINGS_ALREADY_ADDED_FOLDER" = "This folder is already selected";
+"BACKUP_SETTINGS_ROOT_FOLDER_ERROR" = "The root folder cannot be selected for backup.";
 
 // Account Settings
 

--- a/Shared/es.lproj/Localizable.strings
+++ b/Shared/es.lproj/Localizable.strings
@@ -110,6 +110,7 @@
 "BACKUP_SETTINGS_ONE_FOLDER" = "1 carpeta";
 "BACKUP_SETTINGS_ADD_FOLDERS" = "Haga clic en + para seleccionar las carpetas\nde las que desea hacer una copia de seguridad.";
 "BACKUP_SETTINGS_ALREADY_ADDED_FOLDER" = "Esta carpeta ya se encuentra seleccionada";
+"BACKUP_SETTINGS_ROOT_FOLDER_ERROR" = "No se puede seleccionar la carpeta raíz para la copia de seguridad.";
 
 // Account Settings
 

--- a/Shared/fr.lproj/Localizable.strings
+++ b/Shared/fr.lproj/Localizable.strings
@@ -111,6 +111,7 @@
 "BACKUP_MISSING_FOLDERS_ERROR" = "Certains dossiers sont manquants";
 "BACKUP_MISSING_FOLDER_ERROR" = "Non trouvé";
 "BACKUP_SETTINGS_ALREADY_ADDED_FOLDER" = "Ce dossier est déjà sélectionné";
+"BACKUP_SETTINGS_ROOT_FOLDER_ERROR" = "Le dossier racine ne peut pas être sélectionné pour la sauvegarde.";
 
 // Account Settings
 


### PR DESCRIPTION
## Description
Prevent users from choosing the root directory (`/`) for backups. The backend rejects folder creation for the folder name `"/"`.
## Changes
- Added validation to block the root directory selection.
- Added a localized warning message in English, Spanish, and French.