### PR TITLE
Handle backup storage full errors and implement non-blocking alert dialog

### DIFF
--- a/InternxtDesktop.xcodeproj/project.pbxproj
+++ b/InternxtDesktop.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		31F9EF2D2B867F42007DAD86 /* ErrorUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16ECC132A9508B10093D3ED /* ErrorUtils.swift */; };
 		31F9EF2E2B867FE9007DAD86 /* APIFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E109717E2A81143A00ABED41 /* APIFactory.swift */; };
 		31F9EF2F2B867FED007DAD86 /* Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1CC520B2A98B460009DEEAA /* Bundle.swift */; };
+		AA0424162FE36A22001E29EF /* StorageFullDialogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0424152FE36A22001E29EF /* StorageFullDialogView.swift */; };
 		AA0889102C4AF27C00D5CC40 /* SyncExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA08890F2C4AF27C00D5CC40 /* SyncExtensionTests.swift */; };
 		AA08891C2C4AF29F00D5CC40 /* InternxtDesktopTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA08891B2C4AF29F00D5CC40 /* InternxtDesktopTests.swift */; };
 		AA08F36D2DEE5DF400F9D0CA /* FolderMetaCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA08F36C2DEE5DF400F9D0CA /* FolderMetaCache.swift */; };
@@ -526,6 +527,7 @@
 		31DEAEC02B75143F00E76D53 /* XPCBackupServiceDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XPCBackupServiceDelegate.swift; sourceTree = "<group>"; };
 		31EBEF722B32006F0017590F /* WidgetBackupBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetBackupBannerView.swift; sourceTree = "<group>"; };
 		31ED949C2B7151E200EF699F /* DecryptUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecryptUtils.swift; sourceTree = "<group>"; };
+		AA0424152FE36A22001E29EF /* StorageFullDialogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageFullDialogView.swift; sourceTree = "<group>"; };
 		AA08890D2C4AF27C00D5CC40 /* SyncExtensionTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SyncExtensionTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AA08890F2C4AF27C00D5CC40 /* SyncExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncExtensionTests.swift; sourceTree = "<group>"; };
 		AA0889192C4AF29F00D5CC40 /* InternxtDesktopTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = InternxtDesktopTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1075,6 +1077,7 @@
 				E13B83962AFBBCD7009F6684 /* AppSettingsManagerView.swift */,
 				AA9B1BA02FB4094D000E582A /* FileSizeLimitDialogView.swift */,
 				AA3D129D2FE0F4C0000ECA4C /* EmptyFileLimitDialogView.swift */,
+				AA0424152FE36A22001E29EF /* StorageFullDialogView.swift */,
 			);
 			path = App;
 			sourceTree = "<group>";
@@ -2054,6 +2057,7 @@
 				315BC68D2B3DDE4E004C85D8 /* BackupsTabView.swift in Sources */,
 				E18300AE2AA230A600AD023C /* WidgetSyncEntryView.swift in Sources */,
 				E1880BA02AA63215001FC171 /* StartOnLaunchView.swift in Sources */,
+				AA0424162FE36A22001E29EF /* StorageFullDialogView.swift in Sources */,
 				E1880B9E2AA6294D001FC171 /* AppCheckbox.swift in Sources */,
 				E1CC520C2A98B460009DEEAA /* Bundle.swift in Sources */,
 				AA40B3C12D3ED74400FC1FC3 /* AntivirusManager.swift in Sources */,

--- a/InternxtDesktop/AppDelegate.swift
+++ b/InternxtDesktop/AppDelegate.swift
@@ -59,6 +59,7 @@ class AppDelegate: NSObject, NSApplicationDelegate , PKPushRegistryDelegate {
     var notificationsTimer: AnyCancellable?
     let fileSizeLimitState = FileSizeLimitState()
     let emptyFileLimitState = EmptyFileLimitState()
+    let storageFullState = StorageFullState()
     private var backupAlertsCoordinator: BackupAlertsCoordinator!
     var usageUpdateDebouncer = Debouncer(delay: 15.0)
     private let driveNewAPI: DriveAPI = APIFactory.DriveNew
@@ -117,10 +118,18 @@ class AppDelegate: NSObject, NSApplicationDelegate , PKPushRegistryDelegate {
             self?.backupAlertsCoordinator?.handleEmptyFileLimitReached()
         }
 
+        DistributedNotificationCenter.default().addObserver(
+            forName: .storageFull,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.backupAlertsCoordinator?.handleStorageFullReached()
+        }
+
         checkVolumeAndEjectIfNeeded()
         
         self.windowsManager = WindowsManager(
-            initialWindows: defaultWindows(settingsManager: settingsManager, authManager: authManager, usageManager: usageManager, backupsService: backupsService, scheduleManager: scheduledManager, antivirusManager: antivirusManager, cleanerService: cleanerService, updater: updaterController.updater, closeSendFeedbackWindow: closeSendFeedbackWindow, finishOrSkipOnboarding: self.finishOrSkipOnboarding, fileSizeLimitState: fileSizeLimitState, emptyFileLimitState: emptyFileLimitState),
+            initialWindows: defaultWindows(settingsManager: settingsManager, authManager: authManager, usageManager: usageManager, backupsService: backupsService, scheduleManager: scheduledManager, antivirusManager: antivirusManager, cleanerService: cleanerService, updater: updaterController.updater, closeSendFeedbackWindow: closeSendFeedbackWindow, finishOrSkipOnboarding: self.finishOrSkipOnboarding, fileSizeLimitState: fileSizeLimitState, emptyFileLimitState: emptyFileLimitState, storageFullState: storageFullState),
             onWindowClose: receiveOnWindowClose
         )
         self.windowsManager.loadInitialWindows()
@@ -128,6 +137,7 @@ class AppDelegate: NSObject, NSApplicationDelegate , PKPushRegistryDelegate {
         self.backupAlertsCoordinator = BackupAlertsCoordinator(
             fileSizeLimitState: fileSizeLimitState,
             emptyFileLimitState: emptyFileLimitState,
+            storageFullState: storageFullState,
             windowsManager: windowsManager
         )
 

--- a/InternxtDesktop/Views/App/StorageFullDialogView.swift
+++ b/InternxtDesktop/Views/App/StorageFullDialogView.swift
@@ -1,0 +1,99 @@
+//
+//  StorageFullDialogView.swift
+//  InternxtDesktop
+//
+//  Created by Patricio Tovar on 17/6/26.
+//
+
+import SwiftUI
+
+class StorageFullState: ObservableObject {
+    @Published var isVisible: Bool = false
+}
+
+struct StorageFullDialogView: View {
+    @Environment(\.colorScheme) var colorScheme
+
+    var onClose: () -> Void
+    var onUpgrade: () -> Void
+
+    private var titleText: String {
+        return NSLocalizedString(
+            "storage_full_title",
+            value: "Your storage is full",
+            comment: "Alert title when the user runs out of storage space"
+        )
+    }
+
+    private var messageText: String {
+        return NSLocalizedString(
+            "storage_full_message",
+            value: "You have run out of space on Internxt. Upgrade your plan to continue backing up your files.",
+            comment: "Alert body when storage is full"
+        )
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text(titleText)
+                .font(.XLMedium)
+                .foregroundColor(.DefaultTextStrong)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.bottom, 12)
+
+            Text(messageText)
+                .font(.SMRegular)
+                .foregroundColor(.Gray60)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.bottom, 24)
+
+            Spacer()
+
+            HStack(spacing: 8) {
+                Spacer()
+                AppButton(
+                    title: "Close",
+                    onClick: { onClose() },
+                    type: .secondary,
+                    size: .MD
+                )
+                AppButton(
+                    title: "Upgrade plan",
+                    onClick: { onUpgrade() },
+                    type: .primary,
+                    size: .MD
+                )
+            }
+        }
+        .padding(24)
+        .frame(width: 420, height: 200)
+    }
+}
+
+struct StorageFullWindowView: View {
+    @EnvironmentObject var state: StorageFullState
+    @Environment(\.colorScheme) var colorScheme
+
+    var body: some View {
+        ZStack {
+            (colorScheme == .dark ? Color.Gray1 : Color.white)
+                .ignoresSafeArea()
+
+            StorageFullDialogView(
+                onClose: {
+                    state.isVisible = false
+                    if let window = NSApp.windows.first(where: { $0.identifier?.rawValue == "storage-full" }) {
+                        window.close()
+                    }
+                },
+                onUpgrade: {
+                    URLDictionary.UPGRADE_PLAN_DEEP_LINK.open()
+                    state.isVisible = false
+                    if let window = NSApp.windows.first(where: { $0.identifier?.rawValue == "storage-full" }) {
+                        window.close()
+                    }
+                }
+            )
+        }
+    }
+}

--- a/InternxtDesktop/Windows.swift
+++ b/InternxtDesktop/Windows.swift
@@ -15,7 +15,7 @@ import Sparkle
 /// creating them
 func defaultWindows(settingsManager: SettingsTabManager, authManager: AuthManager, usageManager: UsageManager, backupsService: BackupsService, scheduleManager: ScheduledBackupManager,antivirusManager : AntivirusManager ,
                     cleanerService: CleanerService,updater: SPUUpdater, closeSendFeedbackWindow: @escaping () -> Void, finishOrSkipOnboarding: @escaping () -> Void,
-                    fileSizeLimitState: FileSizeLimitState, emptyFileLimitState: EmptyFileLimitState) -> [WindowConfig] {
+                    fileSizeLimitState: FileSizeLimitState, emptyFileLimitState: EmptyFileLimitState, storageFullState: StorageFullState) -> [WindowConfig] {
     let windows = [
         WindowConfig(
             view: AnyView(AppSettingsManagerView{SignInWithBrowserView().environmentObject(authManager)}),
@@ -73,6 +73,18 @@ func defaultWindows(settingsManager: SettingsTabManager, authManager: AuthManage
             ),
             title: nil,
             id: "empty-file-limit",
+            width: 420,
+            height: 200,
+            fixedToFront: true,
+            backgroundColor: Color.clear
+        ),
+        WindowConfig(
+            view: AnyView(
+                StorageFullWindowView()
+                    .environmentObject(storageFullState)
+            ),
+            title: nil,
+            id: "storage-full",
             width: 420,
             height: 200,
             fixedToFront: true,

--- a/Shared/Extensions/Error.swift
+++ b/Shared/Extensions/Error.swift
@@ -67,4 +67,5 @@ extension NSAlert {
 
 extension Notification.Name {
     static let userDidLogout = Notification.Name("userDidLogout")
+    static let storageFull = Notification.Name("com.internxt.drive.storageFull")
 }

--- a/Shared/Services/BackupAlertsCoordinator.swift
+++ b/Shared/Services/BackupAlertsCoordinator.swift
@@ -11,6 +11,7 @@ import Foundation
 final class BackupAlertsCoordinator {
     private let fileSizeLimitState: FileSizeLimitState
     private let emptyFileLimitState: EmptyFileLimitState
+    private let storageFullState: StorageFullState
     private let windowsManager: WindowsManager
 
     private let debounceInterval: TimeInterval = 0.6
@@ -23,9 +24,10 @@ final class BackupAlertsCoordinator {
     private var emptyFilePendingAlert: DispatchWorkItem?
     private var emptyFileAlertIsShowing = false
 
-    init(fileSizeLimitState: FileSizeLimitState, emptyFileLimitState: EmptyFileLimitState, windowsManager: WindowsManager) {
+    init(fileSizeLimitState: FileSizeLimitState, emptyFileLimitState: EmptyFileLimitState, storageFullState: StorageFullState, windowsManager: WindowsManager) {
         self.fileSizeLimitState = fileSizeLimitState
         self.emptyFileLimitState = emptyFileLimitState
+        self.storageFullState = storageFullState
         self.windowsManager = windowsManager
     }
 
@@ -85,5 +87,10 @@ final class BackupAlertsCoordinator {
 
         windowsManager.openWindow(id: "empty-file-limit")
         emptyFileAlertIsShowing = false
+    }
+
+    public func handleStorageFullReached() {
+        storageFullState.isVisible = true
+        windowsManager.openWindow(id: "storage-full")
     }
 }

--- a/Shared/Services/Backups/BackupsService.swift
+++ b/Shared/Services/Backups/BackupsService.swift
@@ -790,9 +790,12 @@ class BackupsService: ObservableObject {
     }
     
     private func showAlert() {
-        DispatchQueue.main.async {
-            NSAlert.showStorageFullAlert()
-        }
+        DistributedNotificationCenter.default().postNotificationName(
+            .storageFull,
+            object: nil,
+            userInfo: nil,
+            deliverImmediately: true
+        )
     }
 
     @MainActor

--- a/XPCBackupService/Entities/BackupTreeNode.swift
+++ b/XPCBackupService/Entities/BackupTreeNode.swift
@@ -220,6 +220,10 @@ class BackupTreeNode {
                 throw BackupError.storageFull
             }
             
+            else if case BackupUploadError.StorageFull = error {
+                throw BackupError.storageFull
+            }
+            
                 if case BackupUploadError.BackupStoppedManually = error {
                     // Noop, this was stopped
                   return

--- a/XPCBackupService/Services/BackupUploadService.swift
+++ b/XPCBackupService/Services/BackupUploadService.swift
@@ -33,6 +33,7 @@ enum BackupUploadError: Error {
     case FileSizeLimitExceeded
     case EmptyFileQuotaExceeded
     case EmptyFilePlanNotAllowed
+    case StorageFull
 }
 
 enum BackupDownloadError: Error {
@@ -77,6 +78,32 @@ class BackupUploadService:  BackupUploadServiceProtocol, ObservableObject {
               let decoded = try? JSONDecoder().decode(APIErrorBody.self, from: apiError.responseBody)
         else { return nil }
         return decoded.message
+    }
+
+
+    private func is420StorageFull(_ error: Error) -> Bool {
+        // Direct APIClientError
+        if let apiError = error as? APIClientError, apiError.statusCode == 420 { return true }
+        
+        // EnrichedError wrapping APIClientError (single upload < 100MB)
+        if let enriched = error as? EnrichedError,
+           let apiError = enriched.cause as? APIClientError,
+           apiError.statusCode == 420 { return true }
+        
+        // EnrichedError wrapping UploadError.PartUploadFailed (multipart >= 100MB)
+        if let enriched = error as? EnrichedError,
+           let partFailed = enriched.cause as? UploadError,
+           case .PartUploadFailed(_, let innerError) = partFailed,
+           let apiError = innerError as? APIClientError,
+           apiError.statusCode == 420 { return true }
+        
+        // Direct UploadError.PartUploadFailed
+        if let partFailed = error as? UploadError,
+           case .PartUploadFailed(_, let innerError) = partFailed,
+           let apiError = innerError as? APIClientError,
+           apiError.statusCode == 420 { return true }
+        
+        return false
     }
 
 
@@ -373,17 +400,18 @@ class BackupUploadService:  BackupUploadServiceProtocol, ObservableObject {
             }
 
         } catch {
+            if is420StorageFull(error) {
+                if encryptedContentURL != nil {
+                    try? FileManager.default.removeItem(at: encryptedContentURL!)
+                }
+                return .failure(BackupUploadError.StorageFull)
+            }
 
             if let uploadError = error as? UploadError, case .PartUploadFailed(let partIndex, let innerError) = uploadError {
                 self.logger.error("❌ Part upload failed at index \(partIndex): \(uploadError.localizedDescription)")
                 self.logger.info("ℹ️ Inner error details: \(String(describing: innerError))")
             } else {
                 self.logger.error("❌ Failed to create file \(node.name) in \(String(describing: node.remoteParentId)): \(error.getErrorDescription())")
-            }
-            if let startUploadError = error as? StartUploadError {
-                if let apiClientError = startUploadError.apiError,  apiClientError.statusCode == 420 {
-                    self.logger.error("❌ Failed to create file \(node.name) in \(String(describing: node.remoteParentId)): Max space used")
-                }
             }
 
             if encryptedContentURL != nil {


### PR DESCRIPTION
## Description
This PR resolves an issue where HTTP 420 (Storage Full) errors during backups were not being correctly caught, causing endless retries. 
Additionally, it replaces the native blocking `NSAlert` with a custom SwiftUI dialog window. This prevents the application UI from freezing or being blocked by the modal event loop of `NSAlert`, ensuring a smoother experience.