### PR TITLE
Refactor Backup Throttling & Optimize Memory Lifecycle in XPCBackupService

### DIFF
--- a/XPCBackupService/Entities/BackupTreeNode.swift
+++ b/XPCBackupService/Entities/BackupTreeNode.swift
@@ -231,7 +231,12 @@ class BackupTreeNode {
                     syncRetries += 1
                     logger.info("Node sync failed, scheduling retry #\(syncRetries)")
                     error.reportToSentry()
-                    try await Task.sleep(nanoseconds: 1_000_000_000 * syncRetries)
+                    let baseDelay = pow(2.0, Double(syncRetries))
+                    let jitter = Double.random(in: 0.0...baseDelay * 0.25)
+                    let delaySeconds = baseDelay + jitter
+                    let delayNanoseconds = UInt64(delaySeconds * 1_000_000_000)
+                    logger.info("Retry #\(syncRetries) — waiting \(String(format: "%.2f", delaySeconds))s (base=\(Int(baseDelay))s + jitter=\(String(format: "%.2f", jitter))s)")
+                    try await Task.sleep(nanoseconds: delayNanoseconds)
                     try await self.syncNode()
                     return
                 } else {

--- a/XPCBackupService/Services/BackupUploadService.swift
+++ b/XPCBackupService/Services/BackupUploadService.swift
@@ -80,11 +80,27 @@ class BackupUploadService:  BackupUploadServiceProtocol, ObservableObject {
         return decoded.message
     }
 
-    private var backupNewAPI: BackupAPI {
-        return BackupAPI(baseUrl: config.DRIVE_NEW_API_URL, authToken: newAuthToken, clientName: CLIENT_NAME, clientVersion: getVersion())
+
+    private lazy var backupNewAPI: BackupAPI = {
+        BackupAPI(baseUrl: config.DRIVE_NEW_API_URL, authToken: newAuthToken, clientName: CLIENT_NAME, clientVersion: getVersion())
+    }()
+
+
+    private let apiSemaphore = AsyncSemaphore(maxConcurrent: 6)
+    private let networkUploadSemaphore = AsyncSemaphore(maxConcurrent: 2)
+
+    private func withAPIThrottle<T>(_ work: () async throws -> T) async rethrows -> T {
+        await apiSemaphore.wait()
+        defer { Task { await apiSemaphore.signal() } }
+        return try await work()
     }
 
-    
+    private func withNetworkUploadThrottle<T>(_ work: () async throws -> T) async rethrows -> T {
+        await networkUploadSemaphore.wait()
+        defer { Task { await networkUploadSemaphore.signal() } }
+        return try await work()
+    }
+
 
     private func getEncryptedContentURL(node: BackupTreeNode) -> URL? {
         let url = encryptedContentDirectory.appendingPathComponent(node.id)
@@ -170,10 +186,12 @@ class BackupUploadService:  BackupUploadServiceProtocol, ObservableObject {
         self.logger.info("Parent id \(safeRemoteParentId)")
 
         do {
-            let createdFolder = try await backupNewAPI.createBackupFolder(
-                parentFolderUuid: safeRemoteParentUuid,
-                folderName: foldername
-            )
+            let createdFolder = try await withAPIThrottle {
+                try await self.backupNewAPI.createBackupFolder(
+                    parentFolderUuid: safeRemoteParentUuid,
+                    folderName: foldername
+                )
+            }
 
             self.logger.info("✅ Folder created successfully: \(createdFolder.id)")
 
@@ -202,7 +220,9 @@ class BackupUploadService:  BackupUploadServiceProtocol, ObservableObject {
             if let apiClientError = error as? APIClientError, apiClientError.statusCode == 409 {
                 // Handle duplicated folder error
                 do {
-                    let parentChilds = try await backupNewAPI.getBackupChilds(folderUuid: "\(safeRemoteParentUuid)")
+                    let parentChilds = try await withAPIThrottle {
+                        try await self.backupNewAPI.getBackupChilds(folderUuid: "\(safeRemoteParentUuid)")
+                    }
 
                     let folder = parentChilds.folders.first { currentFolder in
                         currentFolder.plainName == foldername && currentFolder.removed == false
@@ -278,13 +298,15 @@ class BackupUploadService:  BackupUploadServiceProtocol, ObservableObject {
             }
             
             if uploadSize > 0 {
-                let result = try await networkFacade.uploadFile(
-                    input: inputStream,
-                    encryptedOutput: safeEncryptedContentURL,
-                    fileSize: uploadSize,
-                    bucketId: self.bucketId,
-                    progressHandler: { _ in }
-                )
+                let result = try await withNetworkUploadThrottle {
+                    try await self.networkFacade.uploadFile(
+                        input: inputStream,
+                        encryptedOutput: safeEncryptedContentURL,
+                        fileSize: uploadSize,
+                        bucketId: self.bucketId,
+                        progressHandler: { _ in }
+                    )
+                }
                 
                 uploadFileId = result.id
                 uploadSize = result.size
@@ -306,11 +328,13 @@ class BackupUploadService:  BackupUploadServiceProtocol, ObservableObject {
                     return .failure(BackupUploadError.MissingRemoteId)
                 }
 
-                let updatedFile = try await backupNewAPI.replaceFileId(
-                    fileUuid: remoteUuid,
-                    newFileId: uploadFileId,
-                    newSize: uploadSize
-                )
+                let updatedFile = try await withAPIThrottle {
+                    try await self.backupNewAPI.replaceFileId(
+                        fileUuid: remoteUuid,
+                        newFileId: uploadFileId,
+                        newSize: uploadSize
+                    )
+                }
 
                 self.logger.info("✅ Updated file correctly with identifier \(updatedFile.fileId)")
 
@@ -333,18 +357,20 @@ class BackupUploadService:  BackupUploadServiceProtocol, ObservableObject {
                     iv: Data(cryptoUtils.hexStringToBytes(config.MAGIC_IV_HEX))
                 )
            
-                let createdFile = try await backupNewAPI.createBackupFileNew(
-                    createFileData: CreateFileDataNew(
-                        fileId: uploadFileId,
-                        type: filename.pathExtension,
-                        bucket: uploadBucketId,
-                        size: uploadSize,
-                        folderId: remoteParentId,
-                        name: encryptedFilename.base64EncodedString(),
-                        plainName: filename.deletingPathExtension,
-                        folderUuid: remoteParentUuid
+                let createdFile = try await withAPIThrottle {
+                    try await self.backupNewAPI.createBackupFileNew(
+                        createFileData: CreateFileDataNew(
+                            fileId: uploadFileId,
+                            type: filename.pathExtension,
+                            bucket: uploadBucketId,
+                            size: uploadSize,
+                            folderId: remoteParentId,
+                            name: encryptedFilename.base64EncodedString(),
+                            plainName: filename.deletingPathExtension,
+                            folderUuid: remoteParentUuid
+                        )
                     )
-                )
+                }
                 self.logger.info("✅ Created file correctly with identifier \(createdFile.id)")
 
 
@@ -410,7 +436,9 @@ class BackupUploadService:  BackupUploadServiceProtocol, ObservableObject {
                     let existenceFile = ExistenceFile(plainName: filename.deletingPathExtension, type: filename.pathExtension)
 
                     
-                    let result = try await backupNewAPI.getExistenceFileInFolderByPlainName(uuid: remoteParentUuid, files: [existenceFile])
+                    let result = try await withAPIThrottle {
+                        try await self.backupNewAPI.getExistenceFileInFolderByPlainName(uuid: remoteParentUuid, files: [existenceFile])
+                    }
                     
                     let nodePlainName = (node.name as NSString).deletingPathExtension
   
@@ -466,3 +494,37 @@ class BackupUploadService:  BackupUploadServiceProtocol, ObservableObject {
     }
 }
 
+
+
+
+actor AsyncSemaphore {
+    private var availableSlots: Int
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+
+    init(maxConcurrent: Int) {
+        precondition(maxConcurrent > 0, "AsyncSemaphore requires at least 1 concurrent slot")
+        self.availableSlots = maxConcurrent
+    }
+
+    func wait() async {
+        if availableSlots > 0 {
+            availableSlots -= 1
+            return
+        }
+       
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+
+   
+    func signal() {
+        if waiters.isEmpty {
+            availableSlots += 1
+        } else {
+            let next = waiters.removeFirst()
+            next.resume()
+        }
+    }
+}

--- a/XPCBackupService/XPCBackupService.swift
+++ b/XPCBackupService/XPCBackupService.swift
@@ -33,7 +33,7 @@ public class XPCBackupService: NSObject, XPCBackupServiceProtocol {
         with reply: @escaping (_ result: String?, _ error: String?) -> Void
     ) -> Void {
         let backupRealm = SyncedNodeRepository.shared
-        self.uploadOperationQueue.maxConcurrentOperationCount = 10
+        self.uploadOperationQueue.maxConcurrentOperationCount = 5
         logger.info("Going to backup folders: \(backupURLs)")
         self.backupUploadStatus = .InProgress
         self.backupUploadProgress = Progress()
@@ -131,8 +131,8 @@ public class XPCBackupService: NSObject, XPCBackupServiceProtocol {
                 }
                 do {
                     logger.info("Adding nodes sync operations")
-                    try backupTree.syncBelowNodes(withOperationQueue: self.uploadOperationQueue, syncGroup: syncGroup) { error in
-                        
+                    try backupTree.syncBelowNodes(withOperationQueue: self.uploadOperationQueue, syncGroup: syncGroup) { [weak self] error in
+                        guard let self = self else { return }
                         
                         if let backupUploadError = error as? BackupError, backupUploadError == .storageFull {
                             logger.error("Storage is full, cannot continue with the backup.")
@@ -154,7 +154,8 @@ public class XPCBackupService: NSObject, XPCBackupServiceProtocol {
                 }
             }
             
-            syncGroup.notify(queue: .global()) {
+            syncGroup.notify(queue: .global()) { [weak self] in
+                guard let self = self else { return }
                 logger.info("Sync nodes operations completed")
                 
                 let successCount = totalNodesCount - failedNodesCount
@@ -170,6 +171,9 @@ public class XPCBackupService: NSObject, XPCBackupServiceProtocol {
                 }
                 
                 self.trees = []
+                self.backupUploadService = nil
+                URLCache.shared.removeAllCachedResponses()
+                
                 reply("synced all nodes for all trees", nil)
             }
 


### PR DESCRIPTION

This PR addresses stability, network saturation, and memory lifecycle issues in `XPCBackupService` during large backup runs. It introduces fine-grained concurrency control to prevent massive bursts of simultaneous HTTP requests and optimizes the teardown lifecycle to release memory as soon as a backup finishes.
---
###  Changes
1. **Queue Concurrency Reduction**
   - Reduced `maxConcurrentOperationCount` on the upload queue from **10 to 5** to scale down parallel node processing.
2. **Dual-Layer Concurrency Control (Semaphores)**
   - Implemented an actor-based `AsyncSemaphore` to enforce non-blocking request throttling:
     - **`apiSemaphore` (max: 6)**: Caps quick metadata REST requests (e.g., folder creation, file creation, checks) to prevent rate-limiting or server timeouts.
     - **`networkUploadSemaphore` (max: 2)**: Caps slow, high-bandwidth multipart S3 file uploads. Limiting S3 uploads to 2 concurrent transfers prevents bandwidth starvation on large files.
3. **Lifecycle Memory Cleanup**
   - Avoided memory retention cycles in `XPCBackupService` closures by introducing `[weak self]` capture semantics.
   - Explicitly released `self.backupUploadService` (`= nil`) inside the `syncGroup.notify` block upon completion. This triggers proper deallocation of underlying network managers, `URLSession` pools, and data buffers.
   - Added `URLCache.shared.removeAllCachedResponses()` to free HTTP-level response caches accumulated during the run.