### PR TITLE
Optimize token refresh scheduling for shorter backend token expiry

### DIFF
--- a/InternxtDesktop/AppDelegate.swift
+++ b/InternxtDesktop/AppDelegate.swift
@@ -364,6 +364,7 @@ class AppDelegate: NSObject, NSApplicationDelegate , PKPushRegistryDelegate {
     }
     
     private func startTokensRefreshing() {
+        self.refreshTokensTimer?.cancel()
         self.refreshTokensTimer =  Timer.publish(every: 30, on:.main, in: .common).autoconnect().sink(
             receiveValue: {_ in
                 self.checkRefreshToken()

--- a/InternxtDesktop/Services/Auth/AuthManager.swift
+++ b/InternxtDesktop/Services/Auth/AuthManager.swift
@@ -24,7 +24,7 @@ class AuthManager: ObservableObject {
 
     public let config = ConfigLoader()
     public let cryptoUtils = CryptoUtils()
-    private let REFRESH_TOKEN_DEADLINE = 5
+    private let REFRESH_TOKEN_DEADLINE_SECONDS = 14400
     init() {
         self.isLoggedIn = checkIsLoggedIn()
         self.user = config.getUser()
@@ -220,22 +220,18 @@ class AuthManager: ObservableObject {
         let authTokenExpirationDate = Date(timeIntervalSince1970: TimeInterval(authTokenExpirationTimestamp))
         let authTokenCreationDate = Date(timeIntervalSince1970: TimeInterval(authTokenCreationTimestamp))
 
+        let currentTimestamp = Int(Date().timeIntervalSince1970)
+        let secondsUntilExpiration = authTokenExpirationTimestamp - currentTimestamp
+        let elapsedTime = currentTimestamp - authTokenCreationTimestamp
+        
+        let needsRefresh = elapsedTime >= REFRESH_TOKEN_DEADLINE_SECONDS || secondsUntilExpiration <= REFRESH_TOKEN_DEADLINE_SECONDS
         
         let daysUntilAuthTokenExpires = Date().daysUntil(authTokenExpirationDate) ?? 1
         
-        if daysUntilAuthTokenExpires <= REFRESH_TOKEN_DEADLINE {
-            return NeedsTokenRefreshResult(
-                needsRefresh: true,
-                authTokenCreationDate: authTokenCreationDate,
-                authTokenDaysUntilExpiration: daysUntilAuthTokenExpires,
-            )
-        }
-        
-
         return NeedsTokenRefreshResult(
-            needsRefresh: false,
+            needsRefresh: needsRefresh,
             authTokenCreationDate: authTokenCreationDate,
-            authTokenDaysUntilExpiration: daysUntilAuthTokenExpires,
+            authTokenDaysUntilExpiration: daysUntilAuthTokenExpires
         )
     }
     


### PR DESCRIPTION
This PR optimizes the token refresh scheduling mechanism to accommodate the updated backend token expiration lifetime. 
Previously, the app used a day-based check (renewing if less than 5 days were remaining), which caused continuous redundant background network requests when the token's lifetime was shorter than that threshold. The renewal process is now hour-based, checking if the token has been active for more than 4 hours or if it has less than 4 hours remaining. We also ensure any previous timers are invalidated before scheduling a new one.