### PR TITLE
Sync macOS document packages directly without ZIP compression

### DIFF
--- a/SyncExtension/FileProviderExtension.swift
+++ b/SyncExtension/FileProviderExtension.swift
@@ -387,10 +387,21 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension, NSFile
                         return
                     }
 
-                    let filename = NSString(string: itemTemplate.filename)
-                    let realPackageName = filename.deletingPathExtension
-                    let (processedURL, isZippedPackage, zipURL) = try self.packageHandler.handlePackageFileIfNeeded(url: contentUrl, realFilename: realPackageName)
-                    let finalExtension = isZippedPackage ? "zip" : filename.pathExtension
+                    let isPackage = FileProviderItem.isPackage(contentType: itemTemplate.contentType)
+                    var processedURL = contentUrl
+                    var isZippedPackage = false
+                    var zipURL: URL? = nil
+                    
+                    if !isPackage {
+                        let filename = NSString(string: itemTemplate.filename)
+                        let realPackageName = filename.deletingPathExtension
+                        let (pURL, isZip, zURL) = try self.packageHandler.handlePackageFileIfNeeded(url: contentUrl, realFilename: realPackageName)
+                        processedURL = pURL
+                        isZippedPackage = isZip
+                        zipURL = zURL
+                    }
+                    
+                    let finalExtension = isZippedPackage ? "zip" : (itemTemplate.filename as NSString).pathExtension
                     let fileCopy = self.makeTemporaryURL("plain", finalExtension)
                     
                     try FileManager.default.copyItem(at: processedURL, to: fileCopy)
@@ -400,7 +411,7 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension, NSFile
                     if let docSize = itemTemplate.documentSize {
                         templateSize = Int64(truncating: docSize!)
                     }
-                    let fileSize = attributesSize ?? templateSize ?? 0
+                    let fileSize = (isPackage ? templateSize : attributesSize) ?? templateSize ?? 0
 
                  
                     if !checkFileSizeLimit(
@@ -420,7 +431,7 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension, NSFile
                     let encryptedFileDestination = self.makeTemporaryURL("encrypted", "enc")
                     let thumbnailFileDestination = self.makeTemporaryURL("thumbnail", "jpg")
                     let encryptedThumbnailFileDestination = self.makeTemporaryURL("encrypted_thumbnail", "enc")
-                    let modifiedFilename = isZippedPackage ? "\(filename.deletingPathExtension).zip" : itemTemplate.filename
+                    let modifiedFilename = isZippedPackage ? "\(NSString(string: itemTemplate.filename).deletingPathExtension).zip" : itemTemplate.filename
                     
 
                   

--- a/SyncExtension/FileProviderItem.swift
+++ b/SyncExtension/FileProviderItem.swift
@@ -21,6 +21,39 @@ struct RemoteItem {
 }
 
 class FileProviderItem: NSObject, NSFileProviderItemProtocol, NSFileProviderItemDecorating {
+ 
+ 
+    public static func isPackage(contentType: UTType?) -> Bool {
+        guard let contentType else { return false }
+        if contentType == .folder { return false }
+        return contentType.conforms(to: .package) && !contentType.conforms(to: .bundle)
+    }
+
+    public static func isPackage(filename: String) -> Bool {
+        let ext = (filename as NSString).pathExtension.lowercased()
+        guard !ext.isEmpty else { return false }
+        
+        if let type = UTType(filenameExtension: ext), !type.isDynamic {
+            if type == .folder { return false }
+            return type.conforms(to: .package) && !type.conforms(to: .bundle)
+        }
+    
+        let knownIdentifiers: [String] = [
+            "com.apple.\(ext)",
+            "com.apple.dt.document.\(ext)",
+            "com.apple.iwork.\(ext).\(ext)"
+        ]
+        for id in knownIdentifiers {
+            if let type = UTType(id) {
+                if type == .folder { continue }
+                if type.conforms(to: .package) && !type.conforms(to: .bundle) {
+                    return true
+                }
+            }
+        }
+        return false
+    }
+    
     private let fileProviderItemActions = FileProviderItemActionsManager()
     private let identifier: NSFileProviderItemIdentifier
     private let parentIdentifier: NSFileProviderItemIdentifier

--- a/SyncExtension/UseCases/All/GetFileOrFolderMetaUseCase.swift
+++ b/SyncExtension/UseCases/All/GetFileOrFolderMetaUseCase.swift
@@ -116,14 +116,19 @@ struct GetFileOrFolderMetaUseCase {
 
                         let parentId = folderMeta.parentId.map { NSFileProviderItemIdentifier(String($0)) } ?? .rootContainer
 
+                        let folderName = (folderMeta.plainName ?? folderMeta.name) ?? ""
+                        let isPkg = FileProviderItem.isPackage(filename: folderName)
+                        let ext = isPkg ? (folderName as NSString).pathExtension : nil
+                        let itemType = isPkg ? RemoteItemType.file : RemoteItemType.folder
+
                         let folderItem = FileProviderItem(
                             identifier: self.identifier,
-                            filename: (folderMeta.plainName ?? folderMeta.name) ?? "",
+                            filename: folderName,
                             parentId: parentId,
                             createdAt: createdAt,
                             updatedAt: updatedAt,
-                            itemExtension: nil,
-                            itemType: .folder
+                            itemExtension: ext,
+                            itemType: itemType
                         )
 
                         completionHandler(folderItem, nil)

--- a/SyncExtension/UseCases/Files/DownloadFileUseCase.swift
+++ b/SyncExtension/UseCases/Files/DownloadFileUseCase.swift
@@ -146,7 +146,52 @@ struct DownloadFileUseCase {
                     progress.completedUnitCount = Int64(progressPercentage)
                 }
                 self.logger.info("⬇️ Fetching file \(itemIdentifier.rawValue)")
-                let file = try await getFileMetaWithRetry(uuid: itemIdentifier.rawValue, maxRetries: maxRetries)
+                
+                let idString = itemIdentifier.rawValue
+                let isUUID = UUID(uuidString: idString) != nil
+                
+                if !isUUID {
+            
+                    let folder = try await driveNewAPI.getFolderMetaById(id: idString)
+                    let folderName = folder.plainName ?? folder.name ?? ""
+                    
+                    if let trackingObjectId = trackingObjectId {
+                        activityManager.updateActivityEntryStatus(id: trackingObjectId, filename: folderName, kind: .download, status: .inProgress)
+                    }
+                    
+                    try await downloadFolderRecursively(
+                        folderUuid: folder.uuid!,
+                        localFolderURL: destinationURL
+                    )
+                    
+                    let parentId: NSFileProviderItemIdentifier = folder.parentId != nil ? NSFileProviderItemIdentifier(String(folder.parentId!)) : .rootContainer
+                    
+                    let fileProviderItem = FileProviderItem(
+                        identifier: itemIdentifier,
+                        filename: folderName,
+                        parentId: parentId,
+                        createdAt: Time.dateFromISOString(folder.createdAt) ?? Date(),
+                        updatedAt: Time.dateFromISOString(folder.updatedAt) ?? Date(),
+                        itemExtension: (folderName as NSString).pathExtension,
+                        itemType: .file,
+                        size: 0
+                    )
+                    
+                    completionHandler(destinationURL, fileProviderItem, nil)
+                    progressHandler(completedProgress: 1)
+                    
+                    if let trackingObjectId = trackingObjectId {
+                        activityManager.updateActivityEntryStatus(id: trackingObjectId, filename: folderName, kind: .download, status: .finished)
+                    }
+                    
+                    return
+                }
+                
+                let file = try await getFileMetaWithRetry(uuid: idString, maxRetries: maxRetries)
+                
+                guard let file = Optional.some(file) else {
+                    throw DownloadFileUseCaseError.DriveFileMissing
+                }
                 
                 let currentFilename = FileProviderItem.getFilename(name: file.plainName ?? file.name, itemExtension: file.type)
                 if let trackingObjectId = trackingObjectId {
@@ -246,5 +291,69 @@ struct DownloadFileUseCase {
         }
         
         return progress
+    }
+    
+    private func downloadFolderRecursively(folderUuid: String, localFolderURL: URL) async throws {
+        try FileManager.default.createDirectory(at: localFolderURL, withIntermediateDirectories: true)
+        try await downloadFilesInDirectory(folderUuid: folderUuid, localFolderURL: localFolderURL)
+        try await downloadSubdirectoriesInDirectory(folderUuid: folderUuid, localFolderURL: localFolderURL)
+    }
+    
+    private func downloadFilesInDirectory(folderUuid: String, localFolderURL: URL) async throws {
+        var fileOffset = 0
+        let limit = 50
+        var hasMoreFiles = true
+        
+        while hasMoreFiles {
+            let filesResponse = try await driveNewAPI.getFolderFilesV2(folderUuid: folderUuid, offset: fileOffset, limit: limit)
+            
+            for file in filesResponse.files {
+                let filename = FileProviderItem.getFilename(name: file.plainName ?? file.name ?? "", itemExtension: file.type)
+                let localFileURL = localFolderURL.appendingPathComponent(filename)
+                
+                let encryptedFileDestination = localFolderURL.appendingPathComponent("enc-\(UUID().uuidString).enc")
+                
+                defer {
+                    try? FileManager.default.removeItem(at: encryptedFileDestination)
+                }
+                
+                _ = try await networkFacade.downloadFile(
+                    bucketId: file.bucket,
+                    fileId: file.fileId ?? "",
+                    encryptedFileDestination: encryptedFileDestination,
+                    destinationURL: localFileURL,
+                    progressHandler: { _ in },
+                    debug: true
+                )
+            }
+            
+            if filesResponse.files.count < limit {
+                hasMoreFiles = false
+            } else {
+                fileOffset += limit
+            }
+        }
+    }
+    
+    private func downloadSubdirectoriesInDirectory(folderUuid: String, localFolderURL: URL) async throws {
+        var folderOffset = 0
+        let limit = 50
+        var hasMoreFolders = true
+        
+        while hasMoreFolders {
+            let foldersResponse = try await driveNewAPI.getFolderFolders(folderUuid: folderUuid, offset: folderOffset, limit: limit)
+            
+            for subFolder in foldersResponse.folders {
+                let name = subFolder.plainName ?? subFolder.name
+                let localSubFolderURL = localFolderURL.appendingPathComponent(name)
+                try await downloadFolderRecursively(folderUuid: subFolder.uuid ?? "", localFolderURL: localSubFolderURL)
+            }
+            
+            if foldersResponse.folders.count < limit {
+                hasMoreFolders = false
+            } else {
+                folderOffset += limit
+            }
+        }
     }
 }

--- a/SyncExtension/UseCases/Files/DownloadFileUseCase.swift
+++ b/SyncExtension/UseCases/Files/DownloadFileUseCase.swift
@@ -159,8 +159,8 @@ struct DownloadFileUseCase {
                         activityManager.updateActivityEntryStatus(id: trackingObjectId, filename: folderName, kind: .download, status: .inProgress)
                     }
                     
-                    try await downloadFolderRecursively(
-                        folderUuid: folder.uuid!,
+                    try await downloadFolderIteratively(
+                        initialFolderUuid: folder.uuid!,
                         localFolderURL: destinationURL
                     )
                     
@@ -293,11 +293,7 @@ struct DownloadFileUseCase {
         return progress
     }
     
-    private func downloadFolderRecursively(folderUuid: String, localFolderURL: URL) async throws {
-        try FileManager.default.createDirectory(at: localFolderURL, withIntermediateDirectories: true)
-        try await downloadFilesInDirectory(folderUuid: folderUuid, localFolderURL: localFolderURL)
-        try await downloadSubdirectoriesInDirectory(folderUuid: folderUuid, localFolderURL: localFolderURL)
-    }
+
     
     private func downloadFilesInDirectory(folderUuid: String, localFolderURL: URL) async throws {
         var fileOffset = 0
@@ -335,24 +331,39 @@ struct DownloadFileUseCase {
         }
     }
     
-    private func downloadSubdirectoriesInDirectory(folderUuid: String, localFolderURL: URL) async throws {
-        var folderOffset = 0
-        let limit = 50
-        var hasMoreFolders = true
+    private func downloadFolderIteratively(initialFolderUuid: String, localFolderURL: URL) async throws {
+        struct FolderDownloadTask {
+            let uuid: String
+            let localURL: URL
+        }
         
-        while hasMoreFolders {
-            let foldersResponse = try await driveNewAPI.getFolderFolders(folderUuid: folderUuid, offset: folderOffset, limit: limit)
+        var queue: [FolderDownloadTask] = [FolderDownloadTask(uuid: initialFolderUuid, localURL: localFolderURL)]
+        
+        while !queue.isEmpty {
+            let currentTask = queue.removeFirst()
+            try FileManager.default.createDirectory(at: currentTask.localURL, withIntermediateDirectories: true)
             
-            for subFolder in foldersResponse.folders {
-                let name = subFolder.plainName ?? subFolder.name
-                let localSubFolderURL = localFolderURL.appendingPathComponent(name)
-                try await downloadFolderRecursively(folderUuid: subFolder.uuid ?? "", localFolderURL: localSubFolderURL)
-            }
+        
+            try await downloadFilesInDirectory(folderUuid: currentTask.uuid, localFolderURL: currentTask.localURL)
             
-            if foldersResponse.folders.count < limit {
-                hasMoreFolders = false
-            } else {
-                folderOffset += limit
+            var folderOffset = 0
+            let limit = 50
+            var hasMoreFolders = true
+            
+            while hasMoreFolders {
+                let foldersResponse = try await driveNewAPI.getFolderFolders(folderUuid: currentTask.uuid, offset: folderOffset, limit: limit)
+                
+                for subFolder in foldersResponse.folders {
+                    let name = subFolder.plainName ?? subFolder.name
+                    let localSubFolderURL = currentTask.localURL.appendingPathComponent(name)
+                    queue.append(FolderDownloadTask(uuid: subFolder.uuid ?? "", localURL: localSubFolderURL))
+                }
+                
+                if foldersResponse.folders.count < limit {
+                    hasMoreFolders = false
+                } else {
+                    folderOffset += limit
+                }
             }
         }
     }

--- a/SyncExtension/UseCases/Files/UploadFileUseCase.swift
+++ b/SyncExtension/UseCases/Files/UploadFileUseCase.swift
@@ -126,7 +126,7 @@ struct UploadFileUseCase {
                         }
                     }
                     
-                    try await uploadDirectoryRecursively(
+                    try await uploadDirectoryIteratively(
                         localURL: fileContent,
                         parentFolderId: createdFolderId,
                         parentFolderUuid: createdFolderUuid
@@ -322,40 +322,60 @@ struct UploadFileUseCase {
         
     }
     
-    private func uploadDirectoryRecursively(localURL: URL, parentFolderId: String, parentFolderUuid: String) async throws {
-        let fileManager = FileManager.default
-        let contents = try fileManager.contentsOfDirectory(at: localURL, includingPropertiesForKeys: [.isDirectoryKey, .fileSizeKey, .isSymbolicLinkKey], options: [])
+    private func uploadDirectoryIteratively(localURL: URL, parentFolderId: String, parentFolderUuid: String) async throws {
+        struct FolderUploadTask {
+            let localURL: URL
+            let cloudFolderId: String
+            let cloudFolderUuid: String
+        }
         
-        for itemURL in contents {
-            let name = itemURL.lastPathComponent
-            let resourceValues = try itemURL.resourceValues(forKeys: [.isDirectoryKey, .fileSizeKey, .isSymbolicLinkKey])
-            let isDirectory = resourceValues.isDirectory ?? false
-            let isSymbolicLink = resourceValues.isSymbolicLink ?? false
-            let fileSize = resourceValues.fileSize ?? 0
+        var queue: [FolderUploadTask] = [FolderUploadTask(
+            localURL: localURL,
+            cloudFolderId: parentFolderId,
+            cloudFolderUuid: parentFolderUuid
+        )]
+        
+        let fileManager = FileManager.default
+        
+        while !queue.isEmpty {
+            let currentTask = queue.removeFirst()
+            let contents = try fileManager.contentsOfDirectory(
+                at: currentTask.localURL,
+                includingPropertiesForKeys: [.isDirectoryKey, .fileSizeKey, .isSymbolicLinkKey],
+                options: []
+            )
             
-            if isSymbolicLink {
-                continue
-            }
-            
-            if isDirectory {
-                let folderInfo = try await resolveOrCreateFolder(name: name, parentFolderUuid: parentFolderUuid)
+            for itemURL in contents {
+                let name = itemURL.lastPathComponent
+                let resourceValues = try itemURL.resourceValues(forKeys: [.isDirectoryKey, .fileSizeKey, .isSymbolicLinkKey])
+                let isDirectory = resourceValues.isDirectory ?? false
+                let isSymbolicLink = resourceValues.isSymbolicLink ?? false
+                let fileSize = resourceValues.fileSize ?? 0
                 
-                try await uploadDirectoryRecursively(
-                    localURL: itemURL,
-                    parentFolderId: folderInfo.id,
-                    parentFolderUuid: folderInfo.uuid
-                )
-            } else {
-                do {
-                    try await uploadPackageFile(
+                if isSymbolicLink {
+                    continue
+                }
+                
+                if isDirectory {
+                    let folderInfo = try await resolveOrCreateFolder(name: name, parentFolderUuid: currentTask.cloudFolderUuid)
+                    
+                    queue.append(FolderUploadTask(
                         localURL: itemURL,
-                        filename: name,
-                        fileSize: fileSize,
-                        parentFolderId: parentFolderId,
-                        parentFolderUuid: parentFolderUuid
-                    )
-                } catch {
-                    self.logger.error("❌ Failed to upload internal package file \(name): \(error.getErrorDescription())")
+                        cloudFolderId: folderInfo.id,
+                        cloudFolderUuid: folderInfo.uuid
+                    ))
+                } else {
+                    do {
+                        try await uploadPackageFile(
+                            localURL: itemURL,
+                            filename: name,
+                            fileSize: fileSize,
+                            parentFolderId: currentTask.cloudFolderId,
+                            parentFolderUuid: currentTask.cloudFolderUuid
+                        )
+                    } catch {
+                        self.logger.error("❌ Failed to upload internal package file \(name): \(error.getErrorDescription())")
+                    }
                 }
             }
         }

--- a/SyncExtension/UseCases/Files/UploadFileUseCase.swift
+++ b/SyncExtension/UseCases/Files/UploadFileUseCase.swift
@@ -88,6 +88,66 @@ struct UploadFileUseCase {
             activityManager.saveActivityEntry(entry: ActivityEntry(_id: inProgressId, filename: item.filename, kind: .upload, status: .inProgress))
             
             do {
+                var isPackage = FileProviderItem.isPackage(filename: item.filename)
+
+                if !isPackage, let resourceValues = try? fileContent.resourceValues(forKeys: [.isPackageKey]) {
+                    isPackage = resourceValues.isPackage == true
+                }
+                
+                if isPackage {
+                    self.logger.info("📦 Starting upload of package: \(item.filename)")
+                    
+                    var createdFolderId: String
+                    var createdFolderUuid: String
+                    
+                    do {
+                        let createdFolder = try await driveNewAPI.createFolderNew(
+                            parentFolderUuid: parentUUID,
+                            folderName: item.filename,
+                            debug: true
+                        )
+                        createdFolderId = String(createdFolder.id)
+                        createdFolderUuid = createdFolder.uuid
+                        self.logger.info("📦 Created package folder on cloud \(item.filename)")
+                    } catch {
+                        if let apiClientError = error as? APIClientError, apiClientError.statusCode == 409 {
+                            let existences = try await driveNewAPI.getFolderExistencesInFolder(folderParentUuid: parentUUID, folderName: item.filename)
+                            if let folder = existences.existentFolders.first(where: {
+                                $0.plainName == item.filename && $0.removed == false
+                            }) {
+                                createdFolderId = String(folder.id)
+                                createdFolderUuid = folder.uuid
+                            } else {
+                                throw error
+                            }
+                        } else {
+                            self.logger.error("📦 error uploading package  \(error.getErrorDescription())")
+                            throw error
+                        }
+                    }
+                    
+                    try await uploadDirectoryRecursively(
+                        localURL: fileContent,
+                        parentFolderId: createdFolderId,
+                        parentFolderUuid: createdFolderUuid
+                    )
+                    
+                    let parentIdIsRootFolder = FileProviderItem.parentIdIsRootFolder(identifier: item.parentItemIdentifier)
+                    let fileProviderItem = FileProviderItem(
+                        identifier: NSFileProviderItemIdentifier(rawValue: createdFolderId),
+                        filename: item.filename,
+                        parentId: parentIdIsRootFolder ? .rootContainer : item.parentItemIdentifier,
+                        createdAt: Date(),
+                        updatedAt: Date(),
+                        itemExtension: (item.filename as NSString).pathExtension,
+                        itemType: .file,
+                        size: 0
+                    )
+                    completionHandler(fileProviderItem, [], false, nil)
+                    activityManager.updateActivityEntryStatus(id: inProgressId, filename: item.filename, kind: .upload, status: .finished)
+                    return
+                }
+
                 let parentIdIsRootFolder = FileProviderItem.parentIdIsRootFolder(identifier: item.parentItemIdentifier)
 
                 let startedAt = self.trackStart(processIdentifier: trackId)
@@ -260,6 +320,153 @@ struct UploadFileUseCase {
             return nil
         }
         
+    }
+    
+    private func uploadDirectoryRecursively(localURL: URL, parentFolderId: String, parentFolderUuid: String) async throws {
+        let fileManager = FileManager.default
+        let contents = try fileManager.contentsOfDirectory(at: localURL, includingPropertiesForKeys: [.isDirectoryKey, .fileSizeKey, .isSymbolicLinkKey], options: [])
+        
+        for itemURL in contents {
+            let name = itemURL.lastPathComponent
+            let resourceValues = try itemURL.resourceValues(forKeys: [.isDirectoryKey, .fileSizeKey, .isSymbolicLinkKey])
+            let isDirectory = resourceValues.isDirectory ?? false
+            let isSymbolicLink = resourceValues.isSymbolicLink ?? false
+            let fileSize = resourceValues.fileSize ?? 0
+            
+            if isSymbolicLink {
+                continue
+            }
+            
+            if isDirectory {
+                let folderInfo = try await resolveOrCreateFolder(name: name, parentFolderUuid: parentFolderUuid)
+                
+                try await uploadDirectoryRecursively(
+                    localURL: itemURL,
+                    parentFolderId: folderInfo.id,
+                    parentFolderUuid: folderInfo.uuid
+                )
+            } else {
+                do {
+                    try await uploadPackageFile(
+                        localURL: itemURL,
+                        filename: name,
+                        fileSize: fileSize,
+                        parentFolderId: parentFolderId,
+                        parentFolderUuid: parentFolderUuid
+                    )
+                } catch {
+                    self.logger.error("❌ Failed to upload internal package file \(name): \(error.getErrorDescription())")
+                }
+            }
+        }
+    }
+    
+    private func resolveOrCreateFolder(name: String, parentFolderUuid: String) async throws -> (id: String, uuid: String) {
+        do {
+            let createdFolder = try await driveNewAPI.createFolderNew(
+                parentFolderUuid: parentFolderUuid,
+                folderName: name,
+                debug: true
+            )
+            return (String(createdFolder.id), createdFolder.uuid)
+        } catch {
+            guard let apiClientError = error as? APIClientError, apiClientError.statusCode == 409 else {
+                throw error
+            }
+            
+            let existences = try await driveNewAPI.getFolderExistencesInFolder(folderParentUuid: parentFolderUuid, folderName: name)
+            if let folder = existences.existentFolders.first(where: {
+                $0.plainName == name && $0.removed == false
+            }) {
+                return (String(folder.id), folder.uuid)
+            } else {
+                throw error
+            }
+        }
+    }
+    
+    private func fetchExistingFileUuid(filename: String, parentFolderUuid: String) async -> String? {
+        let plainName = (filename as NSString).deletingPathExtension
+        let ext = (filename as NSString).pathExtension
+        let existenceFile = ExistenceFile(plainName: plainName, type: ext)
+        
+        do {
+            let checkResult = try await driveNewAPI.getExistenceFileInFolderByPlainName(
+                uuid: parentFolderUuid,
+                files: [existenceFile],
+                debug: true
+            )
+            if let foundFile = checkResult.existentFiles.first(where: {
+                $0.plainName == plainName && $0.type == ext
+            }) {
+                return foundFile.uuid
+            }
+        } catch {
+            
+        }
+        return nil
+    }
+    
+    private func uploadPackageFile(localURL: URL, filename: String, fileSize: Int, parentFolderId: String, parentFolderUuid: String) async throws {
+        let plainName = (filename as NSString).deletingPathExtension
+        let ext = (filename as NSString).pathExtension
+        
+      
+        let existingFileUuid = await fetchExistingFileUuid(filename: filename, parentFolderUuid: parentFolderUuid)
+        
+        guard let inputStream = InputStream(url: localURL) else {
+            throw UploadFileUseCaseError.CannotOpenInputStream
+        }
+        
+        let encryptedFileDestination = fileContent.deletingLastPathComponent().appendingPathComponent("enc-package-\(UUID().uuidString).enc")
+        
+        defer {
+            try? FileManager.default.removeItem(at: encryptedFileDestination)
+        }
+        
+        var uploadFileId: String? = nil
+        var uploadSize: Int = fileSize
+        var uploadBucket: String = user.bucket
+        
+        if fileSize > 0 {
+            let result = try await networkFacade.uploadFile(
+                input: inputStream,
+                encryptedOutput: encryptedFileDestination,
+                fileSize: fileSize,
+                bucketId: uploadBucket,
+                progressHandler: { _ in },
+                debug: true
+            )
+            uploadFileId = result.id
+            uploadSize = result.size
+            uploadBucket = result.bucket
+        }
+        
+        if let fileUuid = existingFileUuid {
+          
+            _ = try await driveNewAPI.replaceFileId(fileUuid: fileUuid, newFileId: uploadFileId, newSize: uploadSize)
+        } else {
+      
+            let encryptedFilename = try encrypt.encrypt(
+                string: plainName,
+                password: "\(config.CRYPTO_SECRET2)-\(parentFolderId)",
+                salt: cryptoUtils.hexStringToBytes(config.MAGIC_SALT_HEX),
+                iv: Data(cryptoUtils.hexStringToBytes(config.MAGIC_IV_HEX))
+            )
+            
+            _ = try await driveNewAPI.createFileNew(createFile: CreateFileDataNew(
+                    fileId: uploadFileId,
+                    type: ext,
+                    bucket: uploadBucket,
+                    size: uploadSize,
+                    folderId: 0,
+                    name: encryptedFilename.base64EncodedString(),
+                    plainName: plainName,
+                    folderUuid: parentFolderUuid
+                ),
+                debug: true
+            )
+        }
     }
 }
 

--- a/SyncExtension/UseCases/Folders/EnumerateFolderItemsUseCase.swift
+++ b/SyncExtension/UseCases/Folders/EnumerateFolderItemsUseCase.swift
@@ -80,14 +80,19 @@ struct EnumerateFolderItemsUseCase {
                     }
                     
                     
+                    let folderName = FileProviderItem.getFilename(name: folder.plainName ?? folder.name, itemExtension: nil)
+                    let isPkg = FileProviderItem.isPackage(filename: folderName)
+                    let ext = isPkg ? (folderName as NSString).pathExtension : nil
+                    let itemType = isPkg ? RemoteItemType.file : RemoteItemType.folder
+                    
                     let item = FileProviderItem(
                         identifier: NSFileProviderItemIdentifier(rawValue: String(folder.id)),
-                        filename: FileProviderItem.getFilename(name: folder.plainName ?? folder.name , itemExtension: nil),
+                        filename: folderName,
                         parentId: self.enumeratedItemIdentifier,
                         createdAt: createdAt,
                         updatedAt: updatedAt,
-                        itemExtension: nil,
-                        itemType: .folder
+                        itemExtension: ext,
+                        itemType: itemType
                     )
                     items.append(item)
                 }


### PR DESCRIPTION
In this PR, the following is done:
- Enable direct sync in the cloud for macOS document packages (`.rtfd`, `.pages`, `.keynote`, `.numbers`) as folders instead of compressing them to `.zip` files.
- Optimize network queries during downloads by checking the identifier type (UUID vs Numeric ID) locally before calling the API.