### PR TITLE
Handle 401 session expiration when app is closed

### DIFF
--- a/InternxtDesktop/AppDelegate.swift
+++ b/InternxtDesktop/AppDelegate.swift
@@ -271,6 +271,13 @@ class AppDelegate: NSObject, NSApplicationDelegate , PKPushRegistryDelegate {
     
     func application(_ application: NSApplication, open urls: [URL]) {
         if let url = urls.first {
+            if url.host == "session-expired" {
+                self.logger.info("🔴 Received session-expired deeplink, performing logout")
+                NotificationCenter.default.post(name: .userDidLogout, object: nil)
+                NSApp.activate(ignoringOtherApps: true)
+                return
+            }
+            
             do {
                 let success = try authManager.handleSignInDeeplink(url: url)
                 

--- a/SyncExtension/FileProviderExtension.swift
+++ b/SyncExtension/FileProviderExtension.swift
@@ -117,13 +117,9 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension, NSFile
             error.reportToSentry()
         }
 
-        APIClient.onUnauthorized = {
-            DistributedNotificationCenter.default().postNotificationName(
-                NSNotification.Name(NOTIFICATION_UNAUTHORIZED),
-                object: nil,
-                userInfo: nil,
-                deliverImmediately: true
-            )
+        APIClient.onUnauthorized = { [weak self] in
+            APIClient.onUnauthorized = nil
+            self?.handleSessionExpired()
         }
         
         manager.signalEnumerator(for: .workingSet, completionHandler: {error in
@@ -161,6 +157,37 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension, NSFile
     
     func invalidate() {
         fileProviderItemActions.clean()
+    }
+    
+    private func handleSessionExpired() {
+        
+        DispatchQueue.main.async {
+            if let url = URL(string: "internxt://session-expired") {
+                NSWorkspace.shared.open(url)
+            }
+        }
+        
+        do {
+            try authManager.signOut()
+           
+        } catch {
+            logger.error("❌ Failed to clear credentials: \(error)")
+        }
+        
+        Task {
+            do {
+                for domain in try await NSFileProviderManager.domains() {
+                    do {
+                        try await NSFileProviderManager.remove(domain, mode: .preserveDirtyUserData)
+                    } catch {
+                        try? await NSFileProviderManager.remove(domain)
+                    }
+                    logger.info("✅ Domain '\(domain.displayName)' removed")
+                }
+            } catch {
+                logger.error("❌ Failed to remove domains: \(error)")
+            }
+        }
     }
     
     func refreshAuthTokensIfNeeded() -> Void {


### PR DESCRIPTION
In this PR, an issue is resolved where file synchronization stopped working silently when a 401 Unauthorized occurred while the main app was closed.

Since Finder and the SyncExtension continue running in the background independently of the main app, any 401 response during file operations left the session invalid, causing uploads to fail without any user notification or option to log back in.

 Changes
SyncExtension: Added handleSessionExpired() to clear credentials (authManager.signOut()), remove active FileProvider domains, and open internxt://session-expired via NSWorkspace when a 401 is received in the background.
AppDelegate: Added a handler for the session-expired deeplink to open/bring the main app to the foreground and present the login screen so the user can re-authenticate.