### PR TITLE
Optimize token refresh scheduling for shorter backend token expiry

### DIFF
--- a/InternxtDesktop.xcodeproj/project.pbxproj
+++ b/InternxtDesktop.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		31F9EF2D2B867F42007DAD86 /* ErrorUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16ECC132A9508B10093D3ED /* ErrorUtils.swift */; };
 		31F9EF2E2B867FE9007DAD86 /* APIFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E109717E2A81143A00ABED41 /* APIFactory.swift */; };
 		31F9EF2F2B867FED007DAD86 /* Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1CC520B2A98B460009DEEAA /* Bundle.swift */; };
+		AA0424162FE36A22001E29EF /* StorageFullDialogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0424152FE36A22001E29EF /* StorageFullDialogView.swift */; };
 		AA0889102C4AF27C00D5CC40 /* SyncExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA08890F2C4AF27C00D5CC40 /* SyncExtensionTests.swift */; };
 		AA08891C2C4AF29F00D5CC40 /* InternxtDesktopTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA08891B2C4AF29F00D5CC40 /* InternxtDesktopTests.swift */; };
 		AA08F36D2DEE5DF400F9D0CA /* FolderMetaCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA08F36C2DEE5DF400F9D0CA /* FolderMetaCache.swift */; };
@@ -526,6 +527,7 @@
 		31DEAEC02B75143F00E76D53 /* XPCBackupServiceDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XPCBackupServiceDelegate.swift; sourceTree = "<group>"; };
 		31EBEF722B32006F0017590F /* WidgetBackupBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetBackupBannerView.swift; sourceTree = "<group>"; };
 		31ED949C2B7151E200EF699F /* DecryptUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecryptUtils.swift; sourceTree = "<group>"; };
+		AA0424152FE36A22001E29EF /* StorageFullDialogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageFullDialogView.swift; sourceTree = "<group>"; };
 		AA08890D2C4AF27C00D5CC40 /* SyncExtensionTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SyncExtensionTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AA08890F2C4AF27C00D5CC40 /* SyncExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncExtensionTests.swift; sourceTree = "<group>"; };
 		AA0889192C4AF29F00D5CC40 /* InternxtDesktopTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = InternxtDesktopTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1075,6 +1077,7 @@
 				E13B83962AFBBCD7009F6684 /* AppSettingsManagerView.swift */,
 				AA9B1BA02FB4094D000E582A /* FileSizeLimitDialogView.swift */,
 				AA3D129D2FE0F4C0000ECA4C /* EmptyFileLimitDialogView.swift */,
+				AA0424152FE36A22001E29EF /* StorageFullDialogView.swift */,
 			);
 			path = App;
 			sourceTree = "<group>";
@@ -2054,6 +2057,7 @@
 				315BC68D2B3DDE4E004C85D8 /* BackupsTabView.swift in Sources */,
 				E18300AE2AA230A600AD023C /* WidgetSyncEntryView.swift in Sources */,
 				E1880BA02AA63215001FC171 /* StartOnLaunchView.swift in Sources */,
+				AA0424162FE36A22001E29EF /* StorageFullDialogView.swift in Sources */,
 				E1880B9E2AA6294D001FC171 /* AppCheckbox.swift in Sources */,
 				E1CC520C2A98B460009DEEAA /* Bundle.swift in Sources */,
 				AA40B3C12D3ED74400FC1FC3 /* AntivirusManager.swift in Sources */,

--- a/InternxtDesktop.xcodeproj/project.pbxproj
+++ b/InternxtDesktop.xcodeproj/project.pbxproj
@@ -2210,7 +2210,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 86;
+				CURRENT_PROJECT_VERSION = 87;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=macosx*]" = JR4S3SY396;
@@ -2223,7 +2223,7 @@
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MACOSX_DEPLOYMENT_TARGET = 13.5;
-				MARKETING_VERSION = 2.6.7;
+				MARKETING_VERSION = 2.6.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.internxt.XPCBackupService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2245,7 +2245,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 86;
+				CURRENT_PROJECT_VERSION = 87;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=macosx*]" = JR4S3SY396;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -2257,7 +2257,7 @@
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MACOSX_DEPLOYMENT_TARGET = 13.5;
-				MARKETING_VERSION = 2.6.7;
+				MARKETING_VERSION = 2.6.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.internxt.XPCBackupService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2278,7 +2278,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 86;
+				CURRENT_PROJECT_VERSION = 87;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=macosx*]" = JR4S3SY396;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -2290,7 +2290,7 @@
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MACOSX_DEPLOYMENT_TARGET = 13.5;
-				MARKETING_VERSION = 2.6.7;
+				MARKETING_VERSION = 2.6.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.internxt.XPCBackupService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2672,7 +2672,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 86;
+				CURRENT_PROJECT_VERSION = 87;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"InternxtDesktop/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
@@ -2696,7 +2696,7 @@
 					"$(PROJECT_DIR)/InternxtDesktop/ClamAVResources/lib",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.5;
-				MARKETING_VERSION = 2.6.7;
+				MARKETING_VERSION = 2.6.8;
 				PRODUCT_BUNDLE_IDENTIFIER = internxt.InternxtDesktop;
 				PRODUCT_MODULE_NAME = Internxt;
 				PRODUCT_NAME = "Internxt Drive";
@@ -2716,7 +2716,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 86;
+				CURRENT_PROJECT_VERSION = 87;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=macosx*]" = JR4S3SY396;
@@ -2731,7 +2731,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.5;
-				MARKETING_VERSION = 2.6.7;
+				MARKETING_VERSION = 2.6.8;
 				PRODUCT_BUNDLE_IDENTIFIER = internxt.InternxtDesktop.sync;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = internxt_desktop_ci_profile;
@@ -2883,7 +2883,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 86;
+				CURRENT_PROJECT_VERSION = 87;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"InternxtDesktop/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
@@ -2906,7 +2906,7 @@
 					"$(PROJECT_DIR)/InternxtDesktop/ClamAVResources/lib",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.5;
-				MARKETING_VERSION = 2.6.7;
+				MARKETING_VERSION = 2.6.8;
 				PRODUCT_BUNDLE_IDENTIFIER = internxt.InternxtDesktop;
 				PRODUCT_MODULE_NAME = Internxt;
 				PRODUCT_NAME = "Internxt Drive";
@@ -2929,7 +2929,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 86;
+				CURRENT_PROJECT_VERSION = 87;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"InternxtDesktop/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
@@ -2952,7 +2952,7 @@
 					"$(PROJECT_DIR)/InternxtDesktop/ClamAVResources/lib",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.5;
-				MARKETING_VERSION = 2.6.7;
+				MARKETING_VERSION = 2.6.8;
 				PRODUCT_BUNDLE_IDENTIFIER = internxt.InternxtDesktop;
 				PRODUCT_MODULE_NAME = Internxt;
 				PRODUCT_NAME = "Internxt Drive";
@@ -2971,7 +2971,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 86;
+				CURRENT_PROJECT_VERSION = 87;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=macosx*]" = JR4S3SY396;
@@ -2986,7 +2986,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.5;
-				MARKETING_VERSION = 2.6.7;
+				MARKETING_VERSION = 2.6.8;
 				PRODUCT_BUNDLE_IDENTIFIER = internxt.InternxtDesktop.sync;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -3005,7 +3005,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 86;
+				CURRENT_PROJECT_VERSION = 87;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=macosx*]" = JR4S3SY396;
@@ -3020,7 +3020,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.5;
-				MARKETING_VERSION = 2.6.7;
+				MARKETING_VERSION = 2.6.8;
 				PRODUCT_BUNDLE_IDENTIFIER = internxt.InternxtDesktop.sync;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = internxt_desktop_ci_profile;

--- a/InternxtDesktop/AppDelegate.swift
+++ b/InternxtDesktop/AppDelegate.swift
@@ -59,6 +59,7 @@ class AppDelegate: NSObject, NSApplicationDelegate , PKPushRegistryDelegate {
     var notificationsTimer: AnyCancellable?
     let fileSizeLimitState = FileSizeLimitState()
     let emptyFileLimitState = EmptyFileLimitState()
+    let storageFullState = StorageFullState()
     private var backupAlertsCoordinator: BackupAlertsCoordinator!
     var usageUpdateDebouncer = Debouncer(delay: 15.0)
     private let driveNewAPI: DriveAPI = APIFactory.DriveNew
@@ -117,10 +118,18 @@ class AppDelegate: NSObject, NSApplicationDelegate , PKPushRegistryDelegate {
             self?.backupAlertsCoordinator?.handleEmptyFileLimitReached()
         }
 
+        DistributedNotificationCenter.default().addObserver(
+            forName: .storageFull,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.backupAlertsCoordinator?.handleStorageFullReached()
+        }
+
         checkVolumeAndEjectIfNeeded()
         
         self.windowsManager = WindowsManager(
-            initialWindows: defaultWindows(settingsManager: settingsManager, authManager: authManager, usageManager: usageManager, backupsService: backupsService, scheduleManager: scheduledManager, antivirusManager: antivirusManager, cleanerService: cleanerService, updater: updaterController.updater, closeSendFeedbackWindow: closeSendFeedbackWindow, finishOrSkipOnboarding: self.finishOrSkipOnboarding, fileSizeLimitState: fileSizeLimitState, emptyFileLimitState: emptyFileLimitState),
+            initialWindows: defaultWindows(settingsManager: settingsManager, authManager: authManager, usageManager: usageManager, backupsService: backupsService, scheduleManager: scheduledManager, antivirusManager: antivirusManager, cleanerService: cleanerService, updater: updaterController.updater, closeSendFeedbackWindow: closeSendFeedbackWindow, finishOrSkipOnboarding: self.finishOrSkipOnboarding, fileSizeLimitState: fileSizeLimitState, emptyFileLimitState: emptyFileLimitState, storageFullState: storageFullState),
             onWindowClose: receiveOnWindowClose
         )
         self.windowsManager.loadInitialWindows()
@@ -128,6 +137,7 @@ class AppDelegate: NSObject, NSApplicationDelegate , PKPushRegistryDelegate {
         self.backupAlertsCoordinator = BackupAlertsCoordinator(
             fileSizeLimitState: fileSizeLimitState,
             emptyFileLimitState: emptyFileLimitState,
+            storageFullState: storageFullState,
             windowsManager: windowsManager
         )
 

--- a/InternxtDesktop/AppDelegate.swift
+++ b/InternxtDesktop/AppDelegate.swift
@@ -364,6 +364,7 @@ class AppDelegate: NSObject, NSApplicationDelegate , PKPushRegistryDelegate {
     }
     
     private func startTokensRefreshing() {
+        self.refreshTokensTimer?.cancel()
         self.refreshTokensTimer =  Timer.publish(every: 30, on:.main, in: .common).autoconnect().sink(
             receiveValue: {_ in
                 self.checkRefreshToken()

--- a/InternxtDesktop/Services/Auth/AuthManager.swift
+++ b/InternxtDesktop/Services/Auth/AuthManager.swift
@@ -24,7 +24,7 @@ class AuthManager: ObservableObject {
 
     public let config = ConfigLoader()
     public let cryptoUtils = CryptoUtils()
-    private let REFRESH_TOKEN_DEADLINE = 5
+    private let REFRESH_TOKEN_DEADLINE_SECONDS = 14400
     init() {
         self.isLoggedIn = checkIsLoggedIn()
         self.user = config.getUser()
@@ -220,22 +220,18 @@ class AuthManager: ObservableObject {
         let authTokenExpirationDate = Date(timeIntervalSince1970: TimeInterval(authTokenExpirationTimestamp))
         let authTokenCreationDate = Date(timeIntervalSince1970: TimeInterval(authTokenCreationTimestamp))
 
+        let currentTimestamp = Int(Date().timeIntervalSince1970)
+        let secondsUntilExpiration = authTokenExpirationTimestamp - currentTimestamp
+        let elapsedTime = currentTimestamp - authTokenCreationTimestamp
+        
+        let needsRefresh = elapsedTime >= REFRESH_TOKEN_DEADLINE_SECONDS || secondsUntilExpiration <= REFRESH_TOKEN_DEADLINE_SECONDS
         
         let daysUntilAuthTokenExpires = Date().daysUntil(authTokenExpirationDate) ?? 1
         
-        if daysUntilAuthTokenExpires <= REFRESH_TOKEN_DEADLINE {
-            return NeedsTokenRefreshResult(
-                needsRefresh: true,
-                authTokenCreationDate: authTokenCreationDate,
-                authTokenDaysUntilExpiration: daysUntilAuthTokenExpires,
-            )
-        }
-        
-
         return NeedsTokenRefreshResult(
-            needsRefresh: false,
+            needsRefresh: needsRefresh,
             authTokenCreationDate: authTokenCreationDate,
-            authTokenDaysUntilExpiration: daysUntilAuthTokenExpires,
+            authTokenDaysUntilExpiration: daysUntilAuthTokenExpires
         )
     }
     

--- a/InternxtDesktop/Views/App/StorageFullDialogView.swift
+++ b/InternxtDesktop/Views/App/StorageFullDialogView.swift
@@ -1,0 +1,99 @@
+//
+//  StorageFullDialogView.swift
+//  InternxtDesktop
+//
+//  Created by Patricio Tovar on 17/6/26.
+//
+
+import SwiftUI
+
+class StorageFullState: ObservableObject {
+    @Published var isVisible: Bool = false
+}
+
+struct StorageFullDialogView: View {
+    @Environment(\.colorScheme) var colorScheme
+
+    var onClose: () -> Void
+    var onUpgrade: () -> Void
+
+    private var titleText: String {
+        return NSLocalizedString(
+            "storage_full_title",
+            value: "Your storage is full",
+            comment: "Alert title when the user runs out of storage space"
+        )
+    }
+
+    private var messageText: String {
+        return NSLocalizedString(
+            "storage_full_message",
+            value: "You have run out of space on Internxt. Upgrade your plan to continue backing up your files.",
+            comment: "Alert body when storage is full"
+        )
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text(titleText)
+                .font(.XLMedium)
+                .foregroundColor(.DefaultTextStrong)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.bottom, 12)
+
+            Text(messageText)
+                .font(.SMRegular)
+                .foregroundColor(.Gray60)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.bottom, 24)
+
+            Spacer()
+
+            HStack(spacing: 8) {
+                Spacer()
+                AppButton(
+                    title: "Close",
+                    onClick: { onClose() },
+                    type: .secondary,
+                    size: .MD
+                )
+                AppButton(
+                    title: "Upgrade plan",
+                    onClick: { onUpgrade() },
+                    type: .primary,
+                    size: .MD
+                )
+            }
+        }
+        .padding(24)
+        .frame(width: 420, height: 200)
+    }
+}
+
+struct StorageFullWindowView: View {
+    @EnvironmentObject var state: StorageFullState
+    @Environment(\.colorScheme) var colorScheme
+
+    var body: some View {
+        ZStack {
+            (colorScheme == .dark ? Color.Gray1 : Color.white)
+                .ignoresSafeArea()
+
+            StorageFullDialogView(
+                onClose: {
+                    state.isVisible = false
+                    if let window = NSApp.windows.first(where: { $0.identifier?.rawValue == "storage-full" }) {
+                        window.close()
+                    }
+                },
+                onUpgrade: {
+                    URLDictionary.UPGRADE_PLAN_DEEP_LINK.open()
+                    state.isVisible = false
+                    if let window = NSApp.windows.first(where: { $0.identifier?.rawValue == "storage-full" }) {
+                        window.close()
+                    }
+                }
+            )
+        }
+    }
+}

--- a/InternxtDesktop/Windows.swift
+++ b/InternxtDesktop/Windows.swift
@@ -15,7 +15,7 @@ import Sparkle
 /// creating them
 func defaultWindows(settingsManager: SettingsTabManager, authManager: AuthManager, usageManager: UsageManager, backupsService: BackupsService, scheduleManager: ScheduledBackupManager,antivirusManager : AntivirusManager ,
                     cleanerService: CleanerService,updater: SPUUpdater, closeSendFeedbackWindow: @escaping () -> Void, finishOrSkipOnboarding: @escaping () -> Void,
-                    fileSizeLimitState: FileSizeLimitState, emptyFileLimitState: EmptyFileLimitState) -> [WindowConfig] {
+                    fileSizeLimitState: FileSizeLimitState, emptyFileLimitState: EmptyFileLimitState, storageFullState: StorageFullState) -> [WindowConfig] {
     let windows = [
         WindowConfig(
             view: AnyView(AppSettingsManagerView{SignInWithBrowserView().environmentObject(authManager)}),
@@ -73,6 +73,18 @@ func defaultWindows(settingsManager: SettingsTabManager, authManager: AuthManage
             ),
             title: nil,
             id: "empty-file-limit",
+            width: 420,
+            height: 200,
+            fixedToFront: true,
+            backgroundColor: Color.clear
+        ),
+        WindowConfig(
+            view: AnyView(
+                StorageFullWindowView()
+                    .environmentObject(storageFullState)
+            ),
+            title: nil,
+            id: "storage-full",
             width: 420,
             height: 200,
             fixedToFront: true,

--- a/Shared/Extensions/Error.swift
+++ b/Shared/Extensions/Error.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import InternxtSwiftCore
-import AppKit
 
 extension Error {
     func reportToSentry() {
@@ -48,20 +47,30 @@ extension Error {
             }
         }
     }
-}
 
-extension NSAlert {
-    static func showStorageFullAlert() {
-        let alert = NSAlert()
-        alert.messageText = NSLocalizedString("ALERT_STORAGE_TITLE", comment: "")
-        alert.informativeText = NSLocalizedString("ALERT_STORAGE_SUBTITLE", comment: "")
-        alert.alertStyle = .warning
-        alert.addButton(withTitle: NSLocalizedString("ALERT_STORAGE_BUTTON_TITLE", comment: ""))
-        alert.addButton(withTitle: NSLocalizedString("COMMON_CANCEL", comment: ""))
-        let response = alert.runModal()
-        if response == .alertFirstButtonReturn {
-            URLDictionary.UPGRADE_PLAN.open()
-        }
+    var isStorageFull: Bool {
+        // Case 1: Direct APIClientError
+        if let apiError = self as? APIClientError, apiError.statusCode == 420 { return true }
+        
+        // Case 2: EnrichedError wrapping APIClientError (single upload < 100MB)
+        if let enriched = self as? EnrichedError,
+            let apiError = enriched.cause as? APIClientError,
+            apiError.statusCode == 420 { return true }
+        
+        // Case 3: EnrichedError wrapping UploadError.PartUploadFailed (multipart >= 100MB)
+        if let enriched = self as? EnrichedError,
+            let partFailed = enriched.cause as? UploadError,
+            case .PartUploadFailed(_, let innerError) = partFailed,
+            let apiError = innerError as? APIClientError,
+            apiError.statusCode == 420 { return true }
+        
+        // Case 4: Direct UploadError.PartUploadFailed
+        if let partFailed = self as? UploadError,
+            case .PartUploadFailed(_, let innerError) = partFailed,
+            let apiError = innerError as? APIClientError,
+            apiError.statusCode == 420 { return true }
+        
+        return false
     }
 }
 

--- a/Shared/Extensions/Error.swift
+++ b/Shared/Extensions/Error.swift
@@ -67,4 +67,5 @@ extension NSAlert {
 
 extension Notification.Name {
     static let userDidLogout = Notification.Name("userDidLogout")
+    static let storageFull = Notification.Name("com.internxt.drive.storageFull")
 }

--- a/Shared/Services/BackupAlertsCoordinator.swift
+++ b/Shared/Services/BackupAlertsCoordinator.swift
@@ -11,6 +11,7 @@ import Foundation
 final class BackupAlertsCoordinator {
     private let fileSizeLimitState: FileSizeLimitState
     private let emptyFileLimitState: EmptyFileLimitState
+    private let storageFullState: StorageFullState
     private let windowsManager: WindowsManager
 
     private let debounceInterval: TimeInterval = 0.6
@@ -23,9 +24,10 @@ final class BackupAlertsCoordinator {
     private var emptyFilePendingAlert: DispatchWorkItem?
     private var emptyFileAlertIsShowing = false
 
-    init(fileSizeLimitState: FileSizeLimitState, emptyFileLimitState: EmptyFileLimitState, windowsManager: WindowsManager) {
+    init(fileSizeLimitState: FileSizeLimitState, emptyFileLimitState: EmptyFileLimitState, storageFullState: StorageFullState, windowsManager: WindowsManager) {
         self.fileSizeLimitState = fileSizeLimitState
         self.emptyFileLimitState = emptyFileLimitState
+        self.storageFullState = storageFullState
         self.windowsManager = windowsManager
     }
 
@@ -85,5 +87,10 @@ final class BackupAlertsCoordinator {
 
         windowsManager.openWindow(id: "empty-file-limit")
         emptyFileAlertIsShowing = false
+    }
+
+    public func handleStorageFullReached() {
+        storageFullState.isVisible = true
+        windowsManager.openWindow(id: "storage-full")
     }
 }

--- a/Shared/Services/BackupAlertsCoordinator.swift
+++ b/Shared/Services/BackupAlertsCoordinator.swift
@@ -90,6 +90,7 @@ final class BackupAlertsCoordinator {
     }
 
     public func handleStorageFullReached() {
+        guard !storageFullState.isVisible else { return }
         storageFullState.isVisible = true
         windowsManager.openWindow(id: "storage-full")
     }

--- a/Shared/Services/Backups/BackupsService.swift
+++ b/Shared/Services/Backups/BackupsService.swift
@@ -790,9 +790,12 @@ class BackupsService: ObservableObject {
     }
     
     private func showAlert() {
-        DispatchQueue.main.async {
-            NSAlert.showStorageFullAlert()
-        }
+        DistributedNotificationCenter.default().postNotificationName(
+            .storageFull,
+            object: nil,
+            userInfo: nil,
+            deliverImmediately: true
+        )
     }
 
     @MainActor

--- a/SyncExtension/FileProviderExtension.swift
+++ b/SyncExtension/FileProviderExtension.swift
@@ -326,8 +326,15 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension, NSFile
         
         
         if itemTemplate.parentItemIdentifier == .trashContainer {
-            logger.info("parent deleted, not creating item")
-            let error = NSError.fileProviderErrorForNonExistentItem(withIdentifier: itemTemplate.itemIdentifier)
+            logger.info("Parent is trashContainer, skipping item creation and signaling cannotSynchronize")
+            let error = NSError(
+                domain: NSFileProviderErrorDomain,
+                code: NSFileProviderError.cannotSynchronize.rawValue,
+                userInfo: [
+                    NSLocalizedDescriptionKey: "Item parent is in trash, skipping creation",
+                    NSFileProviderErrorItemKey: itemTemplate.itemIdentifier.rawValue
+                ]
+            )
             completionHandler(nil, [], false, error)
             return Progress()
         }

--- a/SyncExtension/UseCases/All/GetFileOrFolderMetaUseCase.swift
+++ b/SyncExtension/UseCases/All/GetFileOrFolderMetaUseCase.swift
@@ -132,6 +132,9 @@ struct GetFileOrFolderMetaUseCase {
                     }
                 }
                 throw GetFileOrFolderMetaUseCaseError.FileOrFolderMetaNotFound
+            } catch GetFileOrFolderMetaUseCaseError.FileOrFolderMetaNotFound {
+                self.logger.info("Item \(identifier.rawValue) was not found on the server, signaling nonExistentItem to stop retries")
+                completionHandler(nil, NSError.fileProviderErrorForNonExistentItem(withIdentifier: identifier))
             } catch {
                 error.reportToSentry()
                 self.logger.error("❌ Failed to get item meta for \(identifier.rawValue): \(error.getErrorDescription())")

--- a/SyncExtension/UseCases/Files/UpdateFileContentUseCase.swift
+++ b/SyncExtension/UseCases/Files/UpdateFileContentUseCase.swift
@@ -130,7 +130,16 @@ struct UpdateFileContentUseCase {
                 error.reportToSentry()
                 self.logger.error("❌ Failed to update file content: \(error.getErrorDescription())")
                 
-                if let apiClientError = error as? APIClientError, apiClientError.statusCode == 402 {
+                if error.isStorageFull {
+                    self.logger.error("❌ Cannot synchronize file: destination storage is full (420)")
+                    DistributedNotificationCenter.default().postNotificationName(
+                        .storageFull,
+                        object: nil,
+                        userInfo: nil,
+                        deliverImmediately: true
+                    )
+                    completionHandler(nil, [], false, NSError(domain: NSFileProviderErrorDomain, code: NSFileProviderError.insufficientQuota.rawValue))
+                } else if let apiClientError = error as? APIClientError, apiClientError.statusCode == 402 {
                     self.logger.error("❌ Cannot synchronize file due to payment/quota issue (402)")
                     completionHandler(nil, [], false, NSError(domain: NSFileProviderErrorDomain, code: NSFileProviderError.cannotSynchronize.rawValue))
                 } else {

--- a/SyncExtension/UseCases/Files/UploadFileUseCase.swift
+++ b/SyncExtension/UseCases/Files/UploadFileUseCase.swift
@@ -190,7 +190,16 @@ struct UploadFileUseCase {
                 self.logger.error("❌ Failed to create file \(item.filename) : \(error.getErrorDescription())")
                 
                
-                if let apiClientError = error as? APIClientError, apiClientError.statusCode == 402 {
+                if error.isStorageFull {
+                    self.logger.error("❌ Cannot synchronize file: destination storage is full (420)")
+                    DistributedNotificationCenter.default().postNotificationName(
+                        .storageFull,
+                        object: nil,
+                        userInfo: nil,
+                        deliverImmediately: true
+                    )
+                    completionHandler(nil, [], false, NSError(domain: NSFileProviderErrorDomain, code: NSFileProviderError.insufficientQuota.rawValue))
+                } else if let apiClientError = error as? APIClientError, apiClientError.statusCode == 402 {
                     self.logger.error("❌ Cannot synchronize file due to payment/quota issue (402)")
                     completionHandler(nil, [], false, NSError(domain: NSFileProviderErrorDomain, code: NSFileProviderError.cannotSynchronize.rawValue))
                 } else {

--- a/SyncExtension/UseCases/Files/Workspaces/UpdateFileContentWorkspaceUseCase.swift
+++ b/SyncExtension/UseCases/Files/Workspaces/UpdateFileContentWorkspaceUseCase.swift
@@ -120,7 +120,16 @@ struct UpdateFileContentWorkspaceUseCase {
                 error.reportToSentry()
                 self.logger.error("❌ Failed to update file content: \(error.getErrorDescription())")
                 
-                if let apiClientError = error as? APIClientError, apiClientError.statusCode == 402 {
+                if error.isStorageFull {
+                    self.logger.error("❌ Cannot synchronize file: destination storage is full (420)")
+                    DistributedNotificationCenter.default().postNotificationName(
+                        .storageFull,
+                        object: nil,
+                        userInfo: nil,
+                        deliverImmediately: true
+                    )
+                    completionHandler(nil, [], false, NSError(domain: NSFileProviderErrorDomain, code: NSFileProviderError.insufficientQuota.rawValue))
+                } else if let apiClientError = error as? APIClientError, apiClientError.statusCode == 402 {
                     self.logger.error("❌ Cannot synchronize file due to payment/quota issue (402)")
                     completionHandler(nil, [], false, NSError(domain: NSFileProviderErrorDomain, code: NSFileProviderError.cannotSynchronize.rawValue))
                 } else {

--- a/SyncExtension/UseCases/Files/Workspaces/UploadFileWorkspaceUseCase.swift
+++ b/SyncExtension/UseCases/Files/Workspaces/UploadFileWorkspaceUseCase.swift
@@ -236,7 +236,16 @@ struct UploadFileWorkspaceUseCase {
                 activityManager.updateActivityEntryStatus(id: inProgressId, filename: item.filename, kind: .upload, status: .failed)
                 self.logger.error("❌ Failed to create file: \(error.getErrorDescription())")
                 
-                if let apiClientError = error as? APIClientError, apiClientError.statusCode == 402 {
+                if error.isStorageFull {
+                    self.logger.error("❌ Cannot synchronize file: destination storage is full (420)")
+                    DistributedNotificationCenter.default().postNotificationName(
+                        .storageFull,
+                        object: nil,
+                        userInfo: nil,
+                        deliverImmediately: true
+                    )
+                    completionHandler(nil, [], false, NSError(domain: NSFileProviderErrorDomain, code: NSFileProviderError.insufficientQuota.rawValue))
+                } else if let apiClientError = error as? APIClientError, apiClientError.statusCode == 402 {
                     self.logger.error("❌ Cannot synchronize file due to payment/quota issue (402)")
                     completionHandler(nil, [], false, NSError(domain: NSFileProviderErrorDomain, code: NSFileProviderError.cannotSynchronize.rawValue))
                 } else {

--- a/XPCBackupService/Entities/BackupTreeNode.swift
+++ b/XPCBackupService/Entities/BackupTreeNode.swift
@@ -220,6 +220,10 @@ class BackupTreeNode {
                 throw BackupError.storageFull
             }
             
+            else if case BackupUploadError.StorageFull = error {
+                throw BackupError.storageFull
+            }
+            
                 if case BackupUploadError.BackupStoppedManually = error {
                     // Noop, this was stopped
                   return

--- a/XPCBackupService/Services/BackupUploadService.swift
+++ b/XPCBackupService/Services/BackupUploadService.swift
@@ -80,33 +80,6 @@ class BackupUploadService:  BackupUploadServiceProtocol, ObservableObject {
         return decoded.message
     }
 
-
-    private func is420StorageFull(_ error: Error) -> Bool {
-        // Direct APIClientError
-        if let apiError = error as? APIClientError, apiError.statusCode == 420 { return true }
-        
-        // EnrichedError wrapping APIClientError (single upload < 100MB)
-        if let enriched = error as? EnrichedError,
-           let apiError = enriched.cause as? APIClientError,
-           apiError.statusCode == 420 { return true }
-        
-        // EnrichedError wrapping UploadError.PartUploadFailed (multipart >= 100MB)
-        if let enriched = error as? EnrichedError,
-           let partFailed = enriched.cause as? UploadError,
-           case .PartUploadFailed(_, let innerError) = partFailed,
-           let apiError = innerError as? APIClientError,
-           apiError.statusCode == 420 { return true }
-        
-        // Direct UploadError.PartUploadFailed
-        if let partFailed = error as? UploadError,
-           case .PartUploadFailed(_, let innerError) = partFailed,
-           let apiError = innerError as? APIClientError,
-           apiError.statusCode == 420 { return true }
-        
-        return false
-    }
-
-
     private var backupNewAPI: BackupAPI {
         return BackupAPI(baseUrl: config.DRIVE_NEW_API_URL, authToken: newAuthToken, clientName: CLIENT_NAME, clientVersion: getVersion())
     }
@@ -400,7 +373,7 @@ class BackupUploadService:  BackupUploadServiceProtocol, ObservableObject {
             }
 
         } catch {
-            if is420StorageFull(error) {
+            if error.isStorageFull {
                 if encryptedContentURL != nil {
                     try? FileManager.default.removeItem(at: encryptedContentURL!)
                 }

--- a/XPCBackupService/Services/BackupUploadService.swift
+++ b/XPCBackupService/Services/BackupUploadService.swift
@@ -33,6 +33,7 @@ enum BackupUploadError: Error {
     case FileSizeLimitExceeded
     case EmptyFileQuotaExceeded
     case EmptyFilePlanNotAllowed
+    case StorageFull
 }
 
 enum BackupDownloadError: Error {
@@ -77,6 +78,32 @@ class BackupUploadService:  BackupUploadServiceProtocol, ObservableObject {
               let decoded = try? JSONDecoder().decode(APIErrorBody.self, from: apiError.responseBody)
         else { return nil }
         return decoded.message
+    }
+
+
+    private func is420StorageFull(_ error: Error) -> Bool {
+        // Direct APIClientError
+        if let apiError = error as? APIClientError, apiError.statusCode == 420 { return true }
+        
+        // EnrichedError wrapping APIClientError (single upload < 100MB)
+        if let enriched = error as? EnrichedError,
+           let apiError = enriched.cause as? APIClientError,
+           apiError.statusCode == 420 { return true }
+        
+        // EnrichedError wrapping UploadError.PartUploadFailed (multipart >= 100MB)
+        if let enriched = error as? EnrichedError,
+           let partFailed = enriched.cause as? UploadError,
+           case .PartUploadFailed(_, let innerError) = partFailed,
+           let apiError = innerError as? APIClientError,
+           apiError.statusCode == 420 { return true }
+        
+        // Direct UploadError.PartUploadFailed
+        if let partFailed = error as? UploadError,
+           case .PartUploadFailed(_, let innerError) = partFailed,
+           let apiError = innerError as? APIClientError,
+           apiError.statusCode == 420 { return true }
+        
+        return false
     }
 
 
@@ -373,17 +400,18 @@ class BackupUploadService:  BackupUploadServiceProtocol, ObservableObject {
             }
 
         } catch {
+            if is420StorageFull(error) {
+                if encryptedContentURL != nil {
+                    try? FileManager.default.removeItem(at: encryptedContentURL!)
+                }
+                return .failure(BackupUploadError.StorageFull)
+            }
 
             if let uploadError = error as? UploadError, case .PartUploadFailed(let partIndex, let innerError) = uploadError {
                 self.logger.error("❌ Part upload failed at index \(partIndex): \(uploadError.localizedDescription)")
                 self.logger.info("ℹ️ Inner error details: \(String(describing: innerError))")
             } else {
                 self.logger.error("❌ Failed to create file \(node.name) in \(String(describing: node.remoteParentId)): \(error.getErrorDescription())")
-            }
-            if let startUploadError = error as? StartUploadError {
-                if let apiClientError = startUploadError.apiError,  apiClientError.statusCode == 420 {
-                    self.logger.error("❌ Failed to create file \(node.name) in \(String(describing: node.remoteParentId)): Max space used")
-                }
             }
 
             if encryptedContentURL != nil {


### PR DESCRIPTION
This PR optimizes the token refresh scheduling mechanism to accommodate the updated backend token expiration lifetime. 
Previously, the app used a day-based check (renewing if less than 5 days were remaining), which caused continuous redundant background network requests when the token's lifetime was shorter than that threshold. The renewal process is now hour-based, checking if the token has been active for more than 4 hours or if it has less than 4 hours remaining. We also ensure any previous timers are invalidated before scheduling a new one.