### PR TITLE
handle APIClientError gracefully on app launch and redirect to error logs

### DIFF
--- a/InternxtDesktop/AppDelegate.swift
+++ b/InternxtDesktop/AppDelegate.swift
@@ -226,7 +226,7 @@ class AppDelegate: NSObject, NSApplicationDelegate , PKPushRegistryDelegate {
                 logger.info(["📍 Push device token \(deviceTokenString) registered", result])
                 
             }catch{
-                logger.error(["Cannot sync token", error])
+                error.reportToSentry()
             }
         }
     }

--- a/InternxtDesktop/Services/FileLimitsService.swift
+++ b/InternxtDesktop/Services/FileLimitsService.swift
@@ -14,8 +14,7 @@ class FileLimitsService: ObservableObject {
     static let shared = FileLimitsService()
 
     private let config   = ConfigLoader()
-    private let logger   = LogService.shared.createLogger(
-        subsystem: .InternxtDesktop, category: "FileLimitsService")
+
 
 
     @Published private(set) var maxUploadFileSizeBytes: Int64 = Int64.max
@@ -74,8 +73,7 @@ class FileLimitsService: ObservableObject {
             maxUploadFileSizeBytes = config.getMaxFileSizeBytes()
           
         } catch {
-      
-            logger.error("❌ Failed to fetch file limits: \(error.localizedDescription)")
+            error.reportToSentry()
         }
     }
 }


### PR DESCRIPTION
Fixes an issue where users experienced non-critical `InternxtSwiftCore.APIClientError` errors during automatic startup and login on macOS. Non-critical startup tasks (such as push notification device token registration and `FileLimitsService` polling) now route their errors to the dedicated error logging subsystem (`com.internxt.errors`) instead of polluting main application logs or displaying unhandled error states.
## Problem
During automatic startup on macOS, background network requests (such as registering the push notification token or fetching file limits) could trigger `APIClientError` if network connectivity or authentication tokens were not immediately available. These errors were being logged to the general desktop log stream and could present misleading error alerts to the user even though Internxt Drive remained fully functional.