### PR TITLE
Run unit tests automatically on push to fix branches

### DIFF
--- a/.github/workflows/macos-run-tests.yaml
+++ b/.github/workflows/macos-run-tests.yaml
@@ -2,8 +2,6 @@ name: Test Internxt Desktop MacOS App
 
 on:
   push:
-    branches:
-      - 'fix/**'
   workflow_dispatch:
 
 # This envs are available for all the steps

--- a/.github/workflows/macos-run-tests.yaml
+++ b/.github/workflows/macos-run-tests.yaml
@@ -1,6 +1,9 @@
 name: Test Internxt Desktop MacOS App
 
 on:
+  push:
+    branches:
+      - 'fix/**'
   workflow_dispatch:
 
 # This envs are available for all the steps
@@ -9,7 +12,7 @@ env:
   SLACK_WEBHOOK_MAC_TEAM: ${{secrets.SLACK_WEBHOOK_MAC_TEAM}}
 jobs:
   build:
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
 
       - name: Checkout code
@@ -35,10 +38,15 @@ jobs:
           json: ${{ secrets.JSON_ENV }}
           dir: 'InternxtDesktop/'
       
-      - name: Run Fastlane tests
-        run: fastlane test --verbose
-        env:
-          MATCH_PASSWORD: ${{ secrets.FASTLANE_MATCH_PASSWORD }}
+      - name: Run Xcode Unit Tests
+        run: |
+          xcodebuild test \
+            -project InternxtDesktop.xcodeproj \
+            -scheme InternxtDesktop \
+            -destination 'platform=macOS' \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO
 
       - name: Archive logs
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
In this PR, unit tests are automatically triggered on GitHub Actions whenever code is pushed to any `fix/` branch, ensuring better test coverage and code quality across fix branches before merging.
The following changes are implemented:
- **Automated CI Triggers**: Updated `.github/workflows/macos-run-tests.yaml` to automatically run unit tests on every `push` to `fix/**` branches.
- **Environment Upgrade**: Updated runner to `macos-15` (Xcode 16 / Swift 6) for proper package dependency resolution.
- **Test Execution**: Configured `xcodebuild test` to bypass code signing so unit tests run cleanly in CI without requiring developer certificates.