### PR TITLE
fix: update sync existence check and resolve enumeration 

### DIFF
--- a/SyncExtension/UseCases/All/GetRemoteChangesUseCase.swift
+++ b/SyncExtension/UseCases/All/GetRemoteChangesUseCase.swift
@@ -76,8 +76,7 @@ class GetRemoteChangesUseCase {
                 
                 observer.finishEnumeratingChanges(
                     upTo: NSFileProviderSyncAnchor(rawValue: joinedAnchor!),
-                    
-                    moreComing: true
+                    moreComing: false
                 )
                 
                 self.logger.info("✅ Changes enumerated correctly from the server")
@@ -224,7 +223,7 @@ class GetRemoteChangesUseCase {
         }
         
         if hasMoreFiles {
-            self.logger.info("There are more files, requesting them...")
+            
             try await self.obtainFileChanges(lastUpdatedAt: newFilesLastUpdatedAt, limit: self.enumeratedChangesLimit, recommendedBatchSize: recommendedBatchSize)
         } else {
             if mostRecentUpdatedAt > newFilesLastUpdatedAt {

--- a/SyncExtension/UseCases/Files/UploadFileOrUpdateContentUseCase.swift
+++ b/SyncExtension/UseCases/Files/UploadFileOrUpdateContentUseCase.swift
@@ -52,14 +52,12 @@ struct UploadFileOrUpdateContentUseCase {
         self.parentUUID = parentUuid
     }
     
-    private func fileAlreadyExistsByName() async -> GetFileInFolderByPlainNameResponse? {
+    private func fileAlreadyExistsByName() async -> GetExistenceFileInFolderResponse? {
         do {
-            guard let folderIdInt = Int(getParentId(item: self.item, user: self.user)) else {
-                return nil
-            }
-            
             let filename = (item.filename as NSString)
-            return try await self.driveNewAPI.getFileInFolderByPlainName(folderId: folderIdInt, plainName: filename.deletingPathExtension, type:filename.pathExtension)
+            let existenceFile = ExistenceFile(plainName: filename.deletingPathExtension, type: filename.pathExtension)
+            let result = try await self.driveNewAPI.getExistenceFileInFolderByPlainName(uuid: self.parentUUID, files: [existenceFile], debug: true)
+            return result.existentFiles.isEmpty ? nil : result.existentFiles.first
             
         } catch {
             if let apiClientError = error as? APIClientError, apiClientError.statusCode == 404 {


### PR DESCRIPTION
### Description
1. **Fix File Existence Validation:**
   - Switched to `getExistenceFileInFolderByPlainName` in `UploadFileOrUpdateContentUseCase.swift`. The previous method threw errors when querying files without extension, causing failures when attempting to replace existing files. This update ensures files without extension are verified correctly and the replace flow is properly triggered.
2. **Prevent Unnecessary Enumerations:**
   - Changed `moreComing` to `false` in `GetRemoteChangesUseCase.swift` to signal to the FileProvider extension that the current remote synchronization batch is complete. This prevents the OS from triggering immediate, unnecessary subsequent enumeration calls.
   - Cleaned up a redundant log in `obtainFileChanges`.