### PR TITLE
Refactor Alert Handling and Implement Empty File Limits with Circuit Breaker

### DIFF
--- a/InternxtDesktop.xcodeproj/project.pbxproj
+++ b/InternxtDesktop.xcodeproj/project.pbxproj
@@ -87,6 +87,12 @@
 		AA3B497E2D4483AA00924536 /* freshclam in CopyFiles */ = {isa = PBXBuildFile; fileRef = AA3B497C2D44839C00924536 /* freshclam */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		AA3B49802D44886700924536 /* libfreshclam.3.0.2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = AA3B497F2D44886700924536 /* libfreshclam.3.0.2.dylib */; settings = {ATTRIBUTES = (Weak, ); }; };
 		AA3B49812D44887600924536 /* libfreshclam.3.0.2.dylib in CopyFiles */ = {isa = PBXBuildFile; fileRef = AA3B497F2D44886700924536 /* libfreshclam.3.0.2.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		AA3D12952FDC8D71000ECA4C /* EmptyFileLimitNotifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3D12942FDC8D71000ECA4C /* EmptyFileLimitNotifier.swift */; };
+		AA3D12962FDC8D71000ECA4C /* EmptyFileLimitNotifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3D12942FDC8D71000ECA4C /* EmptyFileLimitNotifier.swift */; };
+		AA3D12972FDC8D71000ECA4C /* EmptyFileLimitNotifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3D12942FDC8D71000ECA4C /* EmptyFileLimitNotifier.swift */; };
+		AA3D12982FDC8D71000ECA4C /* EmptyFileLimitNotifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3D12942FDC8D71000ECA4C /* EmptyFileLimitNotifier.swift */; };
+		AA3D129B2FE05921000ECA4C /* BackupAlertsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3D12992FE05921000ECA4C /* BackupAlertsCoordinator.swift */; };
+		AA3D129E2FE0F4C0000ECA4C /* EmptyFileLimitDialogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3D129D2FE0F4C0000ECA4C /* EmptyFileLimitDialogView.swift */; };
 		AA40B3BD2D3B298600FC1FC3 /* AntivirusTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA40B3BC2D3B298600FC1FC3 /* AntivirusTabView.swift */; };
 		AA40B3C12D3ED74400FC1FC3 /* AntivirusManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA40B3C02D3ED74400FC1FC3 /* AntivirusManager.swift */; };
 		AA4395702C174B52003AA905 /* ScheduledBackupManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA43956F2C174B52003AA905 /* ScheduledBackupManager.swift */; };
@@ -537,6 +543,9 @@
 		AA2019662C53F8B700901B93 /* Debouncer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Debouncer.swift; sourceTree = "<group>"; };
 		AA3B497C2D44839C00924536 /* freshclam */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; path = freshclam; sourceTree = "<group>"; };
 		AA3B497F2D44886700924536 /* libfreshclam.3.0.2.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libfreshclam.3.0.2.dylib; sourceTree = "<group>"; };
+		AA3D12942FDC8D71000ECA4C /* EmptyFileLimitNotifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyFileLimitNotifier.swift; sourceTree = "<group>"; };
+		AA3D12992FE05921000ECA4C /* BackupAlertsCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupAlertsCoordinator.swift; sourceTree = "<group>"; };
+		AA3D129D2FE0F4C0000ECA4C /* EmptyFileLimitDialogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyFileLimitDialogView.swift; sourceTree = "<group>"; };
 		AA40B3BC2D3B298600FC1FC3 /* AntivirusTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AntivirusTabView.swift; sourceTree = "<group>"; };
 		AA40B3C02D3ED74400FC1FC3 /* AntivirusManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AntivirusManager.swift; sourceTree = "<group>"; };
 		AA43956F2C174B52003AA905 /* ScheduledBackupManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduledBackupManager.swift; sourceTree = "<group>"; };
@@ -1038,6 +1047,7 @@
 				AAED64A02C23E85000CD971B /* JWTDecoder.swift */,
 				AA2019662C53F8B700901B93 /* Debouncer.swift */,
 				AA9B1B9B2FB2D342000E582A /* FileSizeLimitNotifier.swift */,
+				AA3D12942FDC8D71000ECA4C /* EmptyFileLimitNotifier.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -1064,6 +1074,7 @@
 			children = (
 				E13B83962AFBBCD7009F6684 /* AppSettingsManagerView.swift */,
 				AA9B1BA02FB4094D000E582A /* FileSizeLimitDialogView.swift */,
+				AA3D129D2FE0F4C0000ECA4C /* EmptyFileLimitDialogView.swift */,
 			);
 			path = App;
 			sourceTree = "<group>";
@@ -1103,6 +1114,7 @@
 				E13B83982AFBBD50009F6684 /* AppSettings.swift */,
 				E1FD8C722BA989D900C257E0 /* LogService.swift */,
 				AA8D9AEE2E7CC2370068B333 /* FeaturesService.swift */,
+				AA3D12992FE05921000ECA4C /* BackupAlertsCoordinator.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -1803,6 +1815,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				31DEAEB12B75139400E76D53 /* XPCBackupService.swift in Sources */,
+				AA3D12962FDC8D71000ECA4C /* EmptyFileLimitNotifier.swift in Sources */,
 				3120B5652B84F37F00F524F1 /* Bundle.swift in Sources */,
 				E15F8C3E2B762E6400C60EFA /* BackupTreeNodeType.swift in Sources */,
 				E1D24AF62C0468AF0009EC83 /* AsyncOperation.swift in Sources */,
@@ -1890,6 +1903,7 @@
 				31F9EF2F2B867FED007DAD86 /* Bundle.swift in Sources */,
 				AAA424962C51FFC100EEFD69 /* GenericRepository.swift in Sources */,
 				31F9EF2A2B867DFE007DAD86 /* BackupUploadService.swift in Sources */,
+				AA3D12972FDC8D71000ECA4C /* EmptyFileLimitNotifier.swift in Sources */,
 				31F9EF2D2B867F42007DAD86 /* ErrorUtils.swift in Sources */,
 				31F9EF2B2B867E16007DAD86 /* ConfigLoader.swift in Sources */,
 				AAC188F12C2231E7007E321A /* MockBackupUploadService.swift in Sources */,
@@ -1941,6 +1955,7 @@
 				AAED64A12C23E85000CD971B /* JWTDecoder.swift in Sources */,
 				AA13E0362E6238FB00DD47CB /* CleanerService.swift in Sources */,
 				E1A0AC5F2AB85BF4005E71D6 /* SendFeedbackView.swift in Sources */,
+				AA3D12952FDC8D71000ECA4C /* EmptyFileLimitNotifier.swift in Sources */,
 				E1DB295F2A7D6A03009036B8 /* WidgetView.swift in Sources */,
 				AA13E03A2E62557A00DD47CB /* CleanerRowComponents.swift in Sources */,
 				316DC7EC2B59837D00FDC746 /* BackupsDeviceService.swift in Sources */,
@@ -1981,6 +1996,7 @@
 				E13B83972AFBBCD7009F6684 /* AppSettingsManagerView.swift in Sources */,
 				315BC6922B3E06A5004C85D8 /* FolderSelectorView.swift in Sources */,
 				E1D24AF42C0468AF0009EC83 /* AsyncOperation.swift in Sources */,
+				AA3D129B2FE05921000ECA4C /* BackupAlertsCoordinator.swift in Sources */,
 				AA13E03C2E6255C400DD47CB /* StorageMeterView.swift in Sources */,
 				E1F616092A8D7E6F008C9E62 /* AppButton.swift in Sources */,
 				AAEC16402D485083009B66BE /* BookmarkManager.swift in Sources */,
@@ -2026,6 +2042,7 @@
 				E1DB29542A7D56C4009036B8 /* AppTextInput.swift in Sources */,
 				E1880B972AA6111B001FC171 /* SettingsView.swift in Sources */,
 				E18300B02AA2395100AD023C /* FileExtension.swift in Sources */,
+				AA3D129E2FE0F4C0000ECA4C /* EmptyFileLimitDialogView.swift in Sources */,
 				E17C84B62AB276C000A58414 /* OnboardingSlide3View.swift in Sources */,
 				AA93BEBE2E72128800F12334 /* LockedFeatureCleanerView.swift in Sources */,
 				E16310952A8FAD3C0072989E /* APIFactory.swift in Sources */,
@@ -2097,6 +2114,7 @@
 				AAA6F6482E5FEDB6000082ED /* Cleaner.swift in Sources */,
 				E1C56E232AE19A5100C0EC06 /* URL.swift in Sources */,
 				AA08F36F2DEE5E0C00F9D0CA /* DeletedItemsCache.swift in Sources */,
+				AA3D12982FDC8D71000ECA4C /* EmptyFileLimitNotifier.swift in Sources */,
 				E10B0FDA2A9411C900B97874 /* AuthManager.swift in Sources */,
 				E109717F2A81143A00ABED41 /* APIFactory.swift in Sources */,
 				E1CC520A2A97DE85009DEEAA /* DeleteFileOrFolderUseCase.swift in Sources */,

--- a/InternxtDesktop/AppDelegate.swift
+++ b/InternxtDesktop/AppDelegate.swift
@@ -58,6 +58,8 @@ class AppDelegate: NSObject, NSApplicationDelegate , PKPushRegistryDelegate {
     var signalEnumeratorTimer: AnyCancellable?
     var notificationsTimer: AnyCancellable?
     let fileSizeLimitState = FileSizeLimitState()
+    let emptyFileLimitState = EmptyFileLimitState()
+    private var backupAlertsCoordinator: BackupAlertsCoordinator!
     var usageUpdateDebouncer = Debouncer(delay: 15.0)
     private let driveNewAPI: DriveAPI = APIFactory.DriveNew
     private let notificationsPollingInterval: TimeInterval = 30 * 60
@@ -104,16 +106,30 @@ class AppDelegate: NSObject, NSApplicationDelegate , PKPushRegistryDelegate {
             object: nil,
             queue: .main
         ) { [weak self] notification in
-            self?.handleFileSizeExceeded(notification)
+            self?.backupAlertsCoordinator?.handleFileSizeExceeded(notification)
+        }
+
+        DistributedNotificationCenter.default().addObserver(
+            forName: NSNotification.Name(NOTIFICATION_EMPTY_FILE_LIMIT),
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.backupAlertsCoordinator?.handleEmptyFileLimitReached()
         }
 
         checkVolumeAndEjectIfNeeded()
         
         self.windowsManager = WindowsManager(
-            initialWindows: defaultWindows(settingsManager: settingsManager, authManager: authManager, usageManager: usageManager, backupsService: backupsService, scheduleManager: scheduledManager, antivirusManager: antivirusManager, cleanerService: cleanerService, updater: updaterController.updater, closeSendFeedbackWindow: closeSendFeedbackWindow, finishOrSkipOnboarding: self.finishOrSkipOnboarding, fileSizeLimitState: fileSizeLimitState),
+            initialWindows: defaultWindows(settingsManager: settingsManager, authManager: authManager, usageManager: usageManager, backupsService: backupsService, scheduleManager: scheduledManager, antivirusManager: antivirusManager, cleanerService: cleanerService, updater: updaterController.updater, closeSendFeedbackWindow: closeSendFeedbackWindow, finishOrSkipOnboarding: self.finishOrSkipOnboarding, fileSizeLimitState: fileSizeLimitState, emptyFileLimitState: emptyFileLimitState),
             onWindowClose: receiveOnWindowClose
         )
         self.windowsManager.loadInitialWindows()
+
+        self.backupAlertsCoordinator = BackupAlertsCoordinator(
+            fileSizeLimitState: fileSizeLimitState,
+            emptyFileLimitState: emptyFileLimitState,
+            windowsManager: windowsManager
+        )
 
         
         
@@ -602,43 +618,7 @@ class AppDelegate: NSObject, NSApplicationDelegate , PKPushRegistryDelegate {
     }
 
   
-    private let fileSizeBatchDebounceInterval: TimeInterval = 0.6
 
-  
-    private var fileSizePendingAlert: DispatchWorkItem?
-
-  
-    private var fileSizeAlertIsShowing = false
-
-    private func handleFileSizeExceeded(_ notification: Notification) {
-       
-        fileSizePendingAlert?.cancel()
-
-    
-        guard !fileSizeAlertIsShowing else { return }
-
-     
-        let work = DispatchWorkItem { [weak self] in
-            self?.presentFileSizeAlert()
-        }
-        fileSizePendingAlert = work
-        DispatchQueue.main.asyncAfter(
-            deadline: .now() + fileSizeBatchDebounceInterval,
-            execute: work
-        )
-    }
-
-    private func presentFileSizeAlert() {
-        let batch = FileSizeLimitNotifier.readAndResetBatch()
-        fileSizeLimitState.isBatch    = batch.rejectedCount > 1
-        fileSizeLimitState.filename   = batch.filename
-        fileSizeLimitState.fileSize   = batch.fileBytes
-        fileSizeLimitState.limitBytes = batch.limitBytes
-        fileSizeLimitState.isVisible  = true
-
-        windowsManager.openWindow(id: "file-size-limit")
-        fileSizeAlertIsShowing = false
-    }
 
     
     

--- a/InternxtDesktop/Services/URLDictionary.swift
+++ b/InternxtDesktop/Services/URLDictionary.swift
@@ -13,6 +13,7 @@ struct URLDictionary {
     public static var WEB_AUTH_SIGNUP = URL(string:"https://drive.internxt.com/new?universalLink=true")!
     public static var LEARN_MORE_ABOUT_INTERNXT_DRIVE = URL(string:"https://internxt.com/drive")!
     public static var UPGRADE_PLAN = URL(string:"https://drive.internxt.com/preferences?tab=plans")!
+    public static var UPGRADE_PLAN_DEEP_LINK = URL(string: "https://drive.internxt.com/?preferences=open&section=account&subsection=plans")!
     public static var HELP_CENTER = URL(string:"https://help.internxt.com")!
     public static var BACKUPS_WEB = URL(string: "https://drive.internxt.com/backups")!
     public static var DRIVE_WEB_FILE = "https://drive.internxt.com/file/"

--- a/InternxtDesktop/Views/App/EmptyFileLimitDialogView.swift
+++ b/InternxtDesktop/Views/App/EmptyFileLimitDialogView.swift
@@ -1,0 +1,162 @@
+//
+//  EmptyFileLimitDialogView.swift
+//  InternxtDesktop
+//
+//  Created by Patricio Tovar on 15/6/26.
+//
+
+import SwiftUI
+
+class EmptyFileLimitState: ObservableObject {
+    @Published var isBatch: Bool = false
+    @Published var firstFilename: String = ""
+    @Published var rejectedCount: Int = 0
+    @Published var reason: EmptyFileLimitReason = .quotaExceeded
+    @Published var isVisible: Bool = false
+}
+
+struct EmptyFileLimitDialogView: View {
+    @Environment(\.colorScheme) var colorScheme
+
+    let isBatch: Bool
+    let firstFilename: String
+    let rejectedCount: Int
+    let reason: EmptyFileLimitReason
+    var onClose: () -> Void
+    var onUpgrade: () -> Void
+
+    private var titleText: String {
+        switch reason {
+        case .planNotAllowed:
+            return NSLocalizedString(
+                "empty_file_plan_title",
+                value: "Empty files not available on your plan",
+                comment: "Alert title when the user's plan does not allow empty files"
+            )
+        case .quotaExceeded:
+            return NSLocalizedString(
+                "empty_file_quota_title",
+                value: "Empty file backup limit reached",
+                comment: "Alert title when the empty-file quota is full"
+            )
+        }
+    }
+
+    private var messageText: String {
+        switch reason {
+        case .planNotAllowed:
+            if isBatch {
+                return String(
+                    format: NSLocalizedString(
+                        "empty_file_plan_batch_message",
+                        value: "%d empty files could not be backed up. Upgrade your plan to back up empty files.",
+                        comment: "Alert body when multiple empty files are rejected due to plan restriction"
+                    ),
+                    rejectedCount
+                )
+            } else {
+                return String(
+                    format: NSLocalizedString(
+                        "empty_file_plan_single_message",
+                        value: "'%@' could not be backed up. Upgrade your plan to back up empty files.",
+                        comment: "Alert body when a single empty file is rejected due to plan restriction"
+                    ),
+                    firstFilename
+                )
+            }
+        case .quotaExceeded:
+            if isBatch {
+                return String(
+                    format: NSLocalizedString(
+                        "empty_file_quota_batch_message",
+                        value: "%d empty files could not be backed up because your account has reached the empty file limit.",
+                        comment: "Alert body when multiple empty files are rejected due to quota"
+                    ),
+                    rejectedCount
+                )
+            } else {
+                return String(
+                    format: NSLocalizedString(
+                        "empty_file_quota_single_message",
+                        value: "'%@' could not be backed up because your account has reached the empty file limit.",
+                        comment: "Alert body when a single empty file is rejected due to quota"
+                    ),
+                    firstFilename
+                )
+            }
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text(titleText)
+                .font(.XLMedium)
+                .foregroundColor(.DefaultTextStrong)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.bottom, 12)
+
+            Text(messageText)
+                .font(.SMRegular)
+                .foregroundColor(.Gray60)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.bottom, 24)
+
+            Spacer()
+
+            HStack(spacing: 8) {
+                Spacer()
+                if reason == .quotaExceeded {
+                    AppButton(
+                        title: "Close",
+                        onClick: { onClose() },
+                        type: .primary,
+                        size: .MD
+                    )
+                } else {
+                    AppButton(
+                        title: "Close",
+                        onClick: { onClose() },
+                        type: .secondary,
+                        size: .MD
+                    )
+                    AppButton(
+                        title: "Upgrade plan",
+                        onClick: { onUpgrade() },
+                        type: .primary,
+                        size: .MD
+                    )
+                }
+            }
+        }
+        .padding(24)
+        .frame(width: 420, height: 200)
+    }
+}
+
+struct EmptyFileLimitWindowView: View {
+    @EnvironmentObject var state: EmptyFileLimitState
+    @Environment(\.colorScheme) var colorScheme
+
+    var body: some View {
+        ZStack {
+            (colorScheme == .dark ? Color.Gray1 : Color.white)
+                .ignoresSafeArea()
+
+            EmptyFileLimitDialogView(
+                isBatch:        state.isBatch,
+                firstFilename:  state.firstFilename,
+                rejectedCount:  state.rejectedCount,
+                reason:         state.reason,
+                onClose: {
+                    state.isVisible = false
+                    NSApp.hide(nil)
+                },
+                onUpgrade: {
+                    URLDictionary.UPGRADE_PLAN_DEEP_LINK.open()
+                    state.isVisible = false
+                    NSApp.hide(nil)
+                }
+            )
+        }
+    }
+}

--- a/InternxtDesktop/Views/App/FileSizeLimitDialogView.swift
+++ b/InternxtDesktop/Views/App/FileSizeLimitDialogView.swift
@@ -206,7 +206,7 @@ struct FileSizeLimitWindowView: View {
                     NSApp.hide(nil)
                 },
                 onUpgrade: {
-                    URL(string: "https://drive.internxt.com/?preferences=open&section=account&subsection=plans")?.open()
+                    URLDictionary.UPGRADE_PLAN_DEEP_LINK.open()
                     state.isVisible = false
                     NSApp.hide(nil)
                 }

--- a/InternxtDesktop/Windows.swift
+++ b/InternxtDesktop/Windows.swift
@@ -15,7 +15,7 @@ import Sparkle
 /// creating them
 func defaultWindows(settingsManager: SettingsTabManager, authManager: AuthManager, usageManager: UsageManager, backupsService: BackupsService, scheduleManager: ScheduledBackupManager,antivirusManager : AntivirusManager ,
                     cleanerService: CleanerService,updater: SPUUpdater, closeSendFeedbackWindow: @escaping () -> Void, finishOrSkipOnboarding: @escaping () -> Void,
-                    fileSizeLimitState: FileSizeLimitState) -> [WindowConfig] {
+                    fileSizeLimitState: FileSizeLimitState, emptyFileLimitState: EmptyFileLimitState) -> [WindowConfig] {
     let windows = [
         WindowConfig(
             view: AnyView(AppSettingsManagerView{SignInWithBrowserView().environmentObject(authManager)}),
@@ -63,6 +63,18 @@ func defaultWindows(settingsManager: SettingsTabManager, authManager: AuthManage
             id: "file-size-limit",
             width: 420,
             height: 270,
+            fixedToFront: true,
+            backgroundColor: Color.clear
+        ),
+        WindowConfig(
+            view: AnyView(
+                EmptyFileLimitWindowView()
+                    .environmentObject(emptyFileLimitState)
+            ),
+            title: nil,
+            id: "empty-file-limit",
+            width: 420,
+            height: 200,
             fixedToFront: true,
             backgroundColor: Color.clear
         )

--- a/Shared/Services/BackupAlertsCoordinator.swift
+++ b/Shared/Services/BackupAlertsCoordinator.swift
@@ -1,0 +1,89 @@
+//
+//  BackupAlertsCoordinator.swift
+//  InternxtDesktop
+//
+//  Created by Patricio Tovar on 15/6/26.
+//
+
+import AppKit
+import Foundation
+
+final class BackupAlertsCoordinator {
+    private let fileSizeLimitState: FileSizeLimitState
+    private let emptyFileLimitState: EmptyFileLimitState
+    private let windowsManager: WindowsManager
+
+    private let debounceInterval: TimeInterval = 0.6
+
+    // File Size Limit State
+    private var fileSizePendingAlert: DispatchWorkItem?
+    private var fileSizeAlertIsShowing = false
+
+    // Empty File Limit State
+    private var emptyFilePendingAlert: DispatchWorkItem?
+    private var emptyFileAlertIsShowing = false
+
+    init(fileSizeLimitState: FileSizeLimitState, emptyFileLimitState: EmptyFileLimitState, windowsManager: WindowsManager) {
+        self.fileSizeLimitState = fileSizeLimitState
+        self.emptyFileLimitState = emptyFileLimitState
+        self.windowsManager = windowsManager
+    }
+
+  
+
+    public func handleFileSizeExceeded(_ notification: Notification) {
+        fileSizePendingAlert?.cancel()
+
+        guard !fileSizeAlertIsShowing else { return }
+
+        let work = DispatchWorkItem { [weak self] in
+            self?.presentFileSizeAlert()
+        }
+        fileSizePendingAlert = work
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + debounceInterval,
+            execute: work
+        )
+    }
+
+    private func presentFileSizeAlert() {
+        let batch = FileSizeLimitNotifier.readAndResetBatch()
+        fileSizeLimitState.isBatch    = batch.rejectedCount > 1
+        fileSizeLimitState.filename   = batch.filename
+        fileSizeLimitState.fileSize   = batch.fileBytes
+        fileSizeLimitState.limitBytes = batch.limitBytes
+        fileSizeLimitState.isVisible  = true
+
+        windowsManager.openWindow(id: "file-size-limit")
+        fileSizeAlertIsShowing = false
+    }
+
+ 
+
+    public func handleEmptyFileLimitReached() {
+        emptyFilePendingAlert?.cancel()
+
+        guard !emptyFileAlertIsShowing else { return }
+
+        let work = DispatchWorkItem { [weak self] in
+            self?.presentEmptyFileLimitAlert()
+        }
+        emptyFilePendingAlert = work
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + debounceInterval,
+            execute: work
+        )
+    }
+
+    private func presentEmptyFileLimitAlert() {
+        let batch = EmptyFileLimitNotifier.readAndResetBatch()
+        emptyFileLimitState.isBatch        = batch.rejectedCount > 1
+        emptyFileLimitState.firstFilename  = batch.firstFilename
+        emptyFileLimitState.rejectedCount  = batch.rejectedCount
+        emptyFileLimitState.reason         = batch.reason
+        emptyFileLimitState.isVisible      = true
+
+        windowsManager.openWindow(id: "empty-file-limit")
+        emptyFileAlertIsShowing = false
+    }
+}

--- a/Shared/Utils/EmptyFileLimitNotifier.swift
+++ b/Shared/Utils/EmptyFileLimitNotifier.swift
@@ -1,0 +1,66 @@
+//
+//  EmptyFileLimitNotifier.swift
+//  InternxtDesktop
+//
+//  Created by Patricio Tovar on 12/6/26.
+//
+
+import Foundation
+
+public let NOTIFICATION_EMPTY_FILE_LIMIT = "com.internxt.drive.emptyFileLimitReached"
+private let kEmptyFileLimit_firstFilename = "EmptyFileLimit_firstFilename"
+private let kEmptyFileLimit_count         = "EmptyFileLimit_count"
+private let kEmptyFileLimit_reason        = "EmptyFileLimit_reason"
+
+private let _emptyFileLock = NSLock()
+
+public enum EmptyFileLimitReason: String {
+    case quotaExceeded  = "quotaExceeded"
+    case planNotAllowed = "planNotAllowed"
+}
+
+
+public enum EmptyFileLimitNotifier {
+
+    public static func post(filename: String, reason: EmptyFileLimitReason) {
+        _emptyFileLock.lock()
+        defer { _emptyFileLock.unlock() }
+
+        let defaults = UserDefaults(suiteName: INTERNXT_GROUP_NAME)
+
+        let previousCount = defaults?.integer(forKey: kEmptyFileLimit_count) ?? 0
+        let newCount = previousCount + 1
+        defaults?.set(newCount, forKey: kEmptyFileLimit_count)
+
+       
+        if previousCount == 0 {
+            defaults?.set(filename,       forKey: kEmptyFileLimit_firstFilename)
+            defaults?.set(reason.rawValue, forKey: kEmptyFileLimit_reason)
+        }
+
+        defaults?.synchronize()
+
+        DistributedNotificationCenter.default().postNotificationName(
+            NSNotification.Name(NOTIFICATION_EMPTY_FILE_LIMIT),
+            object: nil,
+            userInfo: nil,
+            deliverImmediately: true
+        )
+    }
+
+    public static func readAndResetBatch() -> (rejectedCount: Int, firstFilename: String, reason: EmptyFileLimitReason) {
+        let defaults = UserDefaults(suiteName: INTERNXT_GROUP_NAME)
+
+        let count      = defaults?.integer(forKey: kEmptyFileLimit_count)              ?? 0
+        let filename   = defaults?.string(forKey: kEmptyFileLimit_firstFilename)       ?? "Unknown"
+        let reasonRaw  = defaults?.string(forKey: kEmptyFileLimit_reason)              ?? ""
+        let reason     = EmptyFileLimitReason(rawValue: reasonRaw) ?? .quotaExceeded
+
+        defaults?.set(0, forKey: kEmptyFileLimit_count)
+        defaults?.removeObject(forKey: kEmptyFileLimit_firstFilename)
+        defaults?.removeObject(forKey: kEmptyFileLimit_reason)
+        defaults?.synchronize()
+
+        return (count, filename, reason)
+    }
+}

--- a/XPCBackupService/Services/BackupUploadService.swift
+++ b/XPCBackupService/Services/BackupUploadService.swift
@@ -10,6 +10,13 @@ import RealmSwift
 import FileProvider
 import InternxtSwiftCore
 
+
+private struct APIErrorBody: Decodable {
+    let message: String
+    let error: String?
+    let statusCode: Int?
+}
+
 enum BackupUploadError: Error {
     case CannotOpenInputStream
     case MissingDocumentSize
@@ -24,6 +31,8 @@ enum BackupUploadError: Error {
     case CannotFindNodeInServer
     case BackupStoppedManually
     case FileSizeLimitExceeded
+    case EmptyFileQuotaExceeded
+    case EmptyFilePlanNotAllowed
 }
 
 enum BackupDownloadError: Error {
@@ -50,6 +59,7 @@ class BackupUploadService:  BackupUploadServiceProtocol, ObservableObject {
     private let bucketId: String
     private let newAuthToken: String
     @Published var canDoBackup = true
+    private var emptyFileRejectReason: EmptyFileLimitReason? = nil
 
 
     init(networkFacade: NetworkFacade, encryptedContentDirectory: URL, deviceId: Int, bucketId: String,newAuthToken: String, deviceUuid: String) {
@@ -59,6 +69,14 @@ class BackupUploadService:  BackupUploadServiceProtocol, ObservableObject {
         self.bucketId = bucketId
         self.newAuthToken = newAuthToken
         self.deviceUuid = deviceUuid
+    }
+
+
+    private func extractServerMessage(from apiError: APIClientError) -> String? {
+        guard !apiError.responseBody.isEmpty,
+              let decoded = try? JSONDecoder().decode(APIErrorBody.self, from: apiError.responseBody)
+        else { return nil }
+        return decoded.message
     }
 
 
@@ -275,6 +293,12 @@ class BackupUploadService:  BackupUploadServiceProtocol, ObservableObject {
                 self.logger.info("Upload completed with id \(result.id)")
             } else {
                 self.logger.info("⚠️ Skipping network upload for empty file: \(filename)")
+                if let reason = emptyFileRejectReason {
+                    self.logger.warning("⛔ Empty-file already rejected (\(reason.rawValue)) — skipping API call for \(filename)")
+                    EmptyFileLimitNotifier.post(filename: filename as String, reason: reason)
+                    let error: BackupUploadError = reason == .planNotAllowed ? .EmptyFilePlanNotAllowed : .EmptyFileQuotaExceeded
+                    return .failure(error)
+                }
             }
 
             if node.syncStatus == .NEEDS_UPDATE {
@@ -416,11 +440,28 @@ class BackupUploadService:  BackupUploadServiceProtocol, ObservableObject {
                 }
             }
 
+            if let apiError = error as? APIClientError, apiError.statusCode == 400,
+               let serverMsg = extractServerMessage(from: apiError),
+               serverMsg.localizedCaseInsensitiveContains("empty") && serverMsg.localizedCaseInsensitiveContains("file") {
+                return handleEmptyFileLimitError(for: node, reason: .quotaExceeded)
+            }
+
+            if let apiError = error as? APIClientError, apiError.statusCode == 402 {
+                return handleEmptyFileLimitError(for: node, reason: .planNotAllowed)
+            }
+
             return .failure(error)
         }
 
     }
 
 
+    private func handleEmptyFileLimitError(for node: BackupTreeNode, reason: EmptyFileLimitReason) -> Result<BackupTreeNodeSyncResult, Error> {
+        self.logger.warning("⛔ Server rejected empty file '\(node.name)' — reason: \(reason.rawValue)")
+        self.emptyFileRejectReason = reason
+        EmptyFileLimitNotifier.post(filename: node.name, reason: reason)
+        let uploadError: BackupUploadError = reason == .planNotAllowed ? .EmptyFilePlanNotAllowed : .EmptyFileQuotaExceeded
+        return .failure(uploadError)
+    }
 }
 


### PR DESCRIPTION
### Summary
This PR implements comprehensive handling for empty file upload limits (HTTP 400 & 402) and refactors the desktop warning alert system.
### Key Changes
* **Empty File Limits & Circuit Breaker:** Implemented robust HTTP error detection and a network circuit breaker (`emptyFileRejectReason`) in `BackupUploadService` to skip redundant requests for 0-byte files.
* **Inter-Process Notifications:** Added `EmptyFileLimitNotifier` to safely batch and forward background upload failures from the XPC Service to the main application.
* **Alert Coordinator Refactor:** Moved alert states and debouncing logic from `AppDelegate` into a new `BackupAlertsCoordinator` to simplify the application lifecycle file.
