### PR TITLE
Global Issue Deduplication & Granular Backup Reports

### DIFF
--- a/InternxtDesktop.xcodeproj/project.pbxproj
+++ b/InternxtDesktop.xcodeproj/project.pbxproj
@@ -170,6 +170,10 @@
 		AAAD0DA02CE12D71003F27BB /* GetFileOrFolderMetaWorkspaceUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAD0D9F2CE12D71003F27BB /* GetFileOrFolderMetaWorkspaceUseCase.swift */; };
 		AAAD0DA22CE17457003F27BB /* RenameFileWorkspaceUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAD0DA12CE17457003F27BB /* RenameFileWorkspaceUseCase.swift */; };
 		AAAD0DA42CE18678003F27BB /* TrashFileWorkspaceUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAD0DA32CE18678003F27BB /* TrashFileWorkspaceUseCase.swift */; };
+		AABD3E823033B65200213211 /* BackupErrorFileQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABD3E813033B65200213211 /* BackupErrorFileQueue.swift */; };
+		AABD3E833033B65200213211 /* BackupErrorFileQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABD3E813033B65200213211 /* BackupErrorFileQueue.swift */; };
+		AABD3E843033B65200213211 /* BackupErrorFileQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABD3E813033B65200213211 /* BackupErrorFileQueue.swift */; };
+		AABD3E853033B65200213211 /* BackupErrorFileQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABD3E813033B65200213211 /* BackupErrorFileQueue.swift */; };
 		AAC188E62C222EB3007E321A /* InternxtSwiftCore in Frameworks */ = {isa = PBXBuildFile; productRef = AAC188E52C222EB3007E321A /* InternxtSwiftCore */; };
 		AAC188E92C222EFF007E321A /* DecryptUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31ED949C2B7151E200EF699F /* DecryptUtils.swift */; };
 		AAC188EA2C222F1F007E321A /* XPCBackupService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31DEAEB02B75139400E76D53 /* XPCBackupService.swift */; };
@@ -613,6 +617,7 @@
 		AAAD0D9F2CE12D71003F27BB /* GetFileOrFolderMetaWorkspaceUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetFileOrFolderMetaWorkspaceUseCase.swift; sourceTree = "<group>"; };
 		AAAD0DA12CE17457003F27BB /* RenameFileWorkspaceUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenameFileWorkspaceUseCase.swift; sourceTree = "<group>"; };
 		AAAD0DA32CE18678003F27BB /* TrashFileWorkspaceUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrashFileWorkspaceUseCase.swift; sourceTree = "<group>"; };
+		AABD3E813033B65200213211 /* BackupErrorFileQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupErrorFileQueue.swift; sourceTree = "<group>"; };
 		AAC188EE2C2231B1007E321A /* MockBackupRealm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBackupRealm.swift; sourceTree = "<group>"; };
 		AAC188F02C2231E7007E321A /* MockBackupUploadService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBackupUploadService.swift; sourceTree = "<group>"; };
 		AACC83A32F7E06770084FFB6 /* ClamAVDatabaseService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClamAVDatabaseService.swift; sourceTree = "<group>"; };
@@ -1335,6 +1340,7 @@
 				316D24792B4D9997007DE91A /* BackupsService.swift */,
 				316DC7EA2B597BD000FDC746 /* BackupsDeviceService.swift */,
 				AA43956F2C174B52003AA905 /* ScheduledBackupManager.swift */,
+				AABD3E813033B65200213211 /* BackupErrorFileQueue.swift */,
 			);
 			path = Backups;
 			sourceTree = "<group>";
@@ -1909,6 +1915,7 @@
 				E1EEB5922C23025900370D77 /* ActivityManager.swift in Sources */,
 				E13DBC6A2BCD4F2900F6B43E /* UsageManager.swift in Sources */,
 				E1FE2B2A2BC539810073B26D /* BackupRemoteSync.swift in Sources */,
+				AABD3E833033B65200213211 /* BackupErrorFileQueue.swift in Sources */,
 				AA5EABE62BFD761F00BA0145 /* NetworkAnalyticsEvents.swift in Sources */,
 				E1EEB5862C1C4B8800370D77 /* BackupDownloadItemOperation.swift in Sources */,
 				E15F8C3B2B762D4200C60EFA /* BackupTreeNode.swift in Sources */,
@@ -1988,6 +1995,7 @@
 				E1D24AFB2C0DA4210009EC83 /* BackupTreeNodeSyncOperation.swift in Sources */,
 				31F9EF2C2B867F24007DAD86 /* Error.swift in Sources */,
 				E1D24AF82C0DA3D00009EC83 /* LogService.swift in Sources */,
+				AABD3E853033B65200213211 /* BackupErrorFileQueue.swift in Sources */,
 				E15F8C3C2B762D4200C60EFA /* BackupTreeNode.swift in Sources */,
 				AAC188EA2C222F1F007E321A /* XPCBackupService.swift in Sources */,
 			);
@@ -2039,6 +2047,7 @@
 				E17DB70C2C53F4600031B465 /* AppBreadcrumbs.swift in Sources */,
 				E1A0AC612AB8639C005E71D6 /* AppTextArea.swift in Sources */,
 				E163105C2A8E6C830072989E /* AppText.swift in Sources */,
+				AABD3E823033B65200213211 /* BackupErrorFileQueue.swift in Sources */,
 				E17C84B42AB2315D00A58414 /* OnboardingSlideIndicator.swift in Sources */,
 				AA93BEC62E7233BA00F12334 /* ProgressPollingService.swift in Sources */,
 				AA13E0272E61067500DD47CB /* CleanerHelperXPCProtocol.swift in Sources */,
@@ -2153,6 +2162,7 @@
 				E1581DDA2A9654930051DD46 /* GetFileOrFolderMetaUseCase.swift in Sources */,
 				E109717C2A81135F00ABED41 /* EnumerateFolderItemsUseCase.swift in Sources */,
 				E16D3E8B2AF141540026C504 /* NetworkAnalyticsEvents.swift in Sources */,
+				AABD3E843033B65200213211 /* BackupErrorFileQueue.swift in Sources */,
 				E1FB2D872A76C48600473AE1 /* FileProviderItem.swift in Sources */,
 				AAAD0D9D2CE11D0D003F27BB /* DownloadFileWorkspaceUseCase.swift in Sources */,
 				E198D7DF2AAA38A500107753 /* RealtimeService.swift in Sources */,

--- a/InternxtDesktop/Services/IssuesManager.swift
+++ b/InternxtDesktop/Services/IssuesManager.swift
@@ -26,6 +26,7 @@ class IssuesManager: ObservableObject {
     private let activityLimit = 200
 
 
+    private var dismissedKeys: Set<String> = []
     private var dismissedIssueIDs: Set<UUID> = []
 
     private var lastClearedAt: Date? = nil
@@ -62,9 +63,10 @@ class IssuesManager: ObservableObject {
     func clearAll() {
         lastClearedAt = Date()
         dismissedIssueIDs = Set(allIssues.map { $0.id })
+        dismissedKeys = Set(allIssues.map { "\($0.category.rawValue)_\($0.filename)_\($0.operation.rawValue)" })
         DispatchQueue.main.async {
             self.allIssues = []
-            self.logger.info("IssuesManager: all issues cleared by user (\(self.dismissedIssueIDs.count) dismissed)")
+            self.logger.info("IssuesManager: all issues cleared by user (\(self.dismissedKeys.count) unique item(s) dismissed)")
         }
     }
 
@@ -82,19 +84,38 @@ class IssuesManager: ObservableObject {
             .sorted(byKeyPath: "createdAt", ascending: false)
 
         var built: [Issue] = []
+        var seenKeys = Set<String>()
+
         for entry in entries.prefix(activityLimit) {
             guard let issue = Issue.fromActivityEntry(entry) else { continue }
 
-            if let clearedAt = lastClearedAt, issue.date <= clearedAt {
-                if dismissedIssueIDs.contains(issue.id) { continue }
+         
+            let deduplicationKey = "\(issue.category.rawValue)_\(issue.filename)_\(issue.operation.rawValue)"
+
+            // Since entries are sorted newest first, skip older retry attempts of the same file
+            guard !seenKeys.contains(deduplicationKey) else { continue }
+
+            // Check if there is a more recent successful entry for this file (auto-resolution on retry success)
+            let hasMoreRecentSuccess = realm
+                .objects(ActivityEntry.self)
+                .filter("filename == %@ AND status == %@ AND createdAt >= %@", entry.filename, ActivityEntryStatus.finished.rawValue, entry.createdAt)
+                .first != nil
+
+            if hasMoreRecentSuccess {
+                continue
             }
 
+            if dismissedKeys.contains(deduplicationKey) || dismissedIssueIDs.contains(issue.id) {
+                continue
+            }
+
+            seenKeys.insert(deduplicationKey)
             built.append(issue)
         }
 
         DispatchQueue.main.async {
             self.allIssues = built
-            self.logger.info("IssuesManager rebuilt: \(built.count) issue(s)")
+            self.logger.info("IssuesManager rebuilt: \(built.count) unique issue(s)")
         }
     }
 

--- a/InternxtDesktop/Views/Issues/IssuesEmptyStateView.swift
+++ b/InternxtDesktop/Views/Issues/IssuesEmptyStateView.swift
@@ -13,10 +13,10 @@ struct IssuesEmptyStateView: View {
             AppIcon(iconName: .CheckCircle, size: 36, color: .Gray40)
             AppText("ISSUES_EMPTY_TITLE")
                 .font(.SMMedium)
-                .foregroundColor(.Gray60)
+                .foregroundColor(.Gray100)
             AppText("ISSUES_EMPTY_SUBTITLE")
                 .font(.XSRegular)
-                .foregroundColor(.Gray40)
+                .foregroundColor(.Gray60)
                 .multilineTextAlignment(.center)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/InternxtDesktop/Views/Issues/IssuesView.swift
+++ b/InternxtDesktop/Views/Issues/IssuesView.swift
@@ -15,10 +15,15 @@ struct IssuesView: View {
     var body: some View {
         VStack(alignment: .center, spacing: 0) {
 
-            categoryPicker
-                .padding(.horizontal, 20)
-                .padding(.top, 16)
-                .padding(.bottom, 12)
+            Picker("", selection: $selectedCategory) {
+                ForEach(IssueCategory.allCases) { category in
+                    Text(category.localizedTitle).tag(category)
+                }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .frame(width: 220)
+            .padding(.vertical, 14)
 
             Divider()
                 .frame(maxWidth: .infinity, maxHeight: 1)
@@ -48,53 +53,6 @@ struct IssuesView: View {
         }
         .frame(width: 540, height: 440)
         .background(Color.Surface)
-    }
-
-  
-
-    private var categoryPicker: some View {
-        HStack(spacing: 4) {
-            ForEach(IssueCategory.allCases) { category in
-                categoryTab(for: category)
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .center)
-    }
-
-    private func categoryTab(for category: IssueCategory) -> some View {
-        let isSelected = selectedCategory == category
-        let count = issuesManager.issues(for: category).count
-
-        return Button {
-            withAnimation(.easeInOut(duration: 0.15)) {
-                selectedCategory = category
-            }
-        } label: {
-            HStack(spacing: 6) {
-                AppText(category.localizedTitle)
-                    .font(isSelected ? .SMMedium : .SMRegular)
-                    .foregroundColor(isSelected ? .Gray100 : .Gray60)
-
-                if count > 0 {
-                    Text("\(count)")
-                        .font(.XXSMedium)
-                        .foregroundColor(.white)
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 2)
-                        .background(
-                            Capsule().fill(Color.Red)
-                        )
-                }
-            }
-            .padding(.horizontal, 14)
-            .padding(.vertical, 7)
-            .background(
-                RoundedRectangle(cornerRadius: 8)
-                    .fill(isSelected ? Color.Gray10 : Color.clear)
-            )
-        }
-        .buttonStyle(.plain)
-        .accessibilityIdentifier("issuesTab_\(category.rawValue)")
     }
 
     private var issuesFooter: some View {

--- a/Shared/Models/Issue.swift
+++ b/Shared/Models/Issue.swift
@@ -96,13 +96,15 @@ extension Issue {
         case .move:           operation = .move
         case .trash:          operation = .trash
         case .backupDownload: operation = .download
+        case .backupUpload:   operation = .upload
         }
 
         return Issue(
             id: stableID,
-            category: entry.kind == .backupDownload ? .backups : .sync,
+            category: (entry.kind == .backupDownload || entry.kind == .backupUpload) ? .backups : .sync,
             filename: entry.filename,
             operation: operation,
+            errorDescription: entry.errorMessage,
             date: entry.createdAt
         )
     }

--- a/Shared/Services/ActivityManager.swift
+++ b/Shared/Services/ActivityManager.swift
@@ -54,19 +54,26 @@ class ActivityManager: ObservableObject {
 
     }
     
-    func updateActivityEntryStatus(id: ObjectId, filename: String, kind: ActivityEntryOperationKind, status: ActivityEntryStatus) {
+    func updateActivityEntryStatus(
+        id: ObjectId,
+        filename: String,
+        kind: ActivityEntryOperationKind,
+        status: ActivityEntryStatus,
+        errorMessage: String? = nil
+    ) {
         guard let realm = getRealm() else { return }
         if let existing = realm.object(ofType: ActivityEntry.self, forPrimaryKey: id) {
             do {
                 try realm.write {
                     existing.filename = filename
                     existing.status = status
+                    if let msg = errorMessage { existing.errorMessage = msg }
                 }
             } catch {
                 error.reportToSentry()
             }
         } else {
-            saveActivityEntry(entry: ActivityEntry(_id: id, filename: filename, kind: kind, status: status))
+            saveActivityEntry(entry: ActivityEntry(_id: id, filename: filename, kind: kind, status: status, errorMessage: errorMessage))
         }
     }
 
@@ -126,12 +133,14 @@ class ActivityEntry: Object {
     @Persisted var createdAt: Date
     @Persisted var kind: ActivityEntryOperationKind
     @Persisted var status: ActivityEntryStatus
-    
+    @Persisted var errorMessage: String?
+
     convenience init(
         _id: ObjectId? = nil,
         filename: String,
         kind: ActivityEntryOperationKind,
-        status: ActivityEntryStatus
+        status: ActivityEntryStatus,
+        errorMessage: String? = nil
     ) {
         self.init()
         self._id = _id ?? ObjectId.generate()
@@ -139,6 +148,7 @@ class ActivityEntry: Object {
         self.createdAt = Date()
         self.kind = kind
         self.status = status
+        self.errorMessage = errorMessage
     }
 }
 
@@ -155,6 +165,7 @@ enum ActivityEntryOperationKind: String, PersistableEnum {
     case upload
     case move
     case backupDownload
+    case backupUpload
 }
 
 enum ActivityEntryStatus: String, PersistableEnum {

--- a/Shared/Services/ActivityManager.swift
+++ b/Shared/Services/ActivityManager.swift
@@ -42,16 +42,20 @@ class ActivityManager: ObservableObject {
     }
     
     func saveActivityEntry(entry: ActivityEntry) {
-        
+        saveActivityEntries(entries: [entry])
+    }
+    
+    func saveActivityEntries(entries: [ActivityEntry]) {
         do {
-            let realm = getRealm()
-            try realm?.write {
-                realm?.add(entry, update: .modified)
+            guard let realm = getRealm() else { return }
+            try realm.write {
+                for entry in entries {
+                    realm.add(entry, update: .modified)
+                }
             }
         } catch {
             error.reportToSentry()
         }
-
     }
     
     func updateActivityEntryStatus(

--- a/Shared/Services/Backups/BackupErrorFileQueue.swift
+++ b/Shared/Services/Backups/BackupErrorFileQueue.swift
@@ -1,0 +1,70 @@
+//
+//  BackupErrorFileQueue.swift
+//  InternxtDesktop
+//
+//  Created by Patricio Tovar on 17/8/26.
+//
+
+import Foundation
+
+final class BackupErrorFileQueue {
+    static let shared = BackupErrorFileQueue()
+    private let fileURL: URL
+    private let writeLock = NSLock()
+
+    private init() {
+        
+        let container = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: INTERNXT_GROUP_NAME)!
+        self.fileURL = container.appendingPathComponent("backup_errors.jsonl")
+    }
+
+   
+    func startNewSession() {
+        writeLock.lock()
+        defer { writeLock.unlock() }
+        try? FileManager.default.removeItem(at: fileURL)
+    }
+
+    func append(filename: String, errorMessage: String) {
+        guard let data = "{\"filename\":\(jsonEscape(filename)),\"error\":\(jsonEscape(errorMessage))}\n".data(using: .utf8) else { return }
+        
+        writeLock.lock()
+        defer { writeLock.unlock() }
+        
+        if FileManager.default.fileExists(atPath: fileURL.path) {
+            if let handle = try? FileHandle(forWritingTo: fileURL) {
+                handle.seekToEndOfFile()
+                handle.write(data)
+                handle.closeFile()
+            }
+        } else {
+            try? data.write(to: fileURL)
+        }
+    }
+
+
+    func readAndClear() -> [(filename: String, error: String)] {
+        writeLock.lock()
+        defer {
+            try? FileManager.default.removeItem(at: fileURL)
+            writeLock.unlock()
+        }
+        
+        guard let content = try? String(contentsOf: fileURL, encoding: .utf8) else { return [] }
+        
+        return content
+            .split(separator: "\n", omittingEmptySubsequences: true)
+            .compactMap { line -> (String, String)? in
+                guard let data = line.data(using: .utf8),
+                      let json = try? JSONSerialization.jsonObject(with: data) as? [String: String],
+                      let filename = json["filename"],
+                      let error = json["error"] else { return nil }
+                return (filename, error)
+            }
+    }
+
+    private func jsonEscape(_ s: String) -> String {
+        let escaped = s.replacingOccurrences(of: "\"", with: "\\\"").replacingOccurrences(of: "\n", with: " ")
+        return "\"\(escaped)\""
+    }
+}

--- a/Shared/Services/Backups/BackupsService.swift
+++ b/Shared/Services/Backups/BackupsService.swift
@@ -396,9 +396,21 @@ class BackupsService: ObservableObject {
 
     private func propagateError(errorMessage: String) {
         logger.info("Error backing up device")
-        let deviceName = currentDevice?.name ?? "Backup"
-        let entry = ActivityEntry(filename: deviceName, kind: .backupUpload, status: .failed, errorMessage: errorMessage)
-        activityManager.saveActivityEntry(entry: entry)
+
+      
+        let individualErrors = BackupErrorFileQueue.shared.readAndClear()
+
+        if individualErrors.isEmpty {
+            let deviceName = currentDevice?.name ?? "Backup"
+            let entry = ActivityEntry(filename: deviceName, kind: .backupUpload, status: .failed, errorMessage: errorMessage)
+            activityManager.saveActivityEntry(entry: entry)
+        } else {
+            let entries = individualErrors.map { fileError in
+                ActivityEntry(filename: fileError.filename, kind: .backupUpload, status: .failed, errorMessage: fileError.error)
+            }
+            activityManager.saveActivityEntries(entries: entries)
+        }
+
         DispatchQueue.main.async { [weak self] in
             self?.currentDeviceHasBackup = true
             self?.backupUploadStatus = .Failed

--- a/Shared/Services/Backups/BackupsService.swift
+++ b/Shared/Services/Backups/BackupsService.swift
@@ -396,6 +396,9 @@ class BackupsService: ObservableObject {
 
     private func propagateError(errorMessage: String) {
         logger.info("Error backing up device")
+        let deviceName = currentDevice?.name ?? "Backup"
+        let entry = ActivityEntry(filename: deviceName, kind: .backupUpload, status: .failed, errorMessage: errorMessage)
+        activityManager.saveActivityEntry(entry: entry)
         DispatchQueue.main.async { [weak self] in
             self?.currentDeviceHasBackup = true
             self?.backupUploadStatus = .Failed
@@ -764,6 +767,11 @@ class BackupsService: ObservableObject {
             
             if(backupDownloadStatus.status == .Done || backupDownloadStatus.status == .Failed) {
                 self.backupDownloadProgressTimer?.cancel()
+                if backupDownloadStatus.status == .Failed {
+                    let deviceName = self.deviceDownloading?.plainName ?? "Backup"
+                    let entry = ActivityEntry(filename: deviceName, kind: .backupDownload, status: .failed, errorMessage: "Backup download failed")
+                    self.activityManager.saveActivityEntry(entry: entry)
+                }
             }
         }
     }

--- a/Shared/en.lproj/Localizable.strings
+++ b/Shared/en.lproj/Localizable.strings
@@ -35,7 +35,7 @@
 "ISSUES_TAB_BACKUPS" = "Backups";
 
 // Issues window — empty state
-"ISSUES_EMPTY_TITLE"    = "No issues found";
+"ISSUES_EMPTY_TITLE"    = "There are no issues";
 "ISSUES_EMPTY_SUBTITLE" = "Any failed file operations will appear here.";
 
 // Issues window — actions

--- a/Shared/es.lproj/Localizable.strings
+++ b/Shared/es.lproj/Localizable.strings
@@ -35,7 +35,7 @@
 "ISSUES_TAB_BACKUPS" = "Copias de seguridad";
 
 // Issues window — empty state
-"ISSUES_EMPTY_TITLE"    = "No se encontraron problemas";
+"ISSUES_EMPTY_TITLE"    = "No hay problemas";
 "ISSUES_EMPTY_SUBTITLE" = "Las operaciones de archivo fallidas aparecerán aquí.";
 
 // Issues window — actions

--- a/Shared/fr.lproj/Localizable.strings
+++ b/Shared/fr.lproj/Localizable.strings
@@ -35,7 +35,7 @@
 "ISSUES_TAB_BACKUPS" = "Sauvegardes";
 
 // Issues window — empty state
-"ISSUES_EMPTY_TITLE"    = "Aucun problème trouvé";
+"ISSUES_EMPTY_TITLE"    = "Aucun problème";
 "ISSUES_EMPTY_SUBTITLE" = "Les opérations de fichier échouées apparaîtront ici.";
 
 // Issues window — actions

--- a/SyncExtension/FileProviderExtension.swift
+++ b/SyncExtension/FileProviderExtension.swift
@@ -603,7 +603,7 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension, NSFile
             if isWorkspaceDomain(){
                return TrashFolderWorkspaceUseCase(item: item, changedFields: changedFields, completionHandler: completionHandler).run()
             }
-            return TrashFolderUseCase(item: item, changedFields: changedFields, completionHandler: completionHandler).run()
+            return TrashFolderUseCase(item: item, changedFields: changedFields, activityManager: activityManager, completionHandler: completionHandler).run()
         }
         
         if folderHasBeenRenamed {
@@ -616,14 +616,14 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension, NSFile
                 return MoveFolderWorkspaceUseCase(user: user, item:item, changedFields: changedFields, completionHandler: completionHandler, workspace: workspace).run()
             }
             
-            return MoveFolderUseCase(user: user, item:item, changedFields: changedFields, completionHandler: completionHandler).run()
+            return MoveFolderUseCase(user: user, item:item, changedFields: changedFields, activityManager: activityManager, completionHandler: completionHandler).run()
         }
         
         if fileHasBeenTrashed {
             if isWorkspaceDomain(){
                 return TrashFileWorkspaceUseCase(item: item, changedFields: changedFields, completionHandler: completionHandler).run()
             }
-            return TrashFileUseCase(item: item, changedFields: changedFields, completionHandler: completionHandler).run()
+            return TrashFileUseCase(item: item, changedFields: changedFields, activityManager: activityManager, completionHandler: completionHandler).run()
         }
         
         if fileHasBeenRenamed  {
@@ -644,7 +644,7 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension, NSFile
             if isWorkspaceDomain(){
                 return MoveFileWorkspaceUseCase(user: user, item:item, changedFields: changedFields, completionHandler: completionHandler, workspace: workspace).run()
             }
-            return MoveFileUseCase(user: user, item:item, changedFields: changedFields, completionHandler: completionHandler).run()
+            return MoveFileUseCase(user: user, item:item, changedFields: changedFields, activityManager: activityManager, completionHandler: completionHandler).run()
         }
         
         if contentHasChanged {

--- a/SyncExtension/UseCases/Files/DownloadFileUseCase.swift
+++ b/SyncExtension/UseCases/Files/DownloadFileUseCase.swift
@@ -285,7 +285,7 @@ struct DownloadFileUseCase {
                 self.logger.error("❌ Failed to fetch file content for file with identifier \(itemIdentifier.rawValue): \(error.getErrorDescription())")
                 
                 if let trackingObjectId = trackingObjectId {
-                    activityManager.updateActivityEntryStatus(id: trackingObjectId, filename: itemIdentifier.rawValue, kind: .download, status: .failed)
+                    activityManager.updateActivityEntryStatus(id: trackingObjectId, filename: itemIdentifier.rawValue, kind: .download, status: .failed, errorMessage: error.getErrorDescription())
                 }
                 completionHandler(nil, nil, NSError(domain: NSFileProviderErrorDomain, code: NSFileProviderError.cannotSynchronize.rawValue))
             }

--- a/SyncExtension/UseCases/Files/MoveFileUseCase.swift
+++ b/SyncExtension/UseCases/Files/MoveFileUseCase.swift
@@ -8,6 +8,7 @@
 import Foundation
 import FileProvider
 import InternxtSwiftCore
+import RealmSwift
 
 
 struct MoveFileUseCase {
@@ -17,20 +18,30 @@ struct MoveFileUseCase {
     let changedFields: NSFileProviderItemFields
     let completionHandler: (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void
     let user: DriveUser
-    init(user: DriveUser,item: NSFileProviderItem, changedFields:  NSFileProviderItemFields, completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void) {
+    private let activityManager: ActivityManager
+
+    init(
+        user: DriveUser,
+        item: NSFileProviderItem,
+        changedFields: NSFileProviderItemFields,
+        activityManager: ActivityManager,
+        completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void
+    ) {
         self.user = user
         self.item = item
         self.completionHandler = completionHandler
         self.changedFields = changedFields
+        self.activityManager = activityManager
     }
     
     
     func run() -> Progress {
+        let trackingId = ObjectId.generate()
         Task {
             self.logger.info("Moving file with uuid \(item.itemIdentifier.rawValue)")
-            
+            activityManager.saveActivityEntry(entry: ActivityEntry(_id: trackingId, filename: item.filename, kind: .move, status: .inProgress))
+
             do {
-                
                 
                 var parentFolderId = item.parentItemIdentifier.rawValue
                 
@@ -60,11 +71,13 @@ struct MoveFileUseCase {
                 
                 
                 self.logger.info("Moving \(newItem.itemIdentifier.rawValue) to \(item.parentItemIdentifier.rawValue)")
+                activityManager.updateActivityEntryStatus(id: trackingId, filename: item.filename, kind: .move, status: .finished)
                 completionHandler(newItem, [], false, nil)
                 self.logger.info("✅ File moved successfully")
             } catch {
                 error.reportToSentry()
                 self.logger.error("❌ Failed to move file: \(error.localizedDescription)")
+                activityManager.updateActivityEntryStatus(id: trackingId, filename: item.filename, kind: .move, status: .failed, errorMessage: error.getErrorDescription())
                 completionHandler(nil, [], false,  NSError(domain: NSFileProviderErrorDomain, code: NSFileProviderError.serverUnreachable.rawValue))
                 
             }

--- a/SyncExtension/UseCases/Files/TrashFileUseCase.swift
+++ b/SyncExtension/UseCases/Files/TrashFileUseCase.swift
@@ -10,6 +10,7 @@ import Foundation
 
 import FileProvider
 import InternxtSwiftCore
+import RealmSwift
 
 enum TrashFileUseCaseError: Error {
     case InvalidItemId
@@ -24,23 +25,35 @@ struct TrashFileUseCase {
     private let item: NSFileProviderItem
     private let completionHandler: (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void
     private let changedFields: NSFileProviderItemFields
-    init(item: NSFileProviderItem, changedFields: NSFileProviderItemFields, completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void) {
+    private let activityManager: ActivityManager
+
+    init(
+        item: NSFileProviderItem,
+        changedFields: NSFileProviderItemFields,
+        activityManager: ActivityManager,
+        completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void
+    ) {
         self.item = item
         self.completionHandler = completionHandler
         self.changedFields = changedFields
+        self.activityManager = activityManager
     }
     
-    public func run( ) -> Progress {
+    public func run() -> Progress {
+        let trackingId = ObjectId.generate()
         Task {
             do {
                 self.logger.info("Trashing file with id \(item.itemIdentifier.rawValue)")
+                activityManager.saveActivityEntry(entry: ActivityEntry(_id: trackingId, filename: item.filename, kind: .trash, status: .inProgress))
                 let driveFileTrashed = try await DriveFileService.shared.trashFile(uuid: item.itemIdentifier.rawValue)
                 self.logger.info("✅ File with id \(item.itemIdentifier.rawValue) trashed correctly")
+                activityManager.updateActivityEntryStatus(id: trackingId, filename: item.filename, kind: .trash, status: .finished)
                 completionHandler(driveFileTrashed.fileProviderItem, changedFields.removing(.parentItemIdentifier), false, nil)
                 
             } catch {
                 error.reportToSentry()
                 self.logger.error("❌ Failed to trash file: \(error.localizedDescription)")
+                activityManager.updateActivityEntryStatus(id: trackingId, filename: item.filename, kind: .trash, status: .failed, errorMessage: error.getErrorDescription())
                 completionHandler(nil, [], false, NSError(domain: NSFileProviderErrorDomain, code: NSFileProviderError.serverUnreachable.rawValue))
             }
         }

--- a/SyncExtension/UseCases/Files/UploadFileUseCase.swift
+++ b/SyncExtension/UseCases/Files/UploadFileUseCase.swift
@@ -251,7 +251,7 @@ struct UploadFileUseCase {
                 
             } catch {
                 error.reportToSentry()
-                activityManager.updateActivityEntryStatus(id: inProgressId, filename: item.filename, kind: .upload, status: .failed)
+                activityManager.updateActivityEntryStatus(id: inProgressId, filename: item.filename, kind: .upload, status: .failed, errorMessage: error.getErrorDescription())
                 self.logger.error("❌ Failed to create file \(item.filename) : \(error.getErrorDescription())")
                 completionHandler(nil, [], false, error.toFileProviderError())
             }

--- a/SyncExtension/UseCases/Folders/MoveFolderUseCase.swift
+++ b/SyncExtension/UseCases/Folders/MoveFolderUseCase.swift
@@ -8,6 +8,7 @@
 import Foundation
 import FileProvider
 import InternxtSwiftCore
+import RealmSwift
 
 
 struct MoveFolderUseCase {
@@ -17,23 +18,34 @@ struct MoveFolderUseCase {
     let changedFields: NSFileProviderItemFields
     let completionHandler: (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void
     let user: DriveUser
-    init(user: DriveUser,item: NSFileProviderItem, changedFields:  NSFileProviderItemFields, completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void) {
+    private let activityManager: ActivityManager
+
+    init(
+        user: DriveUser,
+        item: NSFileProviderItem,
+        changedFields: NSFileProviderItemFields,
+        activityManager: ActivityManager,
+        completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void
+    ) {
         self.user = user
         self.item = item
         self.completionHandler = completionHandler
         self.changedFields = changedFields
+        self.activityManager = activityManager
     }
     
     
     func run() -> Progress {
+        let trackingId = ObjectId.generate()
         Task {
             self.logger.info("Moving folder with id \(item.itemIdentifier.rawValue)")
-            
+            activityManager.saveActivityEntry(entry: ActivityEntry(_id: trackingId, filename: item.filename, kind: .move, status: .inProgress))
+
             do {
                 let newParentIsRootFolder: Bool = item.parentItemIdentifier == .rootContainer
                 
                 let folder = try await driveNewAPI.getFolderMetaById(id: item.itemIdentifier.rawValue)
-                let folderDestination =  try await driveNewAPI.getFolderMetaById(id: newParentIsRootFolder == true ? String(user.root_folder_id) : item.parentItemIdentifier.rawValue)
+                let folderDestination = try await driveNewAPI.getFolderMetaById(id: newParentIsRootFolder == true ? String(user.root_folder_id) : item.parentItemIdentifier.rawValue)
                 
                 guard let parentUuid = folder.uuid  else {
                     throw UploadFileUseCaseError.InvalidParentUUID
@@ -56,11 +68,13 @@ struct MoveFolderUseCase {
                     itemType: .folder
                 )
                 
+                activityManager.updateActivityEntryStatus(id: trackingId, filename: item.filename, kind: .move, status: .finished)
                 completionHandler(newItem, [], false, nil)
                 self.logger.info("✅ Folder moved successfully")
             } catch {
                 error.reportToSentry()
                 self.logger.error("❌ Failed to move folder: \(error.localizedDescription)")
+                activityManager.updateActivityEntryStatus(id: trackingId, filename: item.filename, kind: .move, status: .failed, errorMessage: error.getErrorDescription())
                 completionHandler(nil, [], false,  NSError(domain: NSFileProviderErrorDomain, code: NSFileProviderError.serverUnreachable.rawValue))
                 
             }

--- a/SyncExtension/UseCases/Folders/TrashFolderUseCase.swift
+++ b/SyncExtension/UseCases/Folders/TrashFolderUseCase.swift
@@ -8,6 +8,7 @@
 import Foundation
 import FileProvider
 import InternxtSwiftCore
+import RealmSwift
 
 enum TrashFolderUseCaseError: Error {
     case InvalidItemId
@@ -29,20 +30,31 @@ struct TrashFolderUseCase {
     private let item: NSFileProviderItem
     private let completionHandler: (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void
     private let changedFields: NSFileProviderItemFields
-    init(item: NSFileProviderItem, changedFields: NSFileProviderItemFields, completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void) {
+    private let activityManager: ActivityManager
+
+    init(
+        item: NSFileProviderItem,
+        changedFields: NSFileProviderItemFields,
+        activityManager: ActivityManager,
+        completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void
+    ) {
         self.item = item
         self.completionHandler = completionHandler
         self.changedFields = changedFields
+        self.activityManager = activityManager
     }
     
     public func run() -> Progress {
         self.logger.info("Moving item to trash")
+        let trackingId = ObjectId.generate()
         Task {
             do {
                
                 guard let id = Int(item.itemIdentifier.rawValue) else {
                     throw TrashFolderUseCaseError.InvalidItemId
                 }
+
+                activityManager.saveActivityEntry(entry: ActivityEntry(_id: trackingId, filename: item.filename, kind: .trash, status: .inProgress))
                
                 let trashed: Bool = try await trashAPI.trashFolders(itemsToTrash: [FolderToTrash(id: id)])
                 self.logger.info("Trashed item result is: \(trashed)")
@@ -58,6 +70,7 @@ struct TrashFolderUseCase {
                         itemType: .folder
                     )
                     self.logger.info("✅ Folder with id \(item.itemIdentifier.rawValue) trashed correctly")
+                    activityManager.updateActivityEntryStatus(id: trackingId, filename: item.filename, kind: .trash, status: .finished)
                     DeletedFolderCache.shared.markFolderAsDeleted(String(id))
                     completionHandler(newItem, changedFields.removing(.parentItemIdentifier), false, nil)
                 } else {
@@ -67,6 +80,7 @@ struct TrashFolderUseCase {
             } catch {
                 error.reportToSentry()
                 self.logger.error("❌ Failed to trash folder: \(error.localizedDescription)")
+                activityManager.updateActivityEntryStatus(id: trackingId, filename: item.filename, kind: .trash, status: .failed, errorMessage: error.getErrorDescription())
                 completionHandler(nil, [], false, NSError(domain: NSFileProviderErrorDomain, code: NSFileProviderError.serverUnreachable.rawValue))
             }
         }

--- a/XPCBackupService/Entities/BackupTreeNode.swift
+++ b/XPCBackupService/Entities/BackupTreeNode.swift
@@ -185,6 +185,15 @@ class BackupTreeNode {
             }
         }
         
+        // Check for SF_DATALESS to prevent backing up undownloaded iCloud/Cloud files
+        var fileStat = stat()
+        if stat(nodeURL.path, &fileStat) == 0 {
+            if (fileStat.st_flags & UInt32(SF_DATALESS)) != 0 {
+                backupTotalPogress.completedUnitCount += 1
+                throw BackupUploadError.fileNotDownloadedFromCloud
+            }
+        }
+        
         let currentSyncedNode = try self.nodeIsSynced(url: nodeURL, deviceId: self.deviceId)
         if let currentSyncedNodeUnwrapped = currentSyncedNode {
             try self.updateNodeAsAlreadySynced(syncedNodeRemoteId: currentSyncedNodeUnwrapped.remoteId, syncedNoteRemoteUuid: currentSyncedNodeUnwrapped.remoteUuid)

--- a/XPCBackupService/Entities/BackupTreeNodeSyncOperation.swift
+++ b/XPCBackupService/Entities/BackupTreeNodeSyncOperation.swift
@@ -38,6 +38,10 @@ class BackupTreeNodeSyncOperation: AsyncOperation {
             //    (Files in a failed folder cannot be synced anyway).
             // 2. Fatal errors (e.g. storageFull) will trigger cancelAllOperations() at the XPC layer.
             // 3. Non-fatal errors are counted as failures, but sibling branches will continue processing.
+            BackupErrorFileQueue.shared.append(
+                filename: self.backupTreeNode.name,
+                errorMessage: error.localizedDescription
+            )
             onError?(error)
             throw error
         }

--- a/XPCBackupService/Services/BackupUploadService.swift
+++ b/XPCBackupService/Services/BackupUploadService.swift
@@ -34,6 +34,20 @@ enum BackupUploadError: Error {
     case EmptyFileQuotaExceeded
     case EmptyFilePlanNotAllowed
     case StorageFull
+    case fileNotDownloadedFromCloud
+}
+
+extension BackupUploadError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .fileNotDownloadedFromCloud:
+            return "This file is currently in the cloud and not on your Mac. Please download it first to back it up."
+        case .StorageFull:
+            return "Storage is full."
+        default:
+            return "An unexpected backup error occurred (\(self))."
+        }
+    }
 }
 
 enum BackupDownloadError: Error {

--- a/XPCBackupService/XPCBackupService.swift
+++ b/XPCBackupService/XPCBackupService.swift
@@ -45,6 +45,7 @@ public class XPCBackupService: NSObject, XPCBackupServiceProtocol {
         self.uploadOperationQueue = OperationQueue()
         self.uploadOperationQueue.maxConcurrentOperationCount = 5
         logger.info("Going to backup folders: \(backupURLs)")
+        BackupErrorFileQueue.shared.startNewSession()
         self.backupUploadStatus = .InProgress
         self.backupUploadProgress = Progress()
         


### PR DESCRIPTION
##  What does this PR do?
This PR overhauls the **Issues Tab**, eliminating duplicated errors, showing real backend messages, and providing file-by-file granular error reporting for device backups. 

##  Key Changes
- **UI Deduplication & Auto-resolution:** Groups rapid FileProvider retries into a single row. Automatically hides issues if a successful retry happens later.
- **Real Error Messages:** Sync operations now pass the actual API error string (`getErrorDescription()`) to the UI instead of generic fallbacks.
- **Visual Fix:** Added `.backupUpload` enum to correctly label backup errors as "Upload failed" (was incorrectly showing "Download failed").
- **Granular Backup Errors:** Moved away from global "X errors" summaries. XPC Daemon now streams individual file errors via a shared `.jsonl` queue, which are batched into Realm to ensure real-time UI updates.
- **iCloud Dataless Protection:** Added a POSIX `SF_DATALESS` check to gracefully intercept undownloaded cloud files, replacing cryptic `CryptoError` failures with a user-friendly download reminder.
