### PR TITLE
fix storage full retries and correct widget failure status display

### DIFF
--- a/InternxtDesktop/Views/Widget/WidgetSyncEntryView.swift
+++ b/InternxtDesktop/Views/Widget/WidgetSyncEntryView.swift
@@ -46,13 +46,34 @@ struct WidgetSyncEntryView: View {
     var EntryStatusSubtitle: some View {
         switch self.operationKind {
         case .backupDownload:
-            AppText(status == .inProgress ? "SYNC_ENTRY_KIND_DOWNLOADING" : "SYNC_ENTRY_KIND_DOWNLOADED").font(.XSMedium).foregroundColor(.Gray50)
+            switch status {
+            case .inProgress:
+                AppText("SYNC_ENTRY_KIND_DOWNLOADING").font(.XSMedium).foregroundColor(.Gray50)
+            case .finished:
+                AppText("SYNC_ENTRY_KIND_DOWNLOADED").font(.XSMedium).foregroundColor(.Gray50)
+            case .failed:
+                AppText("SYNC_ENTRY_KIND_FAILED").font(.XSMedium).foregroundColor(.Red)
+            }
         case .trash:
             AppText("SYNC_ENTRY_KIND_TRASHED").font(.XSMedium).foregroundColor(.Gray50)
         case .download:
-            AppText(status == .inProgress ? "SYNC_ENTRY_KIND_DOWNLOADING" : "SYNC_ENTRY_KIND_DOWNLOADED").font(.XSMedium).foregroundColor(.Gray50)
+            switch status {
+            case .inProgress:
+                AppText("SYNC_ENTRY_KIND_DOWNLOADING").font(.XSMedium).foregroundColor(.Gray50)
+            case .finished:
+                AppText("SYNC_ENTRY_KIND_DOWNLOADED").font(.XSMedium).foregroundColor(.Gray50)
+            case .failed:
+                AppText("SYNC_ENTRY_KIND_FAILED").font(.XSMedium).foregroundColor(.Red)
+            }
         case .upload:
-            AppText(status == .inProgress ? "SYNC_ENTRY_KIND_UPLOADING" : "SYNC_ENTRY_KIND_UPLOADED").font(.XSMedium).foregroundColor(.Gray50)
+            switch status {
+            case .inProgress:
+                AppText("SYNC_ENTRY_KIND_UPLOADING").font(.XSMedium).foregroundColor(.Gray50)
+            case .finished:
+                AppText("SYNC_ENTRY_KIND_UPLOADED").font(.XSMedium).foregroundColor(.Gray50)
+            case .failed:
+                AppText("SYNC_ENTRY_KIND_FAILED").font(.XSMedium).foregroundColor(.Red)
+            }
         default:
             EmptyView()
         }
@@ -67,8 +88,8 @@ struct WidgetSyncEntryView: View {
             ProgressView()
                 .scaleEffect(0.7)
                 .frame(width: 24, height: 24)
-        default:
-            EmptyView()
+        case .failed:
+            AppIcon(iconName: .WarningCircle, size: 24, color: .Red)
         }
     }
 }

--- a/Shared/Extensions/Error.swift
+++ b/Shared/Extensions/Error.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import FileProvider
 import InternxtSwiftCore
 
 extension Error {
@@ -95,6 +96,24 @@ extension Error {
             apiError.statusCode == 420 { return true }
         
         return false
+    }
+
+    func toFileProviderError() -> NSError {
+        if self.isStorageFull {
+            syncExtensionLogger.error("❌ Cannot synchronize file: destination storage is full (420)")
+            DistributedNotificationCenter.default().postNotificationName(
+                .storageFull,
+                object: nil,
+                userInfo: nil,
+                deliverImmediately: true
+            )
+            return NSError(domain: NSFileProviderErrorDomain, code: NSFileProviderError.cannotSynchronize.rawValue)
+        } else if let apiClientError = self as? APIClientError, apiClientError.statusCode == 402 {
+            syncExtensionLogger.error("❌ Cannot synchronize file due to payment/quota issue (402)")
+            return NSError(domain: NSFileProviderErrorDomain, code: NSFileProviderError.cannotSynchronize.rawValue)
+        } else {
+            return NSError(domain: NSFileProviderErrorDomain, code: NSFileProviderError.serverUnreachable.rawValue)
+        }
     }
 }
 

--- a/Shared/en.lproj/Localizable.strings
+++ b/Shared/en.lproj/Localizable.strings
@@ -39,6 +39,7 @@
 "SYNC_ENTRY_KIND_UPLOADED" = "Uploaded";
 "SYNC_ENTRY_KIND_DOWNLOADING" = "Downloading...";
 "SYNC_ENTRY_KIND_UPLOADING" = "Uploading...";
+"SYNC_ENTRY_KIND_FAILED" = "Upload failed";
 
 // Widget backup banner
 "INTERNXT_BACKUPS" = "INTERNXT BACKUPS";

--- a/Shared/es.lproj/Localizable.strings
+++ b/Shared/es.lproj/Localizable.strings
@@ -40,6 +40,7 @@
 "SYNC_ENTRY_KIND_UPLOADED" = "Subido";
 "SYNC_ENTRY_KIND_DOWNLOADING" = "Descargando...";
 "SYNC_ENTRY_KIND_UPLOADING" = "Subiendo...";
+"SYNC_ENTRY_KIND_FAILED" = "Error al subir";
 
 // Widget backup banner
 "INTERNXT_BACKUPS" = "INTERNXT BACKUPS";

--- a/Shared/fr.lproj/Localizable.strings
+++ b/Shared/fr.lproj/Localizable.strings
@@ -40,6 +40,7 @@
 "SYNC_ENTRY_KIND_UPLOADED" = "Téléchargé";
 "SYNC_ENTRY_KIND_DOWNLOADING" = "Téléchargement...";
 "SYNC_ENTRY_KIND_UPLOADING" = "Téléversement...";
+"SYNC_ENTRY_KIND_FAILED" = "Échec du téléversement";
 
 // Widget backup banner
 "INTERNXT_BACKUPS" = "INTERNXT BACKUPS";

--- a/SyncExtension/UseCases/Files/UpdateFileContentUseCase.swift
+++ b/SyncExtension/UseCases/Files/UpdateFileContentUseCase.swift
@@ -129,22 +129,7 @@ struct UpdateFileContentUseCase {
             } catch {
                 error.reportToSentry()
                 self.logger.error("❌ Failed to update file content: \(error.getErrorDescription())")
-                
-                if error.isStorageFull {
-                    self.logger.error("❌ Cannot synchronize file: destination storage is full (420)")
-                    DistributedNotificationCenter.default().postNotificationName(
-                        .storageFull,
-                        object: nil,
-                        userInfo: nil,
-                        deliverImmediately: true
-                    )
-                    completionHandler(nil, [], false, NSError(domain: NSFileProviderErrorDomain, code: NSFileProviderError.insufficientQuota.rawValue))
-                } else if let apiClientError = error as? APIClientError, apiClientError.statusCode == 402 {
-                    self.logger.error("❌ Cannot synchronize file due to payment/quota issue (402)")
-                    completionHandler(nil, [], false, NSError(domain: NSFileProviderErrorDomain, code: NSFileProviderError.cannotSynchronize.rawValue))
-                } else {
-                    completionHandler(nil, [], false, NSError(domain: NSFileProviderErrorDomain, code: NSFileProviderError.serverUnreachable.rawValue))
-                }
+                completionHandler(nil, [], false, error.toFileProviderError())
             }
         }
         

--- a/SyncExtension/UseCases/Files/UploadFileUseCase.swift
+++ b/SyncExtension/UseCases/Files/UploadFileUseCase.swift
@@ -248,23 +248,7 @@ struct UploadFileUseCase {
                 error.reportToSentry()
                 activityManager.updateActivityEntryStatus(id: inProgressId, filename: item.filename, kind: .upload, status: .failed)
                 self.logger.error("❌ Failed to create file \(item.filename) : \(error.getErrorDescription())")
-                
-               
-                if error.isStorageFull {
-                    self.logger.error("❌ Cannot synchronize file: destination storage is full (420)")
-                    DistributedNotificationCenter.default().postNotificationName(
-                        .storageFull,
-                        object: nil,
-                        userInfo: nil,
-                        deliverImmediately: true
-                    )
-                    completionHandler(nil, [], false, NSError(domain: NSFileProviderErrorDomain, code: NSFileProviderError.insufficientQuota.rawValue))
-                } else if let apiClientError = error as? APIClientError, apiClientError.statusCode == 402 {
-                    self.logger.error("❌ Cannot synchronize file due to payment/quota issue (402)")
-                    completionHandler(nil, [], false, NSError(domain: NSFileProviderErrorDomain, code: NSFileProviderError.cannotSynchronize.rawValue))
-                } else {
-                    completionHandler(nil, [], false, NSError(domain: NSFileProviderErrorDomain, code: NSFileProviderError.serverUnreachable.rawValue))
-                }
+                completionHandler(nil, [], false, error.toFileProviderError())
             }
         }
         

--- a/SyncExtension/UseCases/Files/Workspaces/UpdateFileContentWorkspaceUseCase.swift
+++ b/SyncExtension/UseCases/Files/Workspaces/UpdateFileContentWorkspaceUseCase.swift
@@ -119,22 +119,7 @@ struct UpdateFileContentWorkspaceUseCase {
             } catch {
                 error.reportToSentry()
                 self.logger.error("❌ Failed to update file content: \(error.getErrorDescription())")
-                
-                if error.isStorageFull {
-                    self.logger.error("❌ Cannot synchronize file: destination storage is full (420)")
-                    DistributedNotificationCenter.default().postNotificationName(
-                        .storageFull,
-                        object: nil,
-                        userInfo: nil,
-                        deliverImmediately: true
-                    )
-                    completionHandler(nil, [], false, NSError(domain: NSFileProviderErrorDomain, code: NSFileProviderError.insufficientQuota.rawValue))
-                } else if let apiClientError = error as? APIClientError, apiClientError.statusCode == 402 {
-                    self.logger.error("❌ Cannot synchronize file due to payment/quota issue (402)")
-                    completionHandler(nil, [], false, NSError(domain: NSFileProviderErrorDomain, code: NSFileProviderError.cannotSynchronize.rawValue))
-                } else {
-                    completionHandler(nil, [], false, NSError(domain: NSFileProviderErrorDomain, code: NSFileProviderError.serverUnreachable.rawValue))
-                }
+                completionHandler(nil, [], false, error.toFileProviderError())
             }
         }
         

--- a/SyncExtension/UseCases/Files/Workspaces/UploadFileWorkspaceUseCase.swift
+++ b/SyncExtension/UseCases/Files/Workspaces/UploadFileWorkspaceUseCase.swift
@@ -235,22 +235,7 @@ struct UploadFileWorkspaceUseCase {
                 error.reportToSentry()
                 activityManager.updateActivityEntryStatus(id: inProgressId, filename: item.filename, kind: .upload, status: .failed)
                 self.logger.error("❌ Failed to create file: \(error.getErrorDescription())")
-                
-                if error.isStorageFull {
-                    self.logger.error("❌ Cannot synchronize file: destination storage is full (420)")
-                    DistributedNotificationCenter.default().postNotificationName(
-                        .storageFull,
-                        object: nil,
-                        userInfo: nil,
-                        deliverImmediately: true
-                    )
-                    completionHandler(nil, [], false, NSError(domain: NSFileProviderErrorDomain, code: NSFileProviderError.insufficientQuota.rawValue))
-                } else if let apiClientError = error as? APIClientError, apiClientError.statusCode == 402 {
-                    self.logger.error("❌ Cannot synchronize file due to payment/quota issue (402)")
-                    completionHandler(nil, [], false, NSError(domain: NSFileProviderErrorDomain, code: NSFileProviderError.cannotSynchronize.rawValue))
-                } else {
-                    completionHandler(nil, [], false, NSError(domain: NSFileProviderErrorDomain, code: NSFileProviderError.serverUnreachable.rawValue))
-                }
+                completionHandler(nil, [], false, error.toFileProviderError())
             }
         }
         


### PR DESCRIPTION
This PR fixes an issue where file uploads failing due to **Storage Full (HTTP 420)** caused an retry loop from macOS FileProvider, repeated error modals, and mislabelled entries in the sync widget showing as `"Uploaded"`.
---
## 🛑 Problem
1. **macOS Retries & Reappearing Modals**: When storage was full, the extension returned `NSFileProviderError.insufficientQuota`. macOS FileProvider treats this as a retryable error, repeatedly re-triggering the upload process and causing the "Storage Full" modal to re-appear after dismissal.
2. **Incorrect Status in Widget**: Failed uploads saved `.failed` status in Realm, but `WidgetSyncEntryView` used a binary ternary check (`status == .inProgress ? "UPLOADING" : "UPLOADED"`). Consequently, any `.failed` entry fell into the `else` branch and was incorrectly displayed as `"Uploaded"`.
3. **Duplicated Error Handling**: Error mapping for 420/402 HTTP status codes was duplicated across four separate upload use cases.
---
## 🛠️ Changes Made
- **FileProvider Error Code**: Replaced `NSFileProviderError.insufficientQuota` with `NSFileProviderError.cannotSynchronize` when storage is full (420), signaling macOS FileProvider to halt retries for un-synchronizable states.
- **Sync Widget Failure State**: Updated `WidgetSyncEntryView` to explicitly handle `status == .failed` by showing a warning icon (`WarningCircle` in red) and localized error text.
- **Refactoring & Clean Code**: Created `Error.toFileProviderError()` extension in `Error.swift` to centralize 420/402/server error mapping across `UploadFileUseCase`, `UpdateFileContentUseCase`, `UploadFileWorkspaceUseCase`, and `UpdateFileContentWorkspaceUseCase`.