### PR TITLE
Fix: Resolve deadlock in AsyncOperation state changes during KVO

### DIFF
--- a/Shared/Utils/AsyncOperation.swift
+++ b/Shared/Utils/AsyncOperation.swift
@@ -8,16 +8,20 @@
 import Foundation
 class AsyncOperation: Operation {
     
-    private let lockQueue = DispatchQueue(label: "com.internxt.AsyncOperation", attributes: .concurrent)
+    private let stateLock = NSRecursiveLock()
     
     private var _isExecuting: Bool = false
     override var isExecuting: Bool {
         get {
-            return lockQueue.sync { _isExecuting }
+            stateLock.lock()
+            defer { stateLock.unlock() }
+            return _isExecuting
         }
         set {
             willChangeValue(forKey: "isExecuting")
-            lockQueue.sync(flags: .barrier) { _isExecuting = newValue }
+            stateLock.lock()
+            _isExecuting = newValue
+            stateLock.unlock()
             didChangeValue(forKey: "isExecuting")
         }
     }
@@ -25,11 +29,15 @@ class AsyncOperation: Operation {
     private var _isFinished: Bool = false
     override var isFinished: Bool {
         get {
-            return lockQueue.sync { _isFinished }
+            stateLock.lock()
+            defer { stateLock.unlock() }
+            return _isFinished
         }
         set {
             willChangeValue(forKey: "isFinished")
-            lockQueue.sync(flags: .barrier) { _isFinished = newValue }
+            stateLock.lock()
+            _isFinished = newValue
+            stateLock.unlock()
             didChangeValue(forKey: "isFinished")
         }
     }
@@ -40,6 +48,7 @@ class AsyncOperation: Operation {
     
     override func start() {
         if isCancelled {
+            isExecuting = false
             isFinished = true
             return
         }


### PR DESCRIPTION
This PR resolves a critical deadlock in `XPCBackupService` that was causing file upload/download operations (specifically `UploadPartOperation`) to hang indefinitely.
### The Problem (Root Cause)
During concurrent operations, `AsyncOperation` managed its `isExecuting` and `isFinished` states using a `DispatchQueue` with a `.barrier` flag. 
When the setter called `didChangeValue(forKey:)`, Foundation's internal KVO observers synchronously called the `getter` to read the new value on the same thread. Since the queue was waiting on/processing the barrier block, this triggered a re-entrancy deadlock (`__ulock_wait`), freezing the execution thread permanently.
### The Solution
1. Replaced the `DispatchQueue` lock mechanism in `AsyncOperation` with `NSRecursiveLock`.
2. Wrapped state changes with the lock but kept `willChangeValue` / `didChangeValue` outside of the lock scope to prevent lock-inversion and re-entrancy issues.
3. Updated the `start()` method to properly trigger state changes if the operation is cancelled before starting.