### PR TITLE
Resolve 409 conflict pagination issue when syncing large directories

### DIFF
--- a/XPCBackupService/Services/BackupUploadService.swift
+++ b/XPCBackupService/Services/BackupUploadService.swift
@@ -85,6 +85,10 @@ class BackupUploadService:  BackupUploadServiceProtocol, ObservableObject {
         BackupAPI(baseUrl: config.DRIVE_NEW_API_URL, authToken: newAuthToken, clientName: CLIENT_NAME, clientVersion: getVersion())
     }()
 
+    private lazy var driveAPI: DriveAPI = {
+        DriveAPI(baseUrl: config.DRIVE_NEW_API_URL, authToken: newAuthToken, clientName: CLIENT_NAME, clientVersion: getVersion())
+    }()
+
 
     private let apiSemaphore = AsyncSemaphore(maxConcurrent: 6)
     private let networkUploadSemaphore = AsyncSemaphore(maxConcurrent: 2)
@@ -218,15 +222,19 @@ class BackupUploadService:  BackupUploadServiceProtocol, ObservableObject {
             if let apiClientError = error as? APIClientError, apiClientError.statusCode == 409 {
                 // Handle duplicated folder error
                 do {
-                    let parentChilds = try await withAPIThrottle {
-                        try await self.backupNewAPI.getBackupChilds(folderUuid: "\(safeRemoteParentUuid)")
+                    let existencesResponse = try await withAPIThrottle {
+                        try await self.driveAPI.getFolderExistencesInFolder(
+                            folderParentUuid: safeRemoteParentUuid, 
+                            folderName: foldername
+                        )
                     }
 
-                    let folder = parentChilds.folders.first { currentFolder in
+                    let folder = existencesResponse.existentFolders.first { currentFolder in
                         currentFolder.plainName == foldername && currentFolder.removed == false
                     }
 
                     guard let folder = folder else {
+                        self.logger.error("❌ CannotFindNodeInServer: searched '\(foldername)' server returned: \(existencesResponse.existentFolders.map { $0.plainName })")
                         return .failure(BackupUploadError.CannotFindNodeInServer)
                     }
 


### PR DESCRIPTION
### What's the problem?
When performing a backup of a directory containing more than 50 subfolders, the process would fail with a `CannotFindNodeInServer` error. 
This happened because, upon encountering a `409 Conflict` (folder already exists), the app relied on `getBackupChilds` to retrieve the folder's data. Since this endpoint is paginated to 50 items, any folder beyond the first page could not be found, causing the backup process to halt.
###  What's the solution?
- Instantiated `DriveAPI` within `BackupUploadService`.
- Replaced the paginated `getBackupChilds` enumeration with a direct call to `DriveAPI.getFolderExistencesInFolder`.
- This ensures we query the exact folder existence directly, completely bypassing the pagination limit and allowing large directories to sync seamlessly.