### PR TITLE
Handle Storage Full Error in Drive Sincronization Operations

### DIFF
--- a/Shared/Extensions/Error.swift
+++ b/Shared/Extensions/Error.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import InternxtSwiftCore
-import AppKit
 
 extension Error {
     func reportToSentry() {
@@ -48,20 +47,30 @@ extension Error {
             }
         }
     }
-}
 
-extension NSAlert {
-    static func showStorageFullAlert() {
-        let alert = NSAlert()
-        alert.messageText = NSLocalizedString("ALERT_STORAGE_TITLE", comment: "")
-        alert.informativeText = NSLocalizedString("ALERT_STORAGE_SUBTITLE", comment: "")
-        alert.alertStyle = .warning
-        alert.addButton(withTitle: NSLocalizedString("ALERT_STORAGE_BUTTON_TITLE", comment: ""))
-        alert.addButton(withTitle: NSLocalizedString("COMMON_CANCEL", comment: ""))
-        let response = alert.runModal()
-        if response == .alertFirstButtonReturn {
-            URLDictionary.UPGRADE_PLAN.open()
-        }
+    var isStorageFull: Bool {
+        // Case 1: Direct APIClientError
+        if let apiError = self as? APIClientError, apiError.statusCode == 420 { return true }
+        
+        // Case 2: EnrichedError wrapping APIClientError (single upload < 100MB)
+        if let enriched = self as? EnrichedError,
+            let apiError = enriched.cause as? APIClientError,
+            apiError.statusCode == 420 { return true }
+        
+        // Case 3: EnrichedError wrapping UploadError.PartUploadFailed (multipart >= 100MB)
+        if let enriched = self as? EnrichedError,
+            let partFailed = enriched.cause as? UploadError,
+            case .PartUploadFailed(_, let innerError) = partFailed,
+            let apiError = innerError as? APIClientError,
+            apiError.statusCode == 420 { return true }
+        
+        // Case 4: Direct UploadError.PartUploadFailed
+        if let partFailed = self as? UploadError,
+            case .PartUploadFailed(_, let innerError) = partFailed,
+            let apiError = innerError as? APIClientError,
+            apiError.statusCode == 420 { return true }
+        
+        return false
     }
 }
 

--- a/Shared/Services/BackupAlertsCoordinator.swift
+++ b/Shared/Services/BackupAlertsCoordinator.swift
@@ -90,6 +90,7 @@ final class BackupAlertsCoordinator {
     }
 
     public func handleStorageFullReached() {
+        guard !storageFullState.isVisible else { return }
         storageFullState.isVisible = true
         windowsManager.openWindow(id: "storage-full")
     }

--- a/SyncExtension/UseCases/Files/UpdateFileContentUseCase.swift
+++ b/SyncExtension/UseCases/Files/UpdateFileContentUseCase.swift
@@ -130,7 +130,16 @@ struct UpdateFileContentUseCase {
                 error.reportToSentry()
                 self.logger.error("❌ Failed to update file content: \(error.getErrorDescription())")
                 
-                if let apiClientError = error as? APIClientError, apiClientError.statusCode == 402 {
+                if error.isStorageFull {
+                    self.logger.error("❌ Cannot synchronize file: destination storage is full (420)")
+                    DistributedNotificationCenter.default().postNotificationName(
+                        .storageFull,
+                        object: nil,
+                        userInfo: nil,
+                        deliverImmediately: true
+                    )
+                    completionHandler(nil, [], false, NSError(domain: NSFileProviderErrorDomain, code: NSFileProviderError.insufficientQuota.rawValue))
+                } else if let apiClientError = error as? APIClientError, apiClientError.statusCode == 402 {
                     self.logger.error("❌ Cannot synchronize file due to payment/quota issue (402)")
                     completionHandler(nil, [], false, NSError(domain: NSFileProviderErrorDomain, code: NSFileProviderError.cannotSynchronize.rawValue))
                 } else {

--- a/SyncExtension/UseCases/Files/UploadFileUseCase.swift
+++ b/SyncExtension/UseCases/Files/UploadFileUseCase.swift
@@ -190,7 +190,16 @@ struct UploadFileUseCase {
                 self.logger.error("❌ Failed to create file \(item.filename) : \(error.getErrorDescription())")
                 
                
-                if let apiClientError = error as? APIClientError, apiClientError.statusCode == 402 {
+                if error.isStorageFull {
+                    self.logger.error("❌ Cannot synchronize file: destination storage is full (420)")
+                    DistributedNotificationCenter.default().postNotificationName(
+                        .storageFull,
+                        object: nil,
+                        userInfo: nil,
+                        deliverImmediately: true
+                    )
+                    completionHandler(nil, [], false, NSError(domain: NSFileProviderErrorDomain, code: NSFileProviderError.insufficientQuota.rawValue))
+                } else if let apiClientError = error as? APIClientError, apiClientError.statusCode == 402 {
                     self.logger.error("❌ Cannot synchronize file due to payment/quota issue (402)")
                     completionHandler(nil, [], false, NSError(domain: NSFileProviderErrorDomain, code: NSFileProviderError.cannotSynchronize.rawValue))
                 } else {

--- a/SyncExtension/UseCases/Files/Workspaces/UpdateFileContentWorkspaceUseCase.swift
+++ b/SyncExtension/UseCases/Files/Workspaces/UpdateFileContentWorkspaceUseCase.swift
@@ -120,7 +120,16 @@ struct UpdateFileContentWorkspaceUseCase {
                 error.reportToSentry()
                 self.logger.error("❌ Failed to update file content: \(error.getErrorDescription())")
                 
-                if let apiClientError = error as? APIClientError, apiClientError.statusCode == 402 {
+                if error.isStorageFull {
+                    self.logger.error("❌ Cannot synchronize file: destination storage is full (420)")
+                    DistributedNotificationCenter.default().postNotificationName(
+                        .storageFull,
+                        object: nil,
+                        userInfo: nil,
+                        deliverImmediately: true
+                    )
+                    completionHandler(nil, [], false, NSError(domain: NSFileProviderErrorDomain, code: NSFileProviderError.insufficientQuota.rawValue))
+                } else if let apiClientError = error as? APIClientError, apiClientError.statusCode == 402 {
                     self.logger.error("❌ Cannot synchronize file due to payment/quota issue (402)")
                     completionHandler(nil, [], false, NSError(domain: NSFileProviderErrorDomain, code: NSFileProviderError.cannotSynchronize.rawValue))
                 } else {

--- a/SyncExtension/UseCases/Files/Workspaces/UploadFileWorkspaceUseCase.swift
+++ b/SyncExtension/UseCases/Files/Workspaces/UploadFileWorkspaceUseCase.swift
@@ -236,7 +236,16 @@ struct UploadFileWorkspaceUseCase {
                 activityManager.updateActivityEntryStatus(id: inProgressId, filename: item.filename, kind: .upload, status: .failed)
                 self.logger.error("❌ Failed to create file: \(error.getErrorDescription())")
                 
-                if let apiClientError = error as? APIClientError, apiClientError.statusCode == 402 {
+                if error.isStorageFull {
+                    self.logger.error("❌ Cannot synchronize file: destination storage is full (420)")
+                    DistributedNotificationCenter.default().postNotificationName(
+                        .storageFull,
+                        object: nil,
+                        userInfo: nil,
+                        deliverImmediately: true
+                    )
+                    completionHandler(nil, [], false, NSError(domain: NSFileProviderErrorDomain, code: NSFileProviderError.insufficientQuota.rawValue))
+                } else if let apiClientError = error as? APIClientError, apiClientError.statusCode == 402 {
                     self.logger.error("❌ Cannot synchronize file due to payment/quota issue (402)")
                     completionHandler(nil, [], false, NSError(domain: NSFileProviderErrorDomain, code: NSFileProviderError.cannotSynchronize.rawValue))
                 } else {

--- a/XPCBackupService/Services/BackupUploadService.swift
+++ b/XPCBackupService/Services/BackupUploadService.swift
@@ -80,33 +80,6 @@ class BackupUploadService:  BackupUploadServiceProtocol, ObservableObject {
         return decoded.message
     }
 
-
-    private func is420StorageFull(_ error: Error) -> Bool {
-        // Direct APIClientError
-        if let apiError = error as? APIClientError, apiError.statusCode == 420 { return true }
-        
-        // EnrichedError wrapping APIClientError (single upload < 100MB)
-        if let enriched = error as? EnrichedError,
-           let apiError = enriched.cause as? APIClientError,
-           apiError.statusCode == 420 { return true }
-        
-        // EnrichedError wrapping UploadError.PartUploadFailed (multipart >= 100MB)
-        if let enriched = error as? EnrichedError,
-           let partFailed = enriched.cause as? UploadError,
-           case .PartUploadFailed(_, let innerError) = partFailed,
-           let apiError = innerError as? APIClientError,
-           apiError.statusCode == 420 { return true }
-        
-        // Direct UploadError.PartUploadFailed
-        if let partFailed = error as? UploadError,
-           case .PartUploadFailed(_, let innerError) = partFailed,
-           let apiError = innerError as? APIClientError,
-           apiError.statusCode == 420 { return true }
-        
-        return false
-    }
-
-
     private var backupNewAPI: BackupAPI {
         return BackupAPI(baseUrl: config.DRIVE_NEW_API_URL, authToken: newAuthToken, clientName: CLIENT_NAME, clientVersion: getVersion())
     }
@@ -400,7 +373,7 @@ class BackupUploadService:  BackupUploadServiceProtocol, ObservableObject {
             }
 
         } catch {
-            if is420StorageFull(error) {
+            if error.isStorageFull {
                 if encryptedContentURL != nil {
                     try? FileManager.default.removeItem(at: encryptedContentURL!)
                 }


### PR DESCRIPTION
## Description
This PR resolves an issue where HTTP 420 (Storage Full) errors during Drive synchronization operations (FileProvider / SyncExtension) were not being handled. This lack of error catching caused the system to perform endless sync retries and left the user without any visual alert in the desktop interface.

## Changes Made
- **FileProvider Integration**: Standardized error propagation to Finder by returning `NSFileProviderError.insufficientQuota`, allowing macOS to throttle retries via its native backoff mechanism.
- **Visual Alert Propagation**: Triggered the `.storageFull` distributed notification from the SyncExtension to display the desktop app's custom storage alert.
- **Aesthetics & Optimizations**: Added a visibility guard to prevent redundant focus-stealing or duplicate window activations when multiple file syncs fail in parallel.
