### PR TITLE
Fix: Trash files in DeleteFileUseCase when directly deleted

### DIFF
--- a/SyncExtension/UseCases/Files/DeleteFileUseCase.swift
+++ b/SyncExtension/UseCases/Files/DeleteFileUseCase.swift
@@ -24,13 +24,17 @@ struct DeleteFileUseCase {
     }
     
     public func run( ) -> Progress {
-        self.logger.info("Deleting file with fileId \(identifier.rawValue)")
-       
-        // File deleting is not allowed from the Internxt Desktop app, so we just let it pass for now
-        
-        self.logger.info("✅ File with id \(identifier.rawValue) deleted correctly")
-        completionHandler(nil)
-        
+        Task {
+            do {
+                self.logger.info("Deleting file with id \(identifier.rawValue)")
+                let _ = try await DriveFileService.shared.trashFile(uuid: identifier.rawValue)
+                self.logger.info("✅ File with id \(identifier.rawValue) deleted correctly")
+                completionHandler(nil)
+            } catch {
+                self.logger.error("❌ Failed to delete file: \(error.getErrorDescription())")
+                completionHandler(NSError(domain: NSFileProviderErrorDomain, code: NSFileProviderError.serverUnreachable.rawValue))
+            }
+        }
         return Progress()
     }
 }


### PR DESCRIPTION
Previously, the drive extension only sent files to the backend trash when they were deleted using the standard "Move to Trash" flow. However, when files were deleted directly (such as running rm in the terminal), the deletion failed to synchronize to the backend. This PR updates DeleteFileUseCase to call DriveFileService.shared.trashFile(uuid:), ensuring that direct deletions are also correctly sent to the trash on the backend.