### PR TITLE
 fix: stop sync extension from iterating on failed files when deleted

### DIFF
--- a/SyncExtension/FileProviderExtension.swift
+++ b/SyncExtension/FileProviderExtension.swift
@@ -326,8 +326,15 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension, NSFile
         
         
         if itemTemplate.parentItemIdentifier == .trashContainer {
-            logger.info("parent deleted, not creating item")
-            let error = NSError.fileProviderErrorForNonExistentItem(withIdentifier: itemTemplate.itemIdentifier)
+            logger.info("Parent is trashContainer, skipping item creation and signaling cannotSynchronize")
+            let error = NSError(
+                domain: NSFileProviderErrorDomain,
+                code: NSFileProviderError.cannotSynchronize.rawValue,
+                userInfo: [
+                    NSLocalizedDescriptionKey: "Item parent is in trash, skipping creation",
+                    NSFileProviderErrorItemKey: itemTemplate.itemIdentifier.rawValue
+                ]
+            )
             completionHandler(nil, [], false, error)
             return Progress()
         }

--- a/SyncExtension/UseCases/All/GetFileOrFolderMetaUseCase.swift
+++ b/SyncExtension/UseCases/All/GetFileOrFolderMetaUseCase.swift
@@ -132,6 +132,9 @@ struct GetFileOrFolderMetaUseCase {
                     }
                 }
                 throw GetFileOrFolderMetaUseCaseError.FileOrFolderMetaNotFound
+            } catch GetFileOrFolderMetaUseCaseError.FileOrFolderMetaNotFound {
+                self.logger.info("Item \(identifier.rawValue) was not found on the server, signaling nonExistentItem to stop retries")
+                completionHandler(nil, NSError.fileProviderErrorForNonExistentItem(withIdentifier: identifier))
             } catch {
                 error.reportToSentry()
                 self.logger.error("❌ Failed to get item meta for \(identifier.rawValue): \(error.getErrorDescription())")


### PR DESCRIPTION
## Description
Fixes an issue where macOS kept iterating and trying to synchronize a file that had previously failed (e.g., due to upload errors) even after the user deleted it (moved it to the trash). 

By returning `.cannotSynchronize` when the destination is `.trashContainer`, we signal macOS to stop retrying and discard the failed item. Additionally, we ensure that missing items on the server return `fileProviderErrorForNonExistentItem` to prevent endless metadata lookup retries.

## Changes
* **FileProviderExtension.swift**: Return `.cannotSynchronize` in `createItem` if the target parent is `.trashContainer` to stop the retry loop on deleted failed files.
* **GetFileOrFolderMetaUseCase.swift**: Properly catch `FileOrFolderMetaNotFound` and return `fileProviderErrorForNonExistentItem` so macOS stops requesting metadata for non-existent items.
