### PR TITLE
Fix/backup multipart error logging

### DIFF
--- a/Shared/Extensions/Error.swift
+++ b/Shared/Extensions/Error.swift
@@ -35,6 +35,30 @@ extension Error {
             
             return parts.joined(separator: " | ")
         }
+        
+        if let uploadError = self as? UploadError {
+            switch uploadError {
+            case .InvalidIndex:
+                return "UploadError: InvalidIndex"
+            case .CannotGenerateFileHash:
+                return "UploadError: CannotGenerateFileHash"
+            case .FailedToFinishUpload:
+                return "UploadError: FailedToFinishUpload"
+            case .MissingUploadUrl:
+                return "UploadError: MissingUploadUrl"
+            case .UploadNotSuccessful:
+                return "UploadError: UploadNotSuccessful"
+            case .UploadedSizeNotMatching:
+                return "UploadError: UploadedSizeNotMatching"
+            case .MissingEtag:
+                return "UploadError: MissingEtag"
+            case .MissingChunk:
+                return "UploadError: MissingChunk"
+            case .PartUploadFailed(let partIndex, let innerError):
+                return "UploadError: PartUploadFailed (part \(partIndex)) | error: \(innerError.getErrorDescription())"
+            }
+        }
+        
         return self.localizedDescription
     }
     

--- a/XPCBackupService/Services/BackupUploadService.swift
+++ b/XPCBackupService/Services/BackupUploadService.swift
@@ -447,6 +447,7 @@ class BackupUploadService:  BackupUploadServiceProtocol, ObservableObject {
                     }
                 
                     guard let file = matchingFile else {
+                        self.logger.error("❌ CannotFindNodeInServer: searched '\(nodePlainName)' server returned: \(result.existentFiles.map { $0.plainName })")
                         return .failure(BackupUploadError.CannotFindNodeInServer)
                     }
 

--- a/XPCBackupService/Services/BackupUploadService.swift
+++ b/XPCBackupService/Services/BackupUploadService.swift
@@ -371,7 +371,7 @@ class BackupUploadService:  BackupUploadServiceProtocol, ObservableObject {
                         )
                     )
                 }
-                self.logger.info("✅ Created file correctly with identifier \(createdFile.id)")
+                self.logger.info("✅ Created file correctly with identifier \(createdFile.id) : \(createdFile.plain_name)")
 
 
                 try await addSyncedNodeSafely(


### PR DESCRIPTION
This PR improves backup upload error logging by providing detailed `UploadError` descriptions in the desktop app logs.