### PR TITLE
propagate background service registration errors

### DIFF
--- a/Shared/Models/Cleaner.swift
+++ b/Shared/Models/Cleaner.swift
@@ -310,6 +310,7 @@ enum CleanerServiceError: LocalizedError {
     case operationNotFound
     case invalidData
     case connectionTimeout
+    case helperRegistrationFailed(underlying: Error)
     
     var errorDescription: String? {
         switch self {
@@ -327,6 +328,8 @@ enum CleanerServiceError: LocalizedError {
             return NSLocalizedString("CLEANER_ERROR_INVALID_DATA", comment: "Error message for invalid data")
         case .connectionTimeout:
             return NSLocalizedString("CLEANER_ERROR_CONNECTION_TIMEOUT", comment: "Error message for connection timeout")
+        case .helperRegistrationFailed(let error):
+            return String(format: NSLocalizedString("CLEANER_ERROR_HELPER_REGISTRATION_FAILED", comment: "Error message for helper registration failed"), error.localizedDescription)
         }
     }
 }

--- a/Shared/Services/Cleaner/CleanerService.swift
+++ b/Shared/Services/Cleaner/CleanerService.swift
@@ -226,13 +226,13 @@ class CleanerService: ObservableObject {
     
     func ensureHelperInstalled() async {
         await executeOperation(newState: .connecting) {
-            let _ = await helperService.ensureHelperIsRegistered()
+            try await helperService.ensureHelperIsRegistered()
         }
     }
     
     func reinstallHelper() async {
         await executeOperation(newState: .connecting) {
-            await helperService.reinstallHelper()
+            try await helperService.reinstallHelper()
             
             if await getHelperStatus() == .enabled {
                 try await Task.sleep(nanoseconds: 2_000_000_000)
@@ -254,7 +254,13 @@ class CleanerService: ObservableObject {
     }
     
     func tryRegisterHelper() async -> Bool {
-        return await helperService.tryRegisterHelper()
+        do {
+            try await helperService.tryRegisterHelper()
+            return true
+        } catch {
+            await handleError(error)
+            return false
+        }
     }
     
     func openSystemSettings() {

--- a/Shared/Services/Cleaner/HelperServiceManager.swift
+++ b/Shared/Services/Cleaner/HelperServiceManager.swift
@@ -69,26 +69,26 @@ class HelperManagementService: ObservableObject {
         )
     }
     
-    func ensureHelperIsRegistered() async -> Bool {
+    func ensureHelperIsRegistered() async throws {
         cleanerLogger.info("Checking helper status...")
         await updateStatus()
         
         switch status {
         case .enabled:
             cleanerLogger.info("Helper is already enabled and running")
-            return true
+            return
             
         case .requiresApproval:
             cleanerLogger.warning("Helper requires user approval in System Settings")
-            return true
+            return
             
         case .notRegistered, .notFound:
             cleanerLogger.info("Helper not registered, attempting registration...")
-            return await tryRegisterHelper()
+            try await tryRegisterHelper()
             
         case .unknown(let code):
             cleanerLogger.warning("Unknown helper status: \(code), attempting registration...")
-            return await tryRegisterHelper()
+            try await tryRegisterHelper()
         }
     }
     
@@ -103,7 +103,7 @@ class HelperManagementService: ObservableObject {
         }
     }
     
-    func tryRegisterHelper() async -> Bool {
+    func tryRegisterHelper() async throws {
         cleanerLogger.info("Attempting to register helper...")
         
         do {
@@ -114,19 +114,18 @@ class HelperManagementService: ObservableObject {
             let isSuccessful = status == .enabled || status == .requiresApproval
             
             if isSuccessful {
-                cleanerLogger.info("Helper registration successful, status:")
+                cleanerLogger.info("Helper registration successful")
             } else {
-                cleanerLogger.warning("Helper registration failed, status: ")
+                cleanerLogger.warning("Helper registration finished but status is not enabled or requires approval")
+                throw CleanerServiceError.helperNotAvailable
             }
-            
-            return isSuccessful
         } catch {
             cleanerLogger.error("Failed to register helper: \(error.localizedDescription)")
-            return false
+            throw CleanerServiceError.helperRegistrationFailed(underlying: error)
         }
     }
     
-    func reinstallHelper() async {
+    func reinstallHelper() async throws {
         cleanerLogger.info("Reinstalling helper daemon...")
         
         do {
@@ -147,7 +146,8 @@ class HelperManagementService: ObservableObject {
             await updateStatus()
             cleanerLogger.info("Helper re-registered successfully with status: \(status.userMessage)")
         } catch {
-            cleanerLogger.error("Helper registration failed: \(error.localizedDescription)")
+            cleanerLogger.error("Helper registration failed during reinstall: \(error.localizedDescription)")
+            throw CleanerServiceError.helperRegistrationFailed(underlying: error)
         }
     }
     

--- a/Shared/en.lproj/Localizable.strings
+++ b/Shared/en.lproj/Localizable.strings
@@ -62,6 +62,7 @@
 "CLEANER_ERROR_OPERATION_NOT_FOUND" = "Operation not found";
 "CLEANER_ERROR_INVALID_DATA" = "Invalid data received";
 "CLEANER_ERROR_CONNECTION_TIMEOUT" = "Connection timeout";
+"CLEANER_ERROR_HELPER_REGISTRATION_FAILED" = "Background service installation failed: %@";
 
 // Cleaner Error Messages
 "CLEANER_ERROR_PERMISSION_DENIED" = "Permission denied for: %@";

--- a/Shared/es.lproj/Localizable.strings
+++ b/Shared/es.lproj/Localizable.strings
@@ -240,6 +240,7 @@
 "CLEANER_ERROR_OPERATION_NOT_FOUND" = "Operación no encontrada";
 "CLEANER_ERROR_INVALID_DATA" = "Datos inválidos recibidos";
 "CLEANER_ERROR_CONNECTION_TIMEOUT" = "Tiempo de espera agotado";
+"CLEANER_ERROR_HELPER_REGISTRATION_FAILED" = "Error al instalar el servicio en segundo plano: %@";
 
 // Cleaner Error Messages
 "CLEANER_ERROR_PERMISSION_DENIED" = "Permiso denegado para: %@";

--- a/Shared/fr.lproj/Localizable.strings
+++ b/Shared/fr.lproj/Localizable.strings
@@ -239,6 +239,7 @@
 "CLEANER_ERROR_OPERATION_NOT_FOUND" = "Opération introuvable";
 "CLEANER_ERROR_INVALID_DATA" = "Données invalides reçues";
 "CLEANER_ERROR_CONNECTION_TIMEOUT" = "Délai de connexion expiré";
+"CLEANER_ERROR_HELPER_REGISTRATION_FAILED" = "Échec de l'installation du service d'arrière-plan : %@";
 
 // Cleaner Error Messages
 "CLEANER_ERROR_PERMISSION_DENIED" = "Permission refusée pour: %@";


### PR DESCRIPTION
This PR fixes an issue where background helper service registration failures (such as EPERM – "Operation not permitted" on macOS) were silently ignored in HelperManagementService. As a result, the application remained stuck in an infinite loading/checking state (.notFound status loop), preventing the UI from notifying the user or responding appropriately.