### PR TITLE
sync UI progress when user stops and restarts a backup

### DIFF
--- a/InternxtDesktop.xcodeproj/project.pbxproj
+++ b/InternxtDesktop.xcodeproj/project.pbxproj
@@ -125,6 +125,18 @@
 		AA9B1B9F2FB2D342000E582A /* FileSizeLimitNotifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA9B1B9B2FB2D342000E582A /* FileSizeLimitNotifier.swift */; };
 		AA9B1BA12FB4094D000E582A /* FileSizeLimitDialogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA9B1BA02FB4094D000E582A /* FileSizeLimitDialogView.swift */; };
 		AA9DF5452EDF6B2E00D1FE52 /* PackageFileHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA9DF5442EDF6B2E00D1FE52 /* PackageFileHandle.swift */; };
+		AAA2F8E43017FB2100F5452C /* BackupUploadServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA2F8E33017FB2100F5452C /* BackupUploadServiceTests.swift */; };
+		AAA2F8E63017FEEF00F5452C /* Realm in Frameworks */ = {isa = PBXBuildFile; productRef = AAA2F8E53017FEEF00F5452C /* Realm */; };
+		AAA2F8E83017FF0100F5452C /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = AAA2F8E73017FF0100F5452C /* RealmSwift */; };
+		AAA2F8EA3017FF0700F5452C /* CocoaLumberjack in Frameworks */ = {isa = PBXBuildFile; productRef = AAA2F8E93017FF0700F5452C /* CocoaLumberjack */; };
+		AAA2F8EC301800EE00F5452C /* CocoaLumberjackSwift in Frameworks */ = {isa = PBXBuildFile; productRef = AAA2F8EB301800EE00F5452C /* CocoaLumberjackSwift */; };
+		AAA2F8ED301802C600F5452C /* BackupConfigurationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA642CAD2C62B26B0015BBB9 /* BackupConfigurationManager.swift */; };
+		AAA2F8EE3018030E00F5452C /* BackupsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 316D24792B4D9997007DE91A /* BackupsService.swift */; };
+		AAA2F8EF301803A300F5452C /* Device.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3185496E2B698AAC00D559E1 /* Device.swift */; };
+		AAA2F8F0301803B300F5452C /* FeaturesService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8D9AEE2E7CC2370068B333 /* FeaturesService.swift */; };
+		AAA2F8F1301803BA00F5452C /* ActivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E17C84C32AB2FEF500A58414 /* ActivityManager.swift */; };
+		AAA2F8F2301803DF00F5452C /* BackupsDeviceService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 316DC7EA2B597BD000FDC746 /* BackupsDeviceService.swift */; };
+		AAA2F8F3301803E600F5452C /* UsageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1ADD0432AA7367800D95694 /* UsageManager.swift */; };
 		AAA424962C51FFC100EEFD69 /* GenericRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFFBE282C50AC4F00C76528 /* GenericRepository.swift */; };
 		AAA666682D402F2900C2B9DF /* CustomModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA666672D402F2900C2B9DF /* CustomModalView.swift */; };
 		AAA6666A2D40380800C2B9DF /* FileSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA666692D40380800C2B9DF /* FileSelectionView.swift */; };
@@ -570,6 +582,7 @@
 		AA9B1B9B2FB2D342000E582A /* FileSizeLimitNotifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSizeLimitNotifier.swift; sourceTree = "<group>"; };
 		AA9B1BA02FB4094D000E582A /* FileSizeLimitDialogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSizeLimitDialogView.swift; sourceTree = "<group>"; };
 		AA9DF5442EDF6B2E00D1FE52 /* PackageFileHandle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackageFileHandle.swift; sourceTree = "<group>"; };
+		AAA2F8E33017FB2100F5452C /* BackupUploadServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupUploadServiceTests.swift; sourceTree = "<group>"; };
 		AAA666672D402F2900C2B9DF /* CustomModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomModalView.swift; sourceTree = "<group>"; };
 		AAA666692D40380800C2B9DF /* FileSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSelectionView.swift; sourceTree = "<group>"; };
 		AAA6666D2D40684500C2B9DF /* libjson-c.5.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = "libjson-c.5.dylib"; sourceTree = "<group>"; };
@@ -777,7 +790,11 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AAA2F8EA3017FF0700F5452C /* CocoaLumberjack in Frameworks */,
+				AAA2F8E83017FF0100F5452C /* RealmSwift in Frameworks */,
+				AAA2F8E63017FEEF00F5452C /* Realm in Frameworks */,
 				AAC188E62C222EB3007E321A /* InternxtSwiftCore in Frameworks */,
+				AAA2F8EC301800EE00F5452C /* CocoaLumberjackSwift in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1221,6 +1238,7 @@
 			isa = PBXGroup;
 			children = (
 				E15F8C342B762BAF00C60EFA /* BackupTreeGeneratorTests.swift */,
+				AAA2F8E33017FB2100F5452C /* BackupUploadServiceTests.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -1590,6 +1608,10 @@
 			name = XPCBackupServiceTests;
 			packageProductDependencies = (
 				AAC188E52C222EB3007E321A /* InternxtSwiftCore */,
+				AAA2F8E53017FEEF00F5452C /* Realm */,
+				AAA2F8E73017FF0100F5452C /* RealmSwift */,
+				AAA2F8E93017FF0700F5452C /* CocoaLumberjack */,
+				AAA2F8EB301800EE00F5452C /* CocoaLumberjackSwift */,
 			);
 			productName = InternxtDesktopTests;
 			productReference = E15F8C252B762B0400C60EFA /* XPCBackupServiceTests.xctest */;
@@ -1904,18 +1926,26 @@
 				E15F8C392B762D3400C60EFA /* BackupTreeGenerator.swift in Sources */,
 				E1D24AF72C0468AF0009EC83 /* AsyncOperation.swift in Sources */,
 				31F9EF2F2B867FED007DAD86 /* Bundle.swift in Sources */,
+				AAA2F8EF301803A300F5452C /* Device.swift in Sources */,
+				AAA2F8F2301803DF00F5452C /* BackupsDeviceService.swift in Sources */,
 				AAA424962C51FFC100EEFD69 /* GenericRepository.swift in Sources */,
 				31F9EF2A2B867DFE007DAD86 /* BackupUploadService.swift in Sources */,
 				AA3D12972FDC8D71000ECA4C /* EmptyFileLimitNotifier.swift in Sources */,
+				AAA2F8F0301803B300F5452C /* FeaturesService.swift in Sources */,
 				31F9EF2D2B867F42007DAD86 /* ErrorUtils.swift in Sources */,
 				31F9EF2B2B867E16007DAD86 /* ConfigLoader.swift in Sources */,
+				AAA2F8EE3018030E00F5452C /* BackupsService.swift in Sources */,
+				AAA2F8ED301802C600F5452C /* BackupConfigurationManager.swift in Sources */,
 				AAC188F12C2231E7007E321A /* MockBackupUploadService.swift in Sources */,
 				31F9EF2E2B867FE9007DAD86 /* APIFactory.swift in Sources */,
 				AA9B1B9E2FB2D342000E582A /* FileSizeLimitNotifier.swift in Sources */,
 				AA0B47AB2C24D9E90036FE1A /* BackupDownloadItemOperation.swift in Sources */,
+				AAA2F8E43017FB2100F5452C /* BackupUploadServiceTests.swift in Sources */,
 				E1D24AFA2C0DA4100009EC83 /* SyncedNode.swift in Sources */,
 				E15F8C352B762BAF00C60EFA /* BackupTreeGeneratorTests.swift in Sources */,
 				E1D24AFC2C0DA4270009EC83 /* BackupTreeNodeSyncResult.swift in Sources */,
+				AAA2F8F3301803E600F5452C /* UsageManager.swift in Sources */,
+				AAA2F8F1301803BA00F5452C /* ActivityManager.swift in Sources */,
 				AAC188EF2C2231B1007E321A /* MockBackupRealm.swift in Sources */,
 				E15F8C422B762EFF00C60EFA /* BackupTreeNodeSyncStatus.swift in Sources */,
 				AAC188EC2C222F3A007E321A /* BackupProgressUpdate.swift in Sources */,
@@ -3220,6 +3250,26 @@
 			isa = XCSwiftPackageProductDependency;
 			package = AA755BEB2D15FE7B00CE56A9 /* XCRemoteSwiftPackageReference "ObjectivePGP" */;
 			productName = ObjectivePGP;
+		};
+		AAA2F8E53017FEEF00F5452C /* Realm */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E19639582C63B46C009EDAFB /* XCRemoteSwiftPackageReference "realm-swift" */;
+			productName = Realm;
+		};
+		AAA2F8E73017FF0100F5452C /* RealmSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E19639582C63B46C009EDAFB /* XCRemoteSwiftPackageReference "realm-swift" */;
+			productName = RealmSwift;
+		};
+		AAA2F8E93017FF0700F5452C /* CocoaLumberjack */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = AA16C5C42E303B5B00E1C295 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */;
+			productName = CocoaLumberjack;
+		};
+		AAA2F8EB301800EE00F5452C /* CocoaLumberjackSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = AA16C5C42E303B5B00E1C295 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */;
+			productName = CocoaLumberjackSwift;
 		};
 		AAC188E52C222EB3007E321A /* InternxtSwiftCore */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/InternxtDesktop.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/InternxtDesktop.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -88,7 +88,7 @@
       "location" : "https://github.com/internxt/swift-core",
       "state" : {
         "branch" : "main",
-        "revision" : "2c47fc31e439440b19fe6acffc527898949b20f0"
+        "revision" : "ad2ca2cbf8fac848fe57808587465ab6c49016e7"
       }
     },
     {

--- a/Shared/Services/Backups/BackupsService.swift
+++ b/Shared/Services/Backups/BackupsService.swift
@@ -730,14 +730,11 @@ class BackupsService: ObservableObject {
             
             self.logger.info(["Backup status update received", backupStatus.totalSyncs, backupStatus.status])
             
-            if(backupStatus.totalSyncs == 0) {
-                return
-            }
-            
             DispatchQueue.main.async {
-                
                 self.backupUploadStatus = backupStatus.status
-                self.backupUploadProgress = backupStatus.progress
+                if backupStatus.totalSyncs > 0 {
+                    self.backupUploadProgress = backupStatus.progress
+                }
                 self.logger.info(["Backup upload is in \(backupStatus.status) status, \(backupStatus.completedSyncs) of \(backupStatus.totalSyncs) nodes synced, \(self.backupUploadProgress * 100)% synced"])
             }
             

--- a/XPCBackupService/Services/BackupUploadService.swift
+++ b/XPCBackupService/Services/BackupUploadService.swift
@@ -129,9 +129,7 @@ class BackupUploadService:  BackupUploadServiceProtocol, ObservableObject {
     }
 
     func stopSync() {
-        DispatchQueue.main.async {
-            self.canDoBackup = false
-        }
+        self.canDoBackup = false
     }
     
 // MARK: - Thread-Safe  Operations

--- a/XPCBackupService/XPCBackupService.swift
+++ b/XPCBackupService/XPCBackupService.swift
@@ -15,6 +15,9 @@ public class XPCBackupService: NSObject, XPCBackupServiceProtocol {
     private var backupUploadService: BackupUploadService? = nil
     private var trees: [BackupTreeNode] = []
     
+    private var currentBackupSessionId: UUID? = nil
+    private let backupSessionLock = NSLock()
+    
     private var backupUploadProgress: Progress = Progress()
     private var backupDownloadProgress: Progress = Progress()
     private var uploadOperationQueue = OperationQueue()
@@ -33,6 +36,13 @@ public class XPCBackupService: NSObject, XPCBackupServiceProtocol {
         with reply: @escaping (_ result: String?, _ error: String?) -> Void
     ) -> Void {
         let backupRealm = SyncedNodeRepository.shared
+        let sessionBackupId = UUID()
+        backupSessionLock.lock()
+        self.currentBackupSessionId = sessionBackupId
+        backupSessionLock.unlock()
+
+        self.trees = []
+        self.uploadOperationQueue = OperationQueue()
         self.uploadOperationQueue.maxConcurrentOperationCount = 5
         logger.info("Going to backup folders: \(backupURLs)")
         self.backupUploadStatus = .InProgress
@@ -121,10 +131,19 @@ public class XPCBackupService: NSObject, XPCBackupServiceProtocol {
             backupUploadProgress.totalUnitCount = Int64(totalNodesCount)
             logger.info("Total progress to backup \(totalNodesCount)")
 
-            logger.info("⏱️ About to start node sync process for \(trees.count) BackupTrees...")
             var hasErrorOccurred = false
             let syncGroup = DispatchGroup()
-            
+            var hasReplied = false
+            let replyLock = NSLock()
+            let sendReply: (_ result: String?, _ error: String?) -> Void = { result, error in
+                replyLock.lock()
+                defer { replyLock.unlock() }
+                if !hasReplied {
+                    hasReplied = true
+                    reply(result, error)
+                }
+            }
+
             for backupTree in trees {
                 if hasErrorOccurred {
                     break
@@ -139,7 +158,7 @@ public class XPCBackupService: NSObject, XPCBackupServiceProtocol {
                             self.backupUploadStatus = .Failed
                             self.uploadOperationQueue.cancelAllOperations()
                             hasErrorOccurred = true
-                            reply(nil, "storageFull")
+                            sendReply(nil, "storageFull")
                         } else {
                             logger.error("Error backing up device \(error)")
                             failureLock.lock()
@@ -150,31 +169,43 @@ public class XPCBackupService: NSObject, XPCBackupServiceProtocol {
                     }
                 } catch {
                     logger.error("Error setting up sync operations \(error)")
-                    reply(nil, error.localizedDescription)
+                    sendReply(nil, error.localizedDescription)
                 }
             }
             
             syncGroup.notify(queue: .global()) { [weak self] in
                 guard let self = self else { return }
+                
+                self.backupSessionLock.lock()
+                let isCurrentSession = (self.currentBackupSessionId == sessionBackupId)
+                self.backupSessionLock.unlock()
+
+                guard isCurrentSession else {
+                    return
+                }
+
                 logger.info("Sync nodes operations completed")
                 
                 let successCount = totalNodesCount - failedNodesCount
                 if failedNodesCount > 0 {
                     logger.warning("⚠️ BACKUP SUMMARY: Finished with ERRORS. \(successCount) nodes synced successfully, \(failedNodesCount) nodes FAILED.")
+                    if self.backupUploadStatus != .Stopped {
+                        self.backupUploadStatus = .Failed
+                    }
+                    self.trees = []
+                    self.backupUploadService = nil
+                    URLCache.shared.removeAllCachedResponses()
+                    sendReply(nil, "Backup completed with \(failedNodesCount) errors")
                 } else {
                     logger.info("✅ BACKUP SUMMARY: All \(totalNodesCount) nodes synced successfully.")
+                    if self.backupUploadStatus != .Stopped {
+                        self.backupUploadStatus = .Done
+                    }
+                    self.trees = []
+                    self.backupUploadService = nil
+                    URLCache.shared.removeAllCachedResponses()
+                    sendReply("synced all nodes for all trees", nil)
                 }
-
-                // If the backup failed, don't set the status to Done
-                if self.backupUploadStatus != .Failed {
-                    self.backupUploadStatus = .Done
-                }
-                
-                self.trees = []
-                self.backupUploadService = nil
-                URLCache.shared.removeAllCachedResponses()
-                
-                reply("synced all nodes for all trees", nil)
             }
 
             logger.info("Backups scheduled in OperationQueue")
@@ -291,6 +322,10 @@ public class XPCBackupService: NSObject, XPCBackupServiceProtocol {
 
     @objc func stopBackupUpload() {
         logger.debug("STOP BACKUP UPLOAD")
+        backupSessionLock.lock()
+        self.currentBackupSessionId = nil
+        backupSessionLock.unlock()
+        
         trees = []
         
         self.backupUploadStatus = .Stopped

--- a/XPCBackupServiceTests/Backups/Mocks/MockBackupUploadService.swift
+++ b/XPCBackupServiceTests/Backups/Mocks/MockBackupUploadService.swift
@@ -7,21 +7,100 @@
 
 import Foundation
 
-class MockBackupUploadService: BackupUploadServiceProtocol {
-    var syncResult: Result<BackupTreeNodeSyncResult, Error>?
-    
+class MockBackupUploadService: BackupUploadServiceProtocol, @unchecked Sendable {
+    private let lock = NSLock()
+
+    private var _canDoBackup: Bool = true
+    var canDoBackup: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return _canDoBackup
+    }
+
+    private var _syncResult: Result<BackupTreeNodeSyncResult, Error>? = nil
+    var syncResult: Result<BackupTreeNodeSyncResult, Error>? {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return _syncResult
+        }
+        set {
+            lock.lock()
+            _syncResult = newValue
+            lock.unlock()
+        }
+    }
+
+    private var _doSyncCallCount: Int = 0
+    var doSyncCallCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return _doSyncCallCount
+    }
+
+    private var _stopSyncCalled: Bool = false
+    var stopSyncCalled: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return _stopSyncCalled
+    }
+
+    private var _syncDelayNanoseconds: UInt64 = 0
+    var syncDelayNanoseconds: UInt64 {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return _syncDelayNanoseconds
+        }
+        set {
+            lock.lock()
+            _syncDelayNanoseconds = newValue
+            lock.unlock()
+        }
+    }
+
+    private func recordSyncAttempt() -> (canDo: Bool, delay: UInt64, overrideResult: Result<BackupTreeNodeSyncResult, Error>?) {
+        lock.lock()
+        defer { lock.unlock() }
+        _doSyncCallCount += 1
+        return (_canDoBackup, _syncDelayNanoseconds, _syncResult)
+    }
+
     func doSync(node: BackupTreeNode) async -> Result<BackupTreeNodeSyncResult, Error> {
-        if let result = syncResult {
+        let (currentCanDoBackup, delay, resultOverride) = recordSyncAttempt()
+
+        guard currentCanDoBackup else {
+            node.removeChildNodes()
+            return .failure(BackupUploadError.BackupStoppedManually)
+        }
+
+        if delay > 0 {
+            try? await Task.sleep(nanoseconds: delay)
+        }
+
+        if let result = resultOverride {
             return result
         }
         if node.type == .folder {
             return .success(BackupTreeNodeSyncResult(id: 100, uuid: nil))
         }
         return .success(BackupTreeNodeSyncResult(id: 100, uuid: "ABC123456"))
-        
     }
-    
+
     func stopSync() {
-       // TODO:
+        lock.lock()
+        _stopSyncCalled = true
+        _canDoBackup = false
+        lock.unlock()
+    }
+
+    func reset() {
+        lock.lock()
+        _canDoBackup = true
+        _syncResult = nil
+        _doSyncCallCount = 0
+        _stopSyncCalled = false
+        _syncDelayNanoseconds = 0
+        lock.unlock()
     }
 }

--- a/XPCBackupServiceTests/Backups/Services/BackupTreeGeneratorTests.swift
+++ b/XPCBackupServiceTests/Backups/Services/BackupTreeGeneratorTests.swift
@@ -30,7 +30,12 @@ final class BackupTreeGeneratorTests: XCTestCase {
     }
     
     override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        if let url = tmpDirectoryURL {
+            try? FileManager.default.removeItem(at: url)
+        }
+        sut = nil
+        mockBackupUploadService = nil
+        tmpDirectoryURL = nil
     }
     
     private func createFileInTmpDir(_ fileRelativePath: String) throws -> URL {
@@ -38,7 +43,10 @@ final class BackupTreeGeneratorTests: XCTestCase {
         
         try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
         
-        FileManager.default.createFile(atPath: url.path(), contents: nil)
+        let created = FileManager.default.createFile(atPath: url.path(), contents: "test".data(using: .utf8))
+        if !created {
+            throw XCTSkip("Could not create test file at \(url.path())")
+        }
         
         return url
     }
@@ -50,54 +58,60 @@ final class BackupTreeGeneratorTests: XCTestCase {
         return url
     }
     
-    
     func testNodeSync() async throws {
         let fileTest1 = try createFileInTmpDir("test1.txt")
-        let folderA = try createDirectoryInTmpDir("folderA")
-        let fileTest2 = try createFileInTmpDir("folderA/test3.txt")
-        let backupTree = try await sut.generateTree()
+        _ = try createDirectoryInTmpDir("folderA")
+        _ = try createFileInTmpDir("folderA/test3.txt")
+        let (backupTree, _) = try await sut.generateTree()
         try await backupTree.syncNode()
         
-        XCTAssertEqual(backupTree.syncStatus, .REMOTE_AND_LOCAL )
+        XCTAssertEqual(backupTree.syncStatus, .REMOTE_AND_LOCAL)
+        let childNode = backupTree.findNode(fileTest1)
+        XCTAssertNotNil(childNode)
     }
     
-    
     func testNodeSyncOperationQueue() async throws {
-        let fileTest1 = try createFileInTmpDir("test1.txt")
-        let folderA = try createDirectoryInTmpDir("folderA")
-        let fileTest2 = try createFileInTmpDir("folderA/test3.txt")
-        let backupTree = try await sut.generateTree()
-        XCTAssertNoThrow(try backupTree.syncBelowNodes(withOperationQueue: uploadOperationQueue))
+        _ = try createFileInTmpDir("test1.txt")
+        _ = try createDirectoryInTmpDir("folderA")
+        _ = try createFileInTmpDir("folderA/test3.txt")
+        let (backupTree, _) = try await sut.generateTree()
+        let syncGroup = DispatchGroup()
+        XCTAssertNoThrow(try backupTree.syncBelowNodes(withOperationQueue: uploadOperationQueue, syncGroup: syncGroup, onError: { _ in }))
+        
+        let expectation = expectation(description: "syncGroup drains")
+        syncGroup.notify(queue: .global()) { expectation.fulfill() }
+        await fulfillment(of: [expectation], timeout: 10)
+        
+        XCTAssertGreaterThan(mockBackupUploadService.doSyncCallCount, 0, "At least one node should be processed")
     }
     
     func testNodeSyncRetries() async throws {
-        let backupTree = try await sut.generateTree()
-        mockBackupUploadService.syncResult = .failure(BackupUploadError.CannotCreateEncryptedContentURL)
-        try await backupTree.syncNode()
-        XCTAssertEqual(backupTree.syncRetries, 3 )
+        let (backupTree, _) = try await sut.generateTree()
+        let retryableError = NSError(domain: "NetworkError", code: 500, userInfo: nil)
+        mockBackupUploadService.syncResult = .failure(retryableError)
+        
+        do {
+            try await backupTree.syncNode()
+            XCTFail("syncNode() should throw after exhausting all retries")
+        } catch {
+            XCTAssertEqual(backupTree.syncRetries, 3)
+        }
     }
     
     func testNodeUrlIsMissing() async throws {
-        let backupTree = try await sut.generateTree()
+        let (backupTree, _) = try await sut.generateTree()
         backupTree.url = nil
-        let expectation = self.expectation(description: "syncNode() should throw")
         
-        Task {
-            do {
-                try await backupTree.syncNode()
-                XCTFail("syncNode() should throw an error")
-            } catch {
-                XCTAssertEqual(error as? BackupTreeNodeError, .cannotGetPath)
-                expectation.fulfill()
-            }
+        do {
+            try await backupTree.syncNode()
+            XCTFail("syncNode() should throw an error when url is nil")
+        } catch {
+            XCTAssertEqual(error as? BackupTreeNodeError, .cannotGetPath)
         }
-        
-        await fulfillment(of: [expectation], timeout: 5)
     }
     
     func testNodeisAlreadySync() async throws {
-        
-        let backupTree = try await sut.generateTree()
+        let (backupTree, _) = try await sut.generateTree()
         let node = SyncedNode(
             remoteId: 2,
             deviceId: 999,
@@ -110,7 +124,7 @@ final class BackupTreeGeneratorTests: XCTestCase {
         
         try backupRealm.addSyncedNode(node)
         try await backupTree.syncNode()
-        XCTAssertEqual(backupTree.syncStatus, .REMOTE_AND_LOCAL )
+        XCTAssertEqual(backupTree.syncStatus, .REMOTE_AND_LOCAL)
     }
     
     func testGenerateTreeFromUrlsTest() async throws {
@@ -118,11 +132,10 @@ final class BackupTreeGeneratorTests: XCTestCase {
         let folderA = try createDirectoryInTmpDir("folderA")
         let fileTest2 = try createFileInTmpDir("folderA/test3.txt")
         
-        let backupTree = try await sut.generateTree()
+        let (backupTree, _) = try await sut.generateTree()
         
         // Ensure the root is the backup root
         XCTAssertEqual(backupTree.url, tmpDirectoryURL)
-        
         
         let fileTest1Node = backupTree.findNode(fileTest1)
         let fileTest1AsChild = backupTree.childs.first(where: {
@@ -136,34 +149,31 @@ final class BackupTreeGeneratorTests: XCTestCase {
         
         // Ensure that folderA/ is the parent node of folderA/test2.txt
         let fileTest3ParentNode = backupTree.findNodeById(fileTest2Node!.parentId!)
-        XCTAssertEqual(fileTest3ParentNode!.url, folderA )
+        XCTAssertEqual(fileTest3ParentNode!.url, folderA)
     }
     
     func testStructureIsCorrect() async throws {
         let fileURL = try createFileInTmpDir("FolderA/FolderB/FolderC/FolderD/FolderE/file.txt")
         
-        let backupTree = try await sut.generateTree()
+        let (backupTree, _) = try await sut.generateTree()
         
-        let fileNode = backupTree.findNode(fileURL)
+        let fileNode = try XCTUnwrap(backupTree.findNode(fileURL), "fileNode should exist in generated tree")
+        XCTAssertEqual(fileNode.url, fileURL)
         
+        let firstParentId = try XCTUnwrap(fileNode.parentId, "firstParentId should not be nil")
+        let firstParent = try XCTUnwrap(backupTree.findNodeById(firstParentId), "FolderE should exist")
+        XCTAssertEqual(firstParent.name, "FolderE")
         
-        // Node exists
-        XCTAssertEqual(fileNode!.url, fileURL )
-        let firstParent = backupTree.findNodeById(fileNode!.parentId!)
+        let secondParentId = try XCTUnwrap(firstParent.parentId, "secondParentId should not be nil")
+        let secondParent = try XCTUnwrap(backupTree.findNodeById(secondParentId), "FolderD should exist")
+        XCTAssertEqual(secondParent.name, "FolderD")
         
-        XCTAssertEqual(firstParent?.name, "FolderE")
+        let thirdParentId = try XCTUnwrap(secondParent.parentId, "thirdParentId should not be nil")
+        let thirdParent = try XCTUnwrap(backupTree.findNodeById(thirdParentId), "FolderC should exist")
+        XCTAssertEqual(thirdParent.name, "FolderC")
         
-        let secondParent = backupTree.findNodeById(firstParent!.parentId!)
-        
-        XCTAssertEqual(secondParent?.name, "FolderD")
-        
-        let thirdParent = backupTree.findNodeById(secondParent!.parentId!)
-        
-        XCTAssertEqual(thirdParent?.name, "FolderC")
-        
-        let fourthParent = backupTree.findNodeById(thirdParent!.parentId!)
-        
-        XCTAssertEqual(fourthParent?.name, "FolderB")
-        
+        let fourthParentId = try XCTUnwrap(thirdParent.parentId, "fourthParentId should not be nil")
+        let fourthParent = try XCTUnwrap(backupTree.findNodeById(fourthParentId), "FolderB should exist")
+        XCTAssertEqual(fourthParent.name, "FolderB")
     }
 }

--- a/XPCBackupServiceTests/Backups/Services/BackupUploadServiceTests.swift
+++ b/XPCBackupServiceTests/Backups/Services/BackupUploadServiceTests.swift
@@ -1,0 +1,188 @@
+//
+//  BackupUploadServiceTests.swift
+//  XPCBackupServiceTests
+//
+//  Created by Patricio Tovar on 27/7/26.
+//
+
+import Foundation
+import Testing
+import InternxtSwiftCore
+
+// MARK: - Tags
+
+extension Tag {
+    @Tag static var backupLifecycle: Self
+    @Tag static var concurrency: Self
+}
+
+// MARK: - BackupUploadServiceTests
+
+struct BackupUploadServiceTests {
+
+    // MARK: - Properties
+
+    let tmpDirectoryURL: URL
+    let backupRealm: MockBackupRealm
+    let mockUploadService: MockBackupUploadService
+
+    // MARK: - Init
+
+    init() throws {
+        let tempURL = URL(fileURLWithPath: "/private\(NSTemporaryDirectory())")
+            .appendingPathComponent("BACKUP_UPLOAD_SERVICE_TESTS_\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempURL, withIntermediateDirectories: true)
+
+        self.tmpDirectoryURL = tempURL
+        self.backupRealm = MockBackupRealm()
+        self.mockUploadService = MockBackupUploadService()
+    }
+
+    // MARK: - Private Helpers
+
+    private func createFile(_ relativePath: String) throws -> URL {
+        let url = tmpDirectoryURL.appendingPathComponent(relativePath)
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let created = FileManager.default.createFile(atPath: url.path(), contents: "test".data(using: .utf8))
+        try #require(created, "Failed to create test file at \(url.path())")
+        return url
+    }
+
+    private func makeTree(progress: Progress = Progress()) async throws -> BackupTreeNode {
+        let generator = BackupTreeGenerator(
+            root: tmpDirectoryURL,
+            deviceId: 999,
+            backupUploadService: mockUploadService,
+            backupTotalProgress: progress,
+            backupRealm: backupRealm
+        )
+        let (tree, _) = try await generator.generateTree()
+        return tree
+    }
+
+   
+    private func wait(for group: DispatchGroup) async {
+        await withCheckedContinuation { continuation in
+            group.notify(queue: .global()) { continuation.resume() }
+        }
+    }
+
+   
+
+    @Test("stopSync() immediately stops uploads and removes child nodes", .tags(.backupLifecycle), .bug(id: "BR-2119"))
+    func stopSyncPreventsSubsequentUploadsAndCleansTree() async throws {
+        defer { try? FileManager.default.removeItem(at: tmpDirectoryURL) }
+
+        _ = try createFile("folder/file1.txt")
+        let tree = try await makeTree()
+
+        try #require(mockUploadService.canDoBackup == true, "canDoBackup must be true before stopSync()")
+        try #require(!tree.childs.isEmpty, "Generated tree must have children for this test to be meaningful")
+
+        mockUploadService.stopSync()
+
+      
+        #expect(mockUploadService.canDoBackup == false, "stopSync() must set canDoBackup = false synchronously")
+
+
+        let result = await mockUploadService.doSync(node: tree)
+        do {
+            _ = try result.get()
+            Issue.record("doSync must not succeed when canDoBackup is false")
+        } catch let error as BackupUploadError {
+            #expect(error == .BackupStoppedManually, "Expected .BackupStoppedManually, got: \(error)")
+        } catch {
+            Issue.record("Unexpected error type thrown: \(error)")
+        }
+
+      
+        #expect(tree.childs.isEmpty, "doSync must remove child nodes when canDoBackup is false")
+    }
+
+
+
+    @Test("After stop-and-restart, progress advances and uploads are attempted",
+          .tags(.backupLifecycle, .concurrency), .bug(id: "BR-2119"), .timeLimit(.minutes(1)))
+    func progressAndUploadsOccurAfterRestart() async throws {
+        defer { try? FileManager.default.removeItem(at: tmpDirectoryURL) }
+
+        _ = try createFile("doc1.txt")
+        _ = try createFile("doc2.txt")
+
+        let progressSession1 = Progress(totalUnitCount: 10)
+        let treeSession1 = try await makeTree(progress: progressSession1)
+        mockUploadService.stopSync()
+        try await treeSession1.syncNode()
+
+        mockUploadService.reset()
+        try #require(mockUploadService.canDoBackup == true, "reset() must restore canDoBackup to true")
+
+        let operationQueue = OperationQueue()
+        operationQueue.maxConcurrentOperationCount = 5
+
+        let progressSession2 = Progress(totalUnitCount: 10)
+        let treeSession2 = try await makeTree(progress: progressSession2)
+
+        let syncGroup = DispatchGroup()
+        try treeSession2.syncBelowNodes(
+            withOperationQueue: operationQueue,
+            syncGroup: syncGroup,
+            onError: { _ in }
+        )
+        await wait(for: syncGroup)
+
+        // UI must not be stuck at 0%
+        #expect(progressSession2.completedUnitCount > 0,
+            "completedUnitCount must be > 0 after restart — the UI must not be stuck at 0%")
+
+        #expect(mockUploadService.doSyncCallCount > 0,
+            "doSync must be called in the new session — files must be attempted for upload")
+    }
+
+
+    @Test("New session OperationQueue processes files independently",
+          .tags(.backupLifecycle, .concurrency), .bug(id: "BR-2119"), .timeLimit(.minutes(1)))
+    func newSessionOperationQueueIsClean() async throws {
+        defer { try? FileManager.default.removeItem(at: tmpDirectoryURL) }
+
+        _ = try createFile("image.png")
+
+        let queueSession1 = OperationQueue()
+        queueSession1.maxConcurrentOperationCount = 5
+
+        let tree1 = try await makeTree()
+        let syncGroup1 = DispatchGroup()
+        try tree1.syncBelowNodes(
+            withOperationQueue: queueSession1,
+            syncGroup: syncGroup1,
+            onError: { _ in }
+        )
+        queueSession1.cancelAllOperations()
+        await wait(for: syncGroup1)
+
+        try #require(queueSession1.operationCount == 0,
+            "Session 1's queue must be empty after cancelAllOperations + drain")
+
+        mockUploadService.reset()
+        try #require(mockUploadService.canDoBackup == true, "reset() must restore canDoBackup to true")
+        let callCountBeforeSession2 = mockUploadService.doSyncCallCount
+
+        let queueSession2 = OperationQueue()
+        queueSession2.maxConcurrentOperationCount = 5
+
+        let tree2 = try await makeTree()
+        let syncGroup2 = DispatchGroup()
+        try tree2.syncBelowNodes(
+            withOperationQueue: queueSession2,
+            syncGroup: syncGroup2,
+            onError: { _ in }
+        )
+        await wait(for: syncGroup2)
+
+        #expect(mockUploadService.doSyncCallCount > callCountBeforeSession2,
+            "Session 2 must call doSync independently — no interference from session 1's canceled queue")
+    }
+}


### PR DESCRIPTION
## Description
Fixes an issue where a user stopping and immediately restarting a backup would see the UI stuck at `0%` (or marked as completed prematurely), even though files were actively being processed and uploaded in the background.
## Changes Made
- **Session Tracking:** Added unique session IDs (`currentBackupSessionId`) to discard completion callbacks from obsolete/canceled backups.
- **State Reset:** Re-instantiated `uploadOperationQueue` and reset internal state on backup restart to prevent task leakage.
- **Progress Handling:** Fixed UI progress polling in `BackupsService` to ensure real-time status updates while generating the file tree.