### PR TITLE
fix: Prevent application startup crash by removing unsafe user unwrap in WidgetView

### DIFF
--- a/InternxtDesktop/Views/Widget/WidgetView.swift
+++ b/InternxtDesktop/Views/Widget/WidgetView.swift
@@ -67,7 +67,7 @@ struct WidgetView: View {
                 if authManager.user != nil {
                     
                     WidgetHeaderView(
-                        user: authManager.user!,
+                        user: authManager.user,
                         openFileProviderRoot: self.openFileProvider,
                         openSendFeedback: self.openSendFeedback
                     )


### PR DESCRIPTION
## Description
Fixes a crash on startup caused by a force-unwrap on `authManager.user` in `WidgetView`.
## Root Cause
During startup, `authManager.user` can temporarily be `nil` before the user profile initialization completes. Force-unwrapping it triggered a runtime abort.
## Changes
- Removed the force-unwrap from `authManager.user!` and passed it as an optional.
- `WidgetHeaderView` already supports optional `DriveUser?` and handles `nil` values safely.