### PR TITLE
make Antivirus UI reactive to subscription changes

### DIFF
--- a/InternxtDesktop.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/InternxtDesktop.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -88,7 +88,7 @@
       "location" : "https://github.com/internxt/swift-core",
       "state" : {
         "branch" : "main",
-        "revision" : "ad2ca2cbf8fac848fe57808587465ab6c49016e7"
+        "revision" : "8afad608bb9d4ebbc862d9be6b6d07cb9d402d25"
       }
     },
     {

--- a/InternxtDesktop/Services/AntivirusManager.swift
+++ b/InternxtDesktop/Services/AntivirusManager.swift
@@ -24,6 +24,24 @@ class AntivirusManager: ObservableObject {
     private let database = ClamAVDatabaseService.shared
     
     private var isCancelled = false
+    private var observationTask: Task<Void, Never>?
+    
+    init() {
+        observationTask = Task { @MainActor [weak self] in
+            for await isEnabled in FeaturesService.shared.$antivirusEnabled.values {
+                guard let self else { return }
+                if isEnabled && self.currentState == .locked {
+                    self.currentState = FeaturesService.shared.antivirusState
+                } else if !isEnabled && self.currentState != .locked {
+                    self.cancelScan(isLocked: true)
+                }
+            }
+        }
+    }
+    
+    deinit {
+        observationTask?.cancel()
+    }
     
     @MainActor
     func fetchAntivirusStatus() async {


### PR DESCRIPTION
The Desktop macOS application was not recognizing an active paid subscription for the Antivirus feature if the plan was updated while the app was running, or if the initial network request failed (e.g., 401 error). `AntivirusManager` was stuck in a `.locked` state until the application was completely restarted because it only fetched the state imperatively during `AppDelegate` initialization.
## 🛠️ Fix
Refactored `AntivirusManager` to reactively observe changes from `FeaturesService` using modern Swift Concurrency:
- Implemented a `@MainActor` isolated `Task` in the `init()` of `AntivirusManager`.
- The task now asynchronously iterates over `FeaturesService.shared.$antivirusEnabled.values`.
- When the background polling in `FeaturesService` detects that the user has upgraded their plan, the Antivirus UI now updates and unlocks instantly in real-time.