### PR TITLE
Add Issues window feature and dynamic menu badge

### DIFF
--- a/InternxtDesktop.xcodeproj/project.pbxproj
+++ b/InternxtDesktop.xcodeproj/project.pbxproj
@@ -107,6 +107,13 @@
 		AA755BED2D15FE7B00CE56A9 /* ObjectivePGP in Frameworks */ = {isa = PBXBuildFile; productRef = AA755BEC2D15FE7B00CE56A9 /* ObjectivePGP */; };
 		AA7FC5A42E450CAA0018C333 /* CleanerTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA7FC5A32E450CAA0018C333 /* CleanerTabView.swift */; };
 		AA825F982CF9049E0058B30A /* GetRemoteChangesUseCaseWorkspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA825F972CF9049E0058B30A /* GetRemoteChangesUseCaseWorkspace.swift */; };
+		AA8B5F5E302A238C00F28F39 /* Issue.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8B5F5D302A238C00F28F39 /* Issue.swift */; };
+		AA8B5F5F302A238C00F28F39 /* Issue.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8B5F5D302A238C00F28F39 /* Issue.swift */; };
+		AA8B5F60302A238C00F28F39 /* Issue.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8B5F5D302A238C00F28F39 /* Issue.swift */; };
+		AA8B5F62302A23AB00F28F39 /* IssuesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8B5F61302A23AB00F28F39 /* IssuesManager.swift */; };
+		AA8B5F65302A2E1700F28F39 /* IssuesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8B5F64302A2E1700F28F39 /* IssuesView.swift */; };
+		AA8B5F67302A2E2600F28F39 /* IssueRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8B5F66302A2E2600F28F39 /* IssueRowView.swift */; };
+		AA8B5F69302A2E4700F28F39 /* IssuesEmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8B5F68302A2E4700F28F39 /* IssuesEmptyStateView.swift */; };
 		AA8D9AEF2E7CC2370068B333 /* FeaturesService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8D9AEE2E7CC2370068B333 /* FeaturesService.swift */; };
 		AA8D9AF02E7CC2370068B333 /* FeaturesService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8D9AEE2E7CC2370068B333 /* FeaturesService.swift */; };
 		AA8D9AF12E7CC3300068B333 /* FeaturesService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8D9AEE2E7CC2370068B333 /* FeaturesService.swift */; };
@@ -570,6 +577,11 @@
 		AA642CAD2C62B26B0015BBB9 /* BackupConfigurationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupConfigurationManager.swift; sourceTree = "<group>"; };
 		AA7FC5A32E450CAA0018C333 /* CleanerTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CleanerTabView.swift; sourceTree = "<group>"; };
 		AA825F972CF9049E0058B30A /* GetRemoteChangesUseCaseWorkspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetRemoteChangesUseCaseWorkspace.swift; sourceTree = "<group>"; };
+		AA8B5F5D302A238C00F28F39 /* Issue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Issue.swift; sourceTree = "<group>"; };
+		AA8B5F61302A23AB00F28F39 /* IssuesManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssuesManager.swift; sourceTree = "<group>"; };
+		AA8B5F64302A2E1700F28F39 /* IssuesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssuesView.swift; sourceTree = "<group>"; };
+		AA8B5F66302A2E2600F28F39 /* IssueRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueRowView.swift; sourceTree = "<group>"; };
+		AA8B5F68302A2E4700F28F39 /* IssuesEmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssuesEmptyStateView.swift; sourceTree = "<group>"; };
 		AA8D9AEE2E7CC2370068B333 /* FeaturesService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturesService.swift; sourceTree = "<group>"; };
 		AA919D752E4FCC0600287FAE /* CleanupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CleanupView.swift; sourceTree = "<group>"; };
 		AA93BEB92E720E8200F12334 /* CleaningView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CleaningView.swift; sourceTree = "<group>"; };
@@ -962,6 +974,16 @@
 			path = Cleaner;
 			sourceTree = "<group>";
 		};
+		AA8B5F63302A23BE00F28F39 /* Issues */ = {
+			isa = PBXGroup;
+			children = (
+				AA8B5F64302A2E1700F28F39 /* IssuesView.swift */,
+				AA8B5F66302A2E2600F28F39 /* IssueRowView.swift */,
+				AA8B5F68302A2E4700F28F39 /* IssuesEmptyStateView.swift */,
+			);
+			path = Issues;
+			sourceTree = "<group>";
+		};
 		AAA6666B2D40680700C2B9DF /* ClamAVResources */ = {
 			isa = PBXGroup;
 			children = (
@@ -1110,6 +1132,7 @@
 				3185496E2B698AAC00D559E1 /* Device.swift */,
 				31ABDE9F2BA9FC2E00EEA7F5 /* SyncedNode.swift */,
 				AAA6F6472E5FEDB6000082ED /* Cleaner.swift */,
+				AA8B5F5D302A238C00F28F39 /* Issue.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1457,6 +1480,7 @@
 				AACC83A32F7E06770084FFB6 /* ClamAVDatabaseService.swift */,
 				AACC83A52F7E068E0084FFB6 /* ClamAVScannerService.swift */,
 				AA9B1B992FB2D327000E582A /* FileLimitsService.swift */,
+				AA8B5F61302A23AB00F28F39 /* IssuesManager.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -1473,6 +1497,7 @@
 		E1FB2D542A76C03300473AE1 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				AA8B5F63302A23BE00F28F39 /* Issues */,
 				AA7FC5A22E450C2A0018C333 /* Cleaner */,
 				AA40B3BB2D3B296E00FC1FC3 /* Antivirus */,
 				3104526A2B4B1C3A00984716 /* Backups */,
@@ -1859,6 +1884,7 @@
 				AA642CAE2C62B26B0015BBB9 /* BackupConfigurationManager.swift in Sources */,
 				31DEAEC12B75143F00E76D53 /* XPCBackupServiceDelegate.swift in Sources */,
 				E1D24AF02C0467710009EC83 /* BackupTreeNodeSyncOperation.swift in Sources */,
+				AA8B5F5E302A238C00F28F39 /* Issue.swift in Sources */,
 				3120B5642B84F36C00F524F1 /* APIFactory.swift in Sources */,
 				31ABDEA12BA9FC5300EEA7F5 /* SyncedNode.swift in Sources */,
 				E1E56C232BC0423A00DBA0BF /* BackupProgressUpdate.swift in Sources */,
@@ -2008,6 +2034,7 @@
 				AA919D762E4FCC0600287FAE /* CleanupView.swift in Sources */,
 				E1EEB5912C21963400370D77 /* WidgetBackupDownloadEntryView.swift in Sources */,
 				E13B83992AFBBD50009F6684 /* AppSettings.swift in Sources */,
+				AA8B5F65302A2E1700F28F39 /* IssuesView.swift in Sources */,
 				E17C84B22AB22C1400A58414 /* OnboardingSlide2View.swift in Sources */,
 				E17DB70C2C53F4600031B465 /* AppBreadcrumbs.swift in Sources */,
 				E1A0AC612AB8639C005E71D6 /* AppTextArea.swift in Sources */,
@@ -2029,6 +2056,7 @@
 				E17C84BC2AB2796F00A58414 /* OnboardingSlide5View.swift in Sources */,
 				E1CC521C2AA0A884009DEEAA /* String.swift in Sources */,
 				3120B5742B84FC4400F524F1 /* BackupTreeNodeType.swift in Sources */,
+				AA8B5F67302A2E2600F28F39 /* IssueRowView.swift in Sources */,
 				E13B83972AFBBCD7009F6684 /* AppSettingsManagerView.swift in Sources */,
 				315BC6922B3E06A5004C85D8 /* FolderSelectorView.swift in Sources */,
 				E1D24AF42C0468AF0009EC83 /* AsyncOperation.swift in Sources */,
@@ -2039,6 +2067,7 @@
 				AA13E0312E620B0000DD47CB /* XPCCleanerConnectionManager.swift in Sources */,
 				E106D4622AB9FD6300E3BF7A /* URL.swift in Sources */,
 				316D247A2B4D9997007DE91A /* BackupsService.swift in Sources */,
+				AA8B5F69302A2E4700F28F39 /* IssuesEmptyStateView.swift in Sources */,
 				E16D3E8A2AF141540026C504 /* NetworkAnalyticsEvents.swift in Sources */,
 				E1A0AC4B2AB3590E005E71D6 /* AppCachedAsyncImage.swift in Sources */,
 				E16310572A8E66F70072989E /* URLDictionary.swift in Sources */,
@@ -2072,6 +2101,7 @@
 				3104526E2B4B1C5C00984716 /* StopBackupDialogView.swift in Sources */,
 				E1DB29612A7D6B80009036B8 /* WidgetContentView.swift in Sources */,
 				E1A0AC562AB48B7F005E71D6 /* WindowsManager.swift in Sources */,
+				AA8B5F5F302A238C00F28F39 /* Issue.swift in Sources */,
 				AA9B1B9A2FB2D327000E582A /* FileLimitsService.swift in Sources */,
 				E1581DCF2A9629620051DD46 /* Generic.swift in Sources */,
 				E145E16C2A82A21500B07E0B /* Time.swift in Sources */,
@@ -2083,6 +2113,7 @@
 				AA93BEBE2E72128800F12334 /* LockedFeatureCleanerView.swift in Sources */,
 				E16310952A8FAD3C0072989E /* APIFactory.swift in Sources */,
 				E10B0FDD2A94143F00B97874 /* Int.swift in Sources */,
+				AA8B5F62302A23AB00F28F39 /* IssuesManager.swift in Sources */,
 				AA93BEC42E72328900F12334 /* CleanupOperationService.swift in Sources */,
 				E1CC521A2AA0A695009DEEAA /* AppIcon.swift in Sources */,
 				AA8D9AF02E7CC2370068B333 /* FeaturesService.swift in Sources */,
@@ -2196,6 +2227,7 @@
 				E1FD8C742BA989D900C257E0 /* LogService.swift in Sources */,
 				AA9DF5452EDF6B2E00D1FE52 /* PackageFileHandle.swift in Sources */,
 				E140C3342AC379AA00A88B9F /* DriveFileService.swift in Sources */,
+				AA8B5F60302A238C00F28F39 /* Issue.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/InternxtDesktop/AppDelegate.swift
+++ b/InternxtDesktop/AppDelegate.swift
@@ -50,6 +50,7 @@ class AppDelegate: NSObject, NSApplicationDelegate , PKPushRegistryDelegate {
     let antivirusManager = AntivirusManager()
     let cleanerService = CleanerService()
     let notificationsManager = NotificationsManager.shared
+    let issuesManager = IssuesManager()
     var popover: NSPopover?
     var statusBarItem: NSStatusItem?
     
@@ -129,10 +130,11 @@ class AppDelegate: NSObject, NSApplicationDelegate , PKPushRegistryDelegate {
         checkVolumeAndEjectIfNeeded()
         
         self.windowsManager = WindowsManager(
-            initialWindows: defaultWindows(settingsManager: settingsManager, authManager: authManager, usageManager: usageManager, backupsService: backupsService, scheduleManager: scheduledManager, antivirusManager: antivirusManager, cleanerService: cleanerService, updater: updaterController.updater, closeSendFeedbackWindow: closeSendFeedbackWindow, finishOrSkipOnboarding: self.finishOrSkipOnboarding, fileSizeLimitState: fileSizeLimitState, emptyFileLimitState: emptyFileLimitState, storageFullState: storageFullState),
+            initialWindows: defaultWindows(settingsManager: settingsManager, authManager: authManager, usageManager: usageManager, backupsService: backupsService, scheduleManager: scheduledManager, antivirusManager: antivirusManager, cleanerService: cleanerService, issuesManager: issuesManager, updater: updaterController.updater, closeSendFeedbackWindow: closeSendFeedbackWindow, finishOrSkipOnboarding: self.finishOrSkipOnboarding, fileSizeLimitState: fileSizeLimitState, emptyFileLimitState: emptyFileLimitState, storageFullState: storageFullState),
             onWindowClose: receiveOnWindowClose
         )
         self.windowsManager.loadInitialWindows()
+        self.issuesManager.startObserving()
 
         self.backupAlertsCoordinator = BackupAlertsCoordinator(
             fileSizeLimitState: fileSizeLimitState,
@@ -525,6 +527,10 @@ class AppDelegate: NSObject, NSApplicationDelegate , PKPushRegistryDelegate {
     @objc func openSettingsWindow() {
         self.windowsManager.openWindow(id: "settings")
     }
+
+    @objc func openIssuesWindow() {
+        self.windowsManager.openWindow(id: "issues")
+    }
     
     @objc func openOnboardingWindow() {
         self.windowsManager.openWindow(id: "onboarding")
@@ -579,6 +585,7 @@ class AppDelegate: NSObject, NSApplicationDelegate , PKPushRegistryDelegate {
                 .environmentObject(self.backupsService)
                 .environmentObject(self.domainManager)
                 .environmentObject(self.antivirusManager)
+                .environmentObject(self.issuesManager)
         )
     }
     

--- a/InternxtDesktop/Services/IssuesManager.swift
+++ b/InternxtDesktop/Services/IssuesManager.swift
@@ -6,3 +6,107 @@
 //
 
 import Foundation
+import Combine
+import RealmSwift
+
+
+class IssuesManager: ObservableObject {
+
+    @Published private(set) var allIssues: [Issue] = []
+
+
+    var totalIssueCount: Int {
+        allIssues.count
+    }
+
+   
+
+    private let logger = LogService.shared.createLogger(subsystem: .InternxtDesktop, category: "IssuesManager")
+    private var notificationToken: NotificationToken?
+    private let activityLimit = 200
+
+
+    private var dismissedIssueIDs: Set<UUID> = []
+
+    private var lastClearedAt: Date? = nil
+
+   
+
+    init() {}
+
+    deinit {
+        notificationToken?.invalidate()
+    }
+
+
+    func startObserving() {
+        guard notificationToken == nil else { return }
+        guard let realm = getRealm() else {
+            logger.error("IssuesManager: cannot open Realm, issues will not be observed")
+            return
+        }
+
+        let results = realm.objects(ActivityEntry.self)
+        notificationToken = results.observe { [weak self] (changes: RealmCollectionChange) in
+            switch changes {
+            case .initial, .update:
+                self?.rebuildIssues(realm: realm)
+            case .error(let error):
+                self?.logger.error("IssuesManager Realm observe error: \(error)")
+            }
+        }
+        logger.info("IssuesManager started observing ActivityEntry changes")
+    }
+
+
+    func clearAll() {
+        lastClearedAt = Date()
+        dismissedIssueIDs = Set(allIssues.map { $0.id })
+        DispatchQueue.main.async {
+            self.allIssues = []
+            self.logger.info("IssuesManager: all issues cleared by user (\(self.dismissedIssueIDs.count) dismissed)")
+        }
+    }
+
+ 
+    func issues(for category: IssueCategory) -> [Issue] {
+        allIssues.filter { $0.category == category }
+    }
+
+
+
+    private func rebuildIssues(realm: Realm) {
+        let entries = realm
+            .objects(ActivityEntry.self)
+            .filter("status == %@", ActivityEntryStatus.failed.rawValue)
+            .sorted(byKeyPath: "createdAt", ascending: false)
+
+        var built: [Issue] = []
+        for entry in entries.prefix(activityLimit) {
+            guard let issue = Issue.fromActivityEntry(entry) else { continue }
+
+            if let clearedAt = lastClearedAt, issue.date <= clearedAt {
+                if dismissedIssueIDs.contains(issue.id) { continue }
+            }
+
+            built.append(issue)
+        }
+
+        DispatchQueue.main.async {
+            self.allIssues = built
+            self.logger.info("IssuesManager rebuilt: \(built.count) issue(s)")
+        }
+    }
+
+    private func getRealm() -> Realm? {
+        do {
+            return try Realm(configuration: Realm.Configuration(
+                fileURL: ConfigLoader.realmURL,
+                deleteRealmIfMigrationNeeded: true
+            ))
+        } catch {
+            error.reportToSentry()
+            return nil
+        }
+    }
+}

--- a/InternxtDesktop/Services/IssuesManager.swift
+++ b/InternxtDesktop/Services/IssuesManager.swift
@@ -1,0 +1,8 @@
+//
+//  IssuesManager.swift
+//  InternxtDesktop
+//
+//  Created by Patricio Tovar on 10/8/26.
+//
+
+import Foundation

--- a/InternxtDesktop/Views/Issues/IssueRowView.swift
+++ b/InternxtDesktop/Views/Issues/IssueRowView.swift
@@ -1,0 +1,8 @@
+//
+//  IssueRowView.swift
+//  InternxtDesktop
+//
+//  Created by Patricio Tovar on 10/8/26.
+//
+
+import Foundation

--- a/InternxtDesktop/Views/Issues/IssueRowView.swift
+++ b/InternxtDesktop/Views/Issues/IssueRowView.swift
@@ -5,4 +5,67 @@
 //  Created by Patricio Tovar on 10/8/26.
 //
 
-import Foundation
+import SwiftUI
+
+struct IssueRowView: View {
+
+    let issue: Issue
+
+    private static let relativeDateFormatter: RelativeDateTimeFormatter = {
+        let f = RelativeDateTimeFormatter()
+        f.unitsStyle = .abbreviated
+        return f
+    }()
+
+    var body: some View {
+        VStack(alignment: .center, spacing: 0) {
+            HStack(alignment: .center, spacing: 10) {
+
+                Image(getFileExtensionIconName(filenameWithExtension: issue.filename))
+                    .resizable()
+                    .scaledToFit()
+                    .frame(height: 32)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(verbatim: issue.filename)
+                        .font(.SMMedium)
+                        .foregroundColor(.Gray100)
+                        .lineLimit(1)
+                        .help(issue.filename)
+
+                    HStack(spacing: 4) {
+                        AppText(issue.operation.localizedLabel)
+                            .font(.XSRegular)
+                            .foregroundColor(.Gray50)
+
+                        if let desc = issue.errorDescription {
+                            Text("·")
+                                .font(.XSRegular)
+                                .foregroundColor(.Gray40)
+                            Text(verbatim: desc)
+                                .font(.XSRegular)
+                                .foregroundColor(.Gray50)
+                                .lineLimit(1)
+                                .help(desc)
+                        }
+                    }
+                }
+
+                Spacer()
+
+                VStack(alignment: .trailing, spacing: 4) {
+                    AppIcon(iconName: .WarningCircle, size: 20, color: .Red)
+                    Text(Self.relativeDateFormatter.localizedString(for: issue.date, relativeTo: Date()))
+                        .font(.XXSRegular)
+                        .foregroundColor(.Gray40)
+                }
+            }
+            .padding(.horizontal, 16)
+            .frame(minHeight: 56)
+
+            Divider()
+                .foregroundColor(.Gray10)
+                .frame(height: 1)
+        }
+    }
+}

--- a/InternxtDesktop/Views/Issues/IssuesEmptyStateView.swift
+++ b/InternxtDesktop/Views/Issues/IssuesEmptyStateView.swift
@@ -1,0 +1,8 @@
+//
+//  IssuesEmptyStateView.swift
+//  InternxtDesktop
+//
+//  Created by Patricio Tovar on 10/8/26.
+//
+
+import Foundation

--- a/InternxtDesktop/Views/Issues/IssuesEmptyStateView.swift
+++ b/InternxtDesktop/Views/Issues/IssuesEmptyStateView.swift
@@ -5,4 +5,22 @@
 //  Created by Patricio Tovar on 10/8/26.
 //
 
-import Foundation
+import SwiftUI
+
+struct IssuesEmptyStateView: View {
+    var body: some View {
+        VStack(spacing: 12) {
+            AppIcon(iconName: .CheckCircle, size: 36, color: .Gray40)
+            AppText("ISSUES_EMPTY_TITLE")
+                .font(.SMMedium)
+                .foregroundColor(.Gray60)
+            AppText("ISSUES_EMPTY_SUBTITLE")
+                .font(.XSRegular)
+                .foregroundColor(.Gray40)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+

--- a/InternxtDesktop/Views/Issues/IssuesView.swift
+++ b/InternxtDesktop/Views/Issues/IssuesView.swift
@@ -1,0 +1,18 @@
+//
+//  IssuesView.swift
+//  InternxtDesktop
+//
+//  Created by Patricio Tovar on 10/8/26.
+//
+
+import SwiftUI
+
+struct IssuesView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    IssuesView()
+}

--- a/InternxtDesktop/Views/Issues/IssuesView.swift
+++ b/InternxtDesktop/Views/Issues/IssuesView.swift
@@ -8,11 +8,118 @@
 import SwiftUI
 
 struct IssuesView: View {
+
+    @EnvironmentObject var issuesManager: IssuesManager
+    @State private var selectedCategory: IssueCategory = .sync
+
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        VStack(alignment: .center, spacing: 0) {
+
+            categoryPicker
+                .padding(.horizontal, 20)
+                .padding(.top, 16)
+                .padding(.bottom, 12)
+
+            Divider()
+                .frame(maxWidth: .infinity, maxHeight: 1)
+                .overlay(Color.Gray10)
+
+     
+            let visibleIssues = issuesManager.issues(for: selectedCategory)
+
+            if visibleIssues.isEmpty {
+                IssuesEmptyStateView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .background(Color.Gray1)
+            } else {
+                ScrollView(.vertical, showsIndicators: true) {
+                    LazyVStack(spacing: 0) {
+                        ForEach(visibleIssues) { issue in
+                            IssueRowView(issue: issue)
+                        }
+                    }
+                }
+                .background(Color.Gray1)
+            }
+
+            if !issuesManager.allIssues.isEmpty {
+                issuesFooter
+            }
+        }
+        .frame(width: 540, height: 440)
+        .background(Color.Surface)
+    }
+
+  
+
+    private var categoryPicker: some View {
+        HStack(spacing: 4) {
+            ForEach(IssueCategory.allCases) { category in
+                categoryTab(for: category)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .center)
+    }
+
+    private func categoryTab(for category: IssueCategory) -> some View {
+        let isSelected = selectedCategory == category
+        let count = issuesManager.issues(for: category).count
+
+        return Button {
+            withAnimation(.easeInOut(duration: 0.15)) {
+                selectedCategory = category
+            }
+        } label: {
+            HStack(spacing: 6) {
+                AppText(category.localizedTitle)
+                    .font(isSelected ? .SMMedium : .SMRegular)
+                    .foregroundColor(isSelected ? .Gray100 : .Gray60)
+
+                if count > 0 {
+                    Text("\(count)")
+                        .font(.XXSMedium)
+                        .foregroundColor(.white)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(
+                            Capsule().fill(Color.Red)
+                        )
+                }
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 7)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(isSelected ? Color.Gray10 : Color.clear)
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("issuesTab_\(category.rawValue)")
+    }
+
+    private var issuesFooter: some View {
+        HStack {
+            Spacer()
+            Button {
+                withAnimation {
+                    issuesManager.clearAll()
+                }
+            } label: {
+                AppText("ISSUES_CLEAR_ALL")
+                    .font(.XSMedium)
+                    .foregroundColor(.Gray60)
+            }
+            .buttonStyle(.plain)
+            .padding(.trailing, 16)
+        }
+        .frame(height: 36)
+        .background(Color.Surface)
+        .overlay(
+            Divider()
+                .frame(maxWidth: .infinity, maxHeight: 1)
+                .overlay(Color.Gray10),
+            alignment: .top
+        )
     }
 }
 
-#Preview {
-    IssuesView()
-}

--- a/InternxtDesktop/Views/Widget/SettingsMenuView.swift
+++ b/InternxtDesktop/Views/Widget/SettingsMenuView.swift
@@ -13,6 +13,7 @@ struct SettingsMenuView: View {
     @EnvironmentObject var usageManager: UsageManager
     @EnvironmentObject var settingsManager: SettingsTabManager
     @EnvironmentObject var antivirusManager: AntivirusManager
+    @EnvironmentObject var issuesManager: IssuesManager
 
     var openSendFeedback: () -> Void
     var isPreview: Bool = false;
@@ -27,6 +28,8 @@ struct SettingsMenuView: View {
                 VStack(alignment: .leading, spacing: 0) {
                     SettingsMenuOption(label: "WIDGET_SETTINGS_PREFERENCES_OPTION", onPress: settingsHandler(for: .General))
                         .accessibilityIdentifier("menuItemPreferences")
+                    SettingsMenuOption(label: "WIDGET_SETTINGS_ISSUES_OPTION", badgeCount: issuesManager.totalIssueCount, onPress: handleOpenIssues)
+                        .accessibilityIdentifier("menuItemIssues")
                     SettingsMenuOption(label: "WIDGET_SETTINGS_SUPPORT_OPTION", onPress: handleOpenSupport)
                         .accessibilityIdentifier("menuItemSupport")
                     SettingsMenuOption(label: "WIDGET_SETTINGS_ANTIVIRUS_OPTION", onPress: settingsHandler(for: .Antivirus))
@@ -75,6 +78,10 @@ struct SettingsMenuView: View {
     }
 
     
+    func handleOpenIssues() {
+        NSApp.sendAction(#selector(AppDelegate.openIssuesWindow), to: nil, from: nil)
+    }
+
     func handleLogout() {
         Task {
             
@@ -113,10 +120,12 @@ struct SettingsMenuOption: View {
     public var onPress: () -> Void
     @State private var isHovering: Bool = false
     public var showNew: Bool = false
+    public var badgeCount: Int = 0
     
-    init(label: String, showNew: Bool = false, onPress: @escaping () -> Void) {
+    init(label: String, showNew: Bool = false, badgeCount: Int = 0, onPress: @escaping () -> Void) {
         self.label = label
         self.showNew = showNew
+        self.badgeCount = badgeCount
         self.onPress = onPress
     }
     
@@ -129,7 +138,15 @@ struct SettingsMenuOption: View {
             
             Spacer()
             
-            if showNew {
+            if badgeCount > 0 {
+                Text("\(min(badgeCount, 99))")
+                    .font(.XXSMedium)
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(Capsule().fill(Color.Red))
+                    .padding(.trailing, 8)
+            } else if showNew {
                 AppText("WIDGET_SETTINGS_NEW_OPTION")
                     .font(.XXSMedium)
                     .foregroundColor(.blue)

--- a/InternxtDesktop/Views/Widget/WidgetHeaderView.swift
+++ b/InternxtDesktop/Views/Widget/WidgetHeaderView.swift
@@ -14,6 +14,7 @@ struct WidgetHeaderView: View {
     @EnvironmentObject var usageManager: UsageManager
     @EnvironmentObject var settingsManager: SettingsTabManager
     @EnvironmentObject var antivirusManager: AntivirusManager
+    @EnvironmentObject var issuesManager: IssuesManager
     @Environment(\.colorScheme) var colorScheme
 
     @State var settingsMenuOpen = false
@@ -93,26 +94,17 @@ struct WidgetHeaderView: View {
                 .accessibilityIdentifier("openVirtualDriveFolder")
             WidgetIconButtonView(iconName: .Gear, onClick: self.openSettings)
                 .accessibilityIdentifier("openSettings")
-                .ifAvailable{view in
-                
-                if #available(macOS 12, *) {
-                    view.overlay(alignment: .bottomLeading) {
-                        SettingsMenuView(openSendFeedback: self.openSendFeedback).opacity((settingsMenuOpen) ? 1 : 0).environmentObject(usageManager)
-                            .environmentObject(antivirusManager)
-                            .environmentObject(settingsManager).onTapBackground(enabled: settingsMenuOpen)
-                           {
-                                self.settingsMenuOpen = false
-                            }
-                    }
-                } else {
-                    view.overlay(SettingsMenuView(openSendFeedback: self.openSendFeedback).opacity((settingsMenuOpen) ? 1 : 0).environmentObject(usageManager)
+                .overlay(alignment: .bottomLeading) {
+                    SettingsMenuView(openSendFeedback: self.openSendFeedback)
+                        .opacity(settingsMenuOpen ? 1 : 0)
+                        .environmentObject(usageManager)
                         .environmentObject(antivirusManager)
                         .environmentObject(settingsManager)
-                                 ,alignment: .bottomLeading)
+                        .environmentObject(issuesManager)
+                        .onTapBackground(enabled: settingsMenuOpen) {
+                            self.settingsMenuOpen = false
+                        }
                 }
-                    
-            }
-        
         }
     }
     

--- a/InternxtDesktop/Views/Widget/WidgetView.swift
+++ b/InternxtDesktop/Views/Widget/WidgetView.swift
@@ -18,6 +18,7 @@ struct WidgetView: View {
     @EnvironmentObject var backupsService: BackupsService
     @EnvironmentObject var domainManager: FileProviderDomainManager
     @EnvironmentObject var antivirusManager: AntivirusManager
+    @EnvironmentObject var issuesManager: IssuesManager
     
     @State private var showBackupBanner = false
     var isEmpty: Bool = true
@@ -76,6 +77,7 @@ struct WidgetView: View {
                         .environmentObject(self.usageManager)
                         .environmentObject(self.settingsManager)
                         .environmentObject(self.antivirusManager)
+                        .environmentObject(self.issuesManager)
 
                     if shouldDisplayBackupBanner() {
                         WidgetBackupBannerView() {

--- a/InternxtDesktop/Windows.swift
+++ b/InternxtDesktop/Windows.swift
@@ -13,8 +13,8 @@ import Sparkle
 /// Return the default windows config, this
 /// windows will be available without needing to explicitly
 /// creating them
-func defaultWindows(settingsManager: SettingsTabManager, authManager: AuthManager, usageManager: UsageManager, backupsService: BackupsService, scheduleManager: ScheduledBackupManager,antivirusManager : AntivirusManager ,
-                    cleanerService: CleanerService,updater: SPUUpdater, closeSendFeedbackWindow: @escaping () -> Void, finishOrSkipOnboarding: @escaping () -> Void,
+func defaultWindows(settingsManager: SettingsTabManager, authManager: AuthManager, usageManager: UsageManager, backupsService: BackupsService, scheduleManager: ScheduledBackupManager, antivirusManager: AntivirusManager,
+                    cleanerService: CleanerService, issuesManager: IssuesManager, updater: SPUUpdater, closeSendFeedbackWindow: @escaping () -> Void, finishOrSkipOnboarding: @escaping () -> Void,
                     fileSizeLimitState: FileSizeLimitState, emptyFileLimitState: EmptyFileLimitState, storageFullState: StorageFullState) -> [WindowConfig] {
     let windows = [
         WindowConfig(
@@ -53,6 +53,20 @@ func defaultWindows(settingsManager: SettingsTabManager, authManager: AuthManage
             id: "send-feedback",
             width: 380,
             height: 320
+        ),
+        WindowConfig(
+            view: AnyView(
+                AppSettingsManagerView {
+                    IssuesView()
+                        .environmentObject(issuesManager)
+                }
+            ),
+            title: "Issues",
+            id: "issues",
+            width: 540,
+            height: 440,
+            fixedToFront: true,
+            backgroundColor: Color.Surface
         ),
         WindowConfig(
             view: AnyView(

--- a/Shared/Models/Issue.swift
+++ b/Shared/Models/Issue.swift
@@ -6,3 +6,104 @@
 //
 
 import Foundation
+
+
+enum IssueCategory: String, CaseIterable, Identifiable {
+    case sync    = "Sync"
+    case backups = "Backups"
+
+    var id: String { rawValue }
+
+    var localizedTitle: String {
+        switch self {
+        case .sync:    return NSLocalizedString("ISSUES_TAB_SYNC",    comment: "")
+        case .backups: return NSLocalizedString("ISSUES_TAB_BACKUPS", comment: "")
+        }
+    }
+}
+
+
+enum IssueOperation: String {
+    case upload   = "upload"
+    case download = "download"
+    case delete   = "delete"
+    case move     = "move"
+    case create   = "create"
+    case trash    = "trash"
+
+    var localizedLabel: String {
+        switch self {
+        case .upload:   return NSLocalizedString("ISSUE_OP_UPLOAD",   comment: "")
+        case .download: return NSLocalizedString("ISSUE_OP_DOWNLOAD", comment: "")
+        case .delete:   return NSLocalizedString("ISSUE_OP_DELETE",   comment: "")
+        case .move:     return NSLocalizedString("ISSUE_OP_MOVE",     comment: "")
+        case .create:   return NSLocalizedString("ISSUE_OP_CREATE",   comment: "")
+        case .trash:    return NSLocalizedString("ISSUE_OP_TRASH",    comment: "")
+        }
+    }
+}
+
+
+struct Issue: Identifiable, Equatable {
+    let id: UUID
+    let category: IssueCategory
+    let filename: String
+    let operation: IssueOperation
+    let errorDescription: String?
+    let date: Date
+
+    init(
+        id: UUID = UUID(),
+        category: IssueCategory,
+        filename: String,
+        operation: IssueOperation,
+        errorDescription: String? = nil,
+        date: Date = Date()
+    ) {
+        self.id = id
+        self.category = category
+        self.filename = filename
+        self.operation = operation
+        self.errorDescription = errorDescription
+        self.date = date
+    }
+
+    static func == (lhs: Issue, rhs: Issue) -> Bool {
+        lhs.id == rhs.id
+    }
+}
+
+
+
+extension Issue {
+
+
+    static func fromActivityEntry(_ entry: ActivityEntry) -> Issue? {
+        guard entry.status == .failed else { return nil }
+
+        let idString = entry._id.stringValue
+        let stableID = UUID(uuidString: idString.padding(
+            toLength: 36,
+            withPad: "-",
+            startingAt: 0
+        )) ?? UUID()
+
+        let operation: IssueOperation
+        switch entry.kind {
+        case .upload:         operation = .upload
+        case .download:       operation = .download
+        case .delete:         operation = .delete
+        case .move:           operation = .move
+        case .trash:          operation = .trash
+        case .backupDownload: operation = .download
+        }
+
+        return Issue(
+            id: stableID,
+            category: entry.kind == .backupDownload ? .backups : .sync,
+            filename: entry.filename,
+            operation: operation,
+            date: entry.createdAt
+        )
+    }
+}

--- a/Shared/Models/Issue.swift
+++ b/Shared/Models/Issue.swift
@@ -1,0 +1,8 @@
+//
+//  Issue.swift
+//  InternxtDesktop
+//
+//  Created by Patricio Tovar on 10/8/26.
+//
+
+import Foundation

--- a/Shared/en.lproj/Localizable.strings
+++ b/Shared/en.lproj/Localizable.strings
@@ -25,9 +25,30 @@
 "WIDGET_SETTINGS_ANTIVIRUS_OPTION" = "Antivirus";
 "WIDGET_SETTINGS_CLEANER_OPTION" = "Cleaner";
 "WIDGET_SETTINGS_REFERRAL_OPTION" = "Refer and Earn";
+"WIDGET_SETTINGS_ISSUES_OPTION" = "Issues";
 
 // Widget new option
 "WIDGET_SETTINGS_NEW_OPTION" = "New";
+
+// Issues window — tabs
+"ISSUES_TAB_SYNC"    = "Sync";
+"ISSUES_TAB_BACKUPS" = "Backups";
+
+// Issues window — empty state
+"ISSUES_EMPTY_TITLE"    = "No issues found";
+"ISSUES_EMPTY_SUBTITLE" = "Any failed file operations will appear here.";
+
+// Issues window — actions
+"ISSUES_CLEAR_ALL" = "Clear all";
+
+// Issues — operation labels
+"ISSUE_OP_UPLOAD"   = "Upload failed";
+"ISSUE_OP_DOWNLOAD" = "Download failed";
+"ISSUE_OP_DELETE"   = "Delete failed";
+"ISSUE_OP_MOVE"     = "Move failed";
+"ISSUE_OP_CREATE"   = "Create failed";
+"ISSUE_OP_TRASH"    = "Trash failed";
+
 
 // Widget sync status
 "SYNC_STATUS_UP_TO_DATE" = "Everything is up to date";

--- a/Shared/es.lproj/Localizable.strings
+++ b/Shared/es.lproj/Localizable.strings
@@ -25,10 +25,30 @@
 "WIDGET_SETTINGS_ANTIVIRUS_OPTION" = "Antivirus";
 "WIDGET_SETTINGS_CLEANER_OPTION" = "Cleaner";
 "WIDGET_SETTINGS_REFERRAL_OPTION" = "Refiere y gana";
-
+"WIDGET_SETTINGS_ISSUES_OPTION" = "Errores";
 
 // Widget new option
 "WIDGET_SETTINGS_NEW_OPTION" = "Nuevo";
+
+// Issues window — tabs
+"ISSUES_TAB_SYNC"    = "Sincronización";
+"ISSUES_TAB_BACKUPS" = "Copias de seguridad";
+
+// Issues window — empty state
+"ISSUES_EMPTY_TITLE"    = "No se encontraron problemas";
+"ISSUES_EMPTY_SUBTITLE" = "Las operaciones de archivo fallidas aparecerán aquí.";
+
+// Issues window — actions
+"ISSUES_CLEAR_ALL" = "Borrar todo";
+
+// Issues — operation labels
+"ISSUE_OP_UPLOAD"   = "Error al subir";
+"ISSUE_OP_DOWNLOAD" = "Error al descargar";
+"ISSUE_OP_DELETE"   = "Error al eliminar";
+"ISSUE_OP_MOVE"     = "Error al mover";
+"ISSUE_OP_CREATE"   = "Error al crear";
+"ISSUE_OP_TRASH"    = "Error al mover a la papelera";
+
 
 // Widget sync status
 "SYNC_STATUS_UP_TO_DATE" = "Todo está actualizado";

--- a/Shared/fr.lproj/Localizable.strings
+++ b/Shared/fr.lproj/Localizable.strings
@@ -25,10 +25,30 @@
 "WIDGET_SETTINGS_ANTIVIRUS_OPTION" = "Antivirus";
 "WIDGET_SETTINGS_CLEANER_OPTION" = "Cleaner";
 "WIDGET_SETTINGS_REFERRAL_OPTION" = "Parrainez et gagnez";
-
+"WIDGET_SETTINGS_ISSUES_OPTION" = "Problèmes";
 
 // Widget new option
 "WIDGET_SETTINGS_NEW_OPTION" = "Nouveau";
+
+// Issues window — tabs
+"ISSUES_TAB_SYNC"    = "Synchronisation";
+"ISSUES_TAB_BACKUPS" = "Sauvegardes";
+
+// Issues window — empty state
+"ISSUES_EMPTY_TITLE"    = "Aucun problème trouvé";
+"ISSUES_EMPTY_SUBTITLE" = "Les opérations de fichier échouées apparaîtront ici.";
+
+// Issues window — actions
+"ISSUES_CLEAR_ALL" = "Tout effacer";
+
+// Issues — operation labels
+"ISSUE_OP_UPLOAD"   = "Échec du téléversement";
+"ISSUE_OP_DOWNLOAD" = "Échec du téléchargement";
+"ISSUE_OP_DELETE"   = "Échec de la suppression";
+"ISSUE_OP_MOVE"     = "Échec du déplacement";
+"ISSUE_OP_CREATE"   = "Échec de la création";
+"ISSUE_OP_TRASH"    = "Échec du déplacement vers la corbeille";
+
 
 // Widget sync status
 "SYNC_STATUS_UP_TO_DATE" = "Tout est à jour";


### PR DESCRIPTION
## 📌 Overview
This PR introduces the new **"Issues"** feature, providing users with a dedicated window to view failed file operations (Drive Sync and Backups) and adding a dynamic numeric badge to the widget settings menu.
---
## ✨ Features & Changes
### 1. Domain & Service Layer
- **`Issue.swift`**: Introduced domain models (`Issue`, `IssueCategory`, `IssueOperation`) with deterministic `UUID` generation derived from Realm `ObjectId` to guarantee stable object identity across rebuilds.
- **`IssuesManager.swift`**: Implemented an `ObservableObject` service that observes Realm `ActivityEntry` objects (`status == .failed`) reactively. It manages session-level dismissal via `clearAll()` (`dismissedIssueIDs` & `lastClearedAt`) so cleared issues remain hidden until a new failure occurs.
### 2. UI Components
- **`IssuesView.swift`**: Main window featuring a category picker (`Sync` / `Backups`), scrollable issue list, empty state handling, and a "Clear all" action button.
- **`IssueRowView.swift`**: Displays file type icons, filename, localized operation status, relative timestamp, and warning indicators.
- **`IssuesEmptyStateView.swift`**: Clean empty state view using existing design system tokens (`AppIcon`, `AppText`).
### 3. Navigation & Architecture Integration
- **`Windows.swift`**: Registered `"issues"` `WindowConfig` set to `fixedToFront: true` (`.floating` window level) to ensure proper Z-ordering over settings windows.
- **`AppDelegate.swift`**: Instantiated `IssuesManager`, initialized Realm observation on launch, added `@objc func openIssuesWindow()`, and injected `issuesManager` into the widget hierarchy.
- **`SettingsMenuView.swift`**: Extended `SettingsMenuOption` with `badgeCount` support to render a red numeric pill badge next to the "Issues" menu item.