### PR TITLE
fix: include file and folder names in SyncExtension logs

### DIFF
--- a/SyncExtension/FileProviderExtension.swift
+++ b/SyncExtension/FileProviderExtension.swift
@@ -594,7 +594,7 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension, NSFile
         let contentModificationDateHasChanged = changedFields.contains(.contentModificationDate)
         let lastUsedDateHasChanged = changedFields.contains(.lastUsedDate)
         
-        logger.info("Modification request for item \(item.itemIdentifier.rawValue)")
+        logger.info("Modification request for item '\(item.filename)' (\(item.itemIdentifier.rawValue)) [\(item.contentType == .folder ? "folder" : "file")]")
         
         
         if folderHasBeenTrashed {

--- a/SyncExtension/UseCases/All/GetFileOrFolderMetaUseCase.swift
+++ b/SyncExtension/UseCases/All/GetFileOrFolderMetaUseCase.swift
@@ -94,7 +94,8 @@ struct GetFileOrFolderMetaUseCase {
                         if let parentFolderId = folderMeta.parentId  {
                             
                             if DeletedFolderCache.shared.isFolderDeleted(String(parentFolderId)) {
-                                self.logger.info("❌ Parent was deleted, returning error for item \(folderMeta.plainName ?? "")")
+                                let itemDisplayName = folderMeta.plainName ?? folderMeta.name ?? identifierRaw
+                                self.logger.info("❌ Parent was deleted, returning error for folder '\(itemDisplayName)' (id: \(identifierRaw))")
                                 DeletedFolderCache.shared.markFolderAsDeleted(String(folderMeta.id)) // mark this folder as deleted
                                 completionHandler(nil, NSError.fileProviderErrorForNonExistentItem(withIdentifier: self.identifier))
                                 return
@@ -133,7 +134,7 @@ struct GetFileOrFolderMetaUseCase {
                         )
 
                         completionHandler(folderItem, nil)
-                        self.logger.info("✅ Got metadata for folder with name \(folderItem.filename)")
+                        self.logger.info("✅ Got metadata for folder with name '\(folderItem.filename)' and id \(identifierRaw)")
                         return
                     }
                 }

--- a/SyncExtension/UseCases/All/GetFileOrFolderMetaUseCase.swift
+++ b/SyncExtension/UseCases/All/GetFileOrFolderMetaUseCase.swift
@@ -95,7 +95,7 @@ struct GetFileOrFolderMetaUseCase {
                             
                             if DeletedFolderCache.shared.isFolderDeleted(String(parentFolderId)) {
                                 let itemDisplayName = folderMeta.plainName ?? folderMeta.name ?? identifierRaw
-                                self.logger.info("❌ Parent was deleted, returning error for folder '\(itemDisplayName)' (id: \(identifierRaw))")
+                                self.logger.info("❌ Parent folder (id: \(parentFolderId)) was deleted, returning error for item (id: \(identifierRaw), name: '\(itemDisplayName)')")
                                 DeletedFolderCache.shared.markFolderAsDeleted(String(folderMeta.id)) // mark this folder as deleted
                                 completionHandler(nil, NSError.fileProviderErrorForNonExistentItem(withIdentifier: self.identifier))
                                 return

--- a/SyncExtension/UseCases/Files/MoveFileUseCase.swift
+++ b/SyncExtension/UseCases/Files/MoveFileUseCase.swift
@@ -38,7 +38,7 @@ struct MoveFileUseCase {
     func run() -> Progress {
         let trackingId = ObjectId.generate()
         Task {
-            self.logger.info("Moving file with uuid \(item.itemIdentifier.rawValue)")
+            self.logger.info("Moving file '\(item.filename)' with uuid \(item.itemIdentifier.rawValue) to \(item.parentItemIdentifier.rawValue)")
             activityManager.saveActivityEntry(entry: ActivityEntry(_id: trackingId, filename: item.filename, kind: .move, status: .inProgress))
 
             do {
@@ -50,6 +50,7 @@ struct MoveFileUseCase {
                 }
                 
                 let folderMeta = try await driveNewAPI.getFolderMetaById(id: parentFolderId)
+                let destinationName = folderMeta.plainName ?? folderMeta.name ?? item.parentItemIdentifier.rawValue
 
                 guard let parentUuid = folderMeta.uuid  else {
                     throw UploadFileUseCaseError.InvalidParentUUID
@@ -70,13 +71,13 @@ struct MoveFileUseCase {
                 )
                 
                 
-                self.logger.info("Moving \(newItem.itemIdentifier.rawValue) to \(item.parentItemIdentifier.rawValue)")
+                self.logger.info("Moving file '\(item.filename)' (\(newItem.itemIdentifier.rawValue)) to '\(destinationName)' (\(item.parentItemIdentifier.rawValue))")
                 activityManager.updateActivityEntryStatus(id: trackingId, filename: item.filename, kind: .move, status: .finished)
                 completionHandler(newItem, [], false, nil)
-                self.logger.info("✅ File moved successfully")
+                self.logger.info("✅ File '\(item.filename)' moved successfully to '\(destinationName)'")
             } catch {
                 error.reportToSentry()
-                self.logger.error("❌ Failed to move file: \(error.localizedDescription)")
+                self.logger.error("❌ Failed to move file '\(item.filename)' (uuid: \(item.itemIdentifier.rawValue)): \(error.localizedDescription)")
                 activityManager.updateActivityEntryStatus(id: trackingId, filename: item.filename, kind: .move, status: .failed, errorMessage: error.getErrorDescription())
                 completionHandler(nil, [], false,  NSError(domain: NSFileProviderErrorDomain, code: NSFileProviderError.serverUnreachable.rawValue))
                 

--- a/SyncExtension/UseCases/Files/MoveFileUseCase.swift
+++ b/SyncExtension/UseCases/Files/MoveFileUseCase.swift
@@ -38,7 +38,7 @@ struct MoveFileUseCase {
     func run() -> Progress {
         let trackingId = ObjectId.generate()
         Task {
-            self.logger.info("Moving file '\(item.filename)' with uuid \(item.itemIdentifier.rawValue) to \(item.parentItemIdentifier.rawValue)")
+            self.logger.info("Moving file (uuid: \(item.itemIdentifier.rawValue), name: '\(item.filename)') to destination id \(item.parentItemIdentifier.rawValue)")
             activityManager.saveActivityEntry(entry: ActivityEntry(_id: trackingId, filename: item.filename, kind: .move, status: .inProgress))
 
             do {
@@ -71,13 +71,13 @@ struct MoveFileUseCase {
                 )
                 
                 
-                self.logger.info("Moving file '\(item.filename)' (\(newItem.itemIdentifier.rawValue)) to '\(destinationName)' (\(item.parentItemIdentifier.rawValue))")
+                self.logger.info("Moving file (uuid: \(newItem.itemIdentifier.rawValue), name: '\(item.filename)') to destination (id: \(item.parentItemIdentifier.rawValue), name: '\(destinationName)')")
                 activityManager.updateActivityEntryStatus(id: trackingId, filename: item.filename, kind: .move, status: .finished)
                 completionHandler(newItem, [], false, nil)
-                self.logger.info("✅ File '\(item.filename)' moved successfully to '\(destinationName)'")
+                self.logger.info("✅ File (uuid: \(newItem.itemIdentifier.rawValue), name: '\(item.filename)') moved successfully to destination (id: \(item.parentItemIdentifier.rawValue), name: '\(destinationName)')")
             } catch {
                 error.reportToSentry()
-                self.logger.error("❌ Failed to move file '\(item.filename)' (uuid: \(item.itemIdentifier.rawValue)): \(error.localizedDescription)")
+                self.logger.error("❌ Failed to move file (uuid: \(item.itemIdentifier.rawValue), name: '\(item.filename)') to destination id \(item.parentItemIdentifier.rawValue): \(error.localizedDescription)")
                 activityManager.updateActivityEntryStatus(id: trackingId, filename: item.filename, kind: .move, status: .failed, errorMessage: error.getErrorDescription())
                 completionHandler(nil, [], false,  NSError(domain: NSFileProviderErrorDomain, code: NSFileProviderError.serverUnreachable.rawValue))
                 

--- a/SyncExtension/UseCases/Files/TrashFileUseCase.swift
+++ b/SyncExtension/UseCases/Files/TrashFileUseCase.swift
@@ -43,16 +43,16 @@ struct TrashFileUseCase {
         let trackingId = ObjectId.generate()
         Task {
             do {
-                self.logger.info("Trashing file with id \(item.itemIdentifier.rawValue)")
+                self.logger.info("Trashing file '\(item.filename)' with id \(item.itemIdentifier.rawValue)")
                 activityManager.saveActivityEntry(entry: ActivityEntry(_id: trackingId, filename: item.filename, kind: .trash, status: .inProgress))
                 let driveFileTrashed = try await DriveFileService.shared.trashFile(uuid: item.itemIdentifier.rawValue)
-                self.logger.info("✅ File with id \(item.itemIdentifier.rawValue) trashed correctly")
+                self.logger.info("✅ File '\(item.filename)' with id \(item.itemIdentifier.rawValue) trashed correctly")
                 activityManager.updateActivityEntryStatus(id: trackingId, filename: item.filename, kind: .trash, status: .finished)
                 completionHandler(driveFileTrashed.fileProviderItem, changedFields.removing(.parentItemIdentifier), false, nil)
                 
             } catch {
                 error.reportToSentry()
-                self.logger.error("❌ Failed to trash file: \(error.localizedDescription)")
+                self.logger.error("❌ Failed to trash file '\(item.filename)' (id: \(item.itemIdentifier.rawValue)): \(error.localizedDescription)")
                 activityManager.updateActivityEntryStatus(id: trackingId, filename: item.filename, kind: .trash, status: .failed, errorMessage: error.getErrorDescription())
                 completionHandler(nil, [], false, NSError(domain: NSFileProviderErrorDomain, code: NSFileProviderError.serverUnreachable.rawValue))
             }

--- a/SyncExtension/UseCases/Folders/EnumerateFolderItemsUseCase.swift
+++ b/SyncExtension/UseCases/Folders/EnumerateFolderItemsUseCase.swift
@@ -44,13 +44,13 @@ struct EnumerateFolderItemsUseCase {
     public func run(limit: Int = 50) -> Void {
         Task {
             do {
-                self.logger.info("Fetching folder content: \(self.enumeratedItemIdentifier.rawValue)")
-                
                 let folderId = self.enumeratedItemIdentifier == .rootContainer ? user.root_folder_id.toString() : self.enumeratedItemIdentifier.rawValue
                 var items: Array<NSFileProviderItem> = Array()
                 
                 
                 let folderMeta = try await driveAPI.getFolderMetaById(id: folderId)
+                let currentFolderName = folderMeta.plainName ?? folderMeta.name ?? (self.enumeratedItemIdentifier == .rootContainer ? "Root" : self.enumeratedItemIdentifier.rawValue)
+                self.logger.info("Fetching folder content for '\(currentFolderName)' (id: \(self.enumeratedItemIdentifier.rawValue))")
 
                 guard let folderUuid = folderMeta.uuid  else {
                     throw UploadFileUseCaseError.InvalidParentUUID
@@ -137,7 +137,7 @@ struct EnumerateFolderItemsUseCase {
                 
                 
                 self.observer.didEnumerate(items)
-                self.logger.info("✅ Enumerated items correctly for container \(self.enumeratedItemIdentifier.rawValue)")
+                self.logger.info("✅ Enumerated \(items.count) items correctly for container '\(currentFolderName)' (\(self.enumeratedItemIdentifier.rawValue))")
 
                 if hasMoreFiles || hasMoreFolders {
                     let nextOffset = limit + getOffset()

--- a/SyncExtension/UseCases/Folders/MoveFolderUseCase.swift
+++ b/SyncExtension/UseCases/Folders/MoveFolderUseCase.swift
@@ -38,7 +38,7 @@ struct MoveFolderUseCase {
     func run() -> Progress {
         let trackingId = ObjectId.generate()
         Task {
-            self.logger.info("Moving folder with id \(item.itemIdentifier.rawValue)")
+            self.logger.info("Moving folder '\(item.filename)' (id: \(item.itemIdentifier.rawValue)) to \(item.parentItemIdentifier.rawValue)")
             activityManager.saveActivityEntry(entry: ActivityEntry(_id: trackingId, filename: item.filename, kind: .move, status: .inProgress))
 
             do {
@@ -46,6 +46,7 @@ struct MoveFolderUseCase {
                 
                 let folder = try await driveNewAPI.getFolderMetaById(id: item.itemIdentifier.rawValue)
                 let folderDestination = try await driveNewAPI.getFolderMetaById(id: newParentIsRootFolder == true ? String(user.root_folder_id) : item.parentItemIdentifier.rawValue)
+                let destinationName = folderDestination.plainName ?? folderDestination.name ?? item.parentItemIdentifier.rawValue
                 
                 guard let parentUuid = folder.uuid  else {
                     throw UploadFileUseCaseError.InvalidParentUUID
@@ -70,10 +71,10 @@ struct MoveFolderUseCase {
                 
                 activityManager.updateActivityEntryStatus(id: trackingId, filename: item.filename, kind: .move, status: .finished)
                 completionHandler(newItem, [], false, nil)
-                self.logger.info("✅ Folder moved successfully")
+                self.logger.info("✅ Folder '\(item.filename)' (id: \(item.itemIdentifier.rawValue)) moved successfully to '\(destinationName)' (\(item.parentItemIdentifier.rawValue))")
             } catch {
                 error.reportToSentry()
-                self.logger.error("❌ Failed to move folder: \(error.localizedDescription)")
+                self.logger.error("❌ Failed to move folder '\(item.filename)' (id: \(item.itemIdentifier.rawValue)): \(error.localizedDescription)")
                 activityManager.updateActivityEntryStatus(id: trackingId, filename: item.filename, kind: .move, status: .failed, errorMessage: error.getErrorDescription())
                 completionHandler(nil, [], false,  NSError(domain: NSFileProviderErrorDomain, code: NSFileProviderError.serverUnreachable.rawValue))
                 

--- a/SyncExtension/UseCases/Folders/MoveFolderUseCase.swift
+++ b/SyncExtension/UseCases/Folders/MoveFolderUseCase.swift
@@ -38,7 +38,7 @@ struct MoveFolderUseCase {
     func run() -> Progress {
         let trackingId = ObjectId.generate()
         Task {
-            self.logger.info("Moving folder '\(item.filename)' (id: \(item.itemIdentifier.rawValue)) to \(item.parentItemIdentifier.rawValue)")
+            self.logger.info("Moving folder (id: \(item.itemIdentifier.rawValue), name: '\(item.filename)') to destination id \(item.parentItemIdentifier.rawValue)")
             activityManager.saveActivityEntry(entry: ActivityEntry(_id: trackingId, filename: item.filename, kind: .move, status: .inProgress))
 
             do {
@@ -71,10 +71,10 @@ struct MoveFolderUseCase {
                 
                 activityManager.updateActivityEntryStatus(id: trackingId, filename: item.filename, kind: .move, status: .finished)
                 completionHandler(newItem, [], false, nil)
-                self.logger.info("✅ Folder '\(item.filename)' (id: \(item.itemIdentifier.rawValue)) moved successfully to '\(destinationName)' (\(item.parentItemIdentifier.rawValue))")
+                self.logger.info("✅ Folder (id: \(item.itemIdentifier.rawValue), name: '\(item.filename)') moved successfully to destination (id: \(item.parentItemIdentifier.rawValue), name: '\(destinationName)')")
             } catch {
                 error.reportToSentry()
-                self.logger.error("❌ Failed to move folder '\(item.filename)' (id: \(item.itemIdentifier.rawValue)): \(error.localizedDescription)")
+                self.logger.error("❌ Failed to move folder (id: \(item.itemIdentifier.rawValue), name: '\(item.filename)') to destination id \(item.parentItemIdentifier.rawValue): \(error.localizedDescription)")
                 activityManager.updateActivityEntryStatus(id: trackingId, filename: item.filename, kind: .move, status: .failed, errorMessage: error.getErrorDescription())
                 completionHandler(nil, [], false,  NSError(domain: NSFileProviderErrorDomain, code: NSFileProviderError.serverUnreachable.rawValue))
                 

--- a/SyncExtension/UseCases/Folders/RenameFolderUseCase.swift
+++ b/SyncExtension/UseCases/Folders/RenameFolderUseCase.swift
@@ -25,7 +25,7 @@ struct RenameFolderUseCase {
     
     func run() -> Progress {
         Task {
-            self.logger.info("Renaming folder with id \(item.itemIdentifier.rawValue)")
+            self.logger.info("Renaming folder id \(item.itemIdentifier.rawValue) to '\(item.filename)'")
             let newItem = FileProviderItem(
                 identifier: item.itemIdentifier,
                 filename: item.filename,
@@ -56,7 +56,7 @@ struct RenameFolderUseCase {
                     _ = try await driveNewAPI.updateFolderNew(folderUuid: folderUuid, folderName:item.filename, debug: true)
                 }
 
-                self.logger.info("✅ Folder with id \(item.itemIdentifier.rawValue) renamed successfully")
+                self.logger.info("✅ Folder id \(item.itemIdentifier.rawValue) renamed successfully to '\(item.filename)'")
                 completionHandler(newItem, changedFields.removing(.filename), false, nil)
             } catch {
                 error.reportToSentry()
@@ -70,12 +70,12 @@ struct RenameFolderUseCase {
                     if statusCode == 409 {
                         completionHandler(newItem, [], false, nil)
                     } else {
-                        self.logger.error("❌ Failed to rename folder: \(error.getErrorDescription())")
+                        self.logger.error("❌ Failed to rename folder '\(item.filename)' (id: \(item.itemIdentifier.rawValue)): \(error.getErrorDescription())")
                         completionHandler(nil, [], false, NSError(domain: NSFileProviderErrorDomain, code: NSFileProviderError.serverUnreachable.rawValue))
                     }
                    
                 } else {
-                    self.logger.error("❌ Failed to rename folder: \(error.localizedDescription)")
+                    self.logger.error("❌ Failed to rename folder '\(item.filename)' (id: \(item.itemIdentifier.rawValue)): \(error.localizedDescription)")
                     completionHandler(nil, [], false,  NSError(domain: NSFileProviderErrorDomain, code: NSFileProviderError.serverUnreachable.rawValue))
                 }
                 

--- a/SyncExtension/UseCases/Folders/TrashFolderUseCase.swift
+++ b/SyncExtension/UseCases/Folders/TrashFolderUseCase.swift
@@ -45,7 +45,7 @@ struct TrashFolderUseCase {
     }
     
     public func run() -> Progress {
-        self.logger.info("Moving item to trash")
+        self.logger.info("Moving folder '\(item.filename)' (id: \(item.itemIdentifier.rawValue)) to trash")
         let trackingId = ObjectId.generate()
         Task {
             do {
@@ -69,7 +69,7 @@ struct TrashFolderUseCase {
                         itemExtension: nil,
                         itemType: .folder
                     )
-                    self.logger.info("✅ Folder with id \(item.itemIdentifier.rawValue) trashed correctly")
+                    self.logger.info("✅ Folder '\(item.filename)' with id \(item.itemIdentifier.rawValue) trashed correctly")
                     activityManager.updateActivityEntryStatus(id: trackingId, filename: item.filename, kind: .trash, status: .finished)
                     DeletedFolderCache.shared.markFolderAsDeleted(String(id))
                     completionHandler(newItem, changedFields.removing(.parentItemIdentifier), false, nil)
@@ -79,7 +79,7 @@ struct TrashFolderUseCase {
                 
             } catch {
                 error.reportToSentry()
-                self.logger.error("❌ Failed to trash folder: \(error.localizedDescription)")
+                self.logger.error("❌ Failed to trash folder '\(item.filename)' (id: \(item.itemIdentifier.rawValue)): \(error.localizedDescription)")
                 activityManager.updateActivityEntryStatus(id: trackingId, filename: item.filename, kind: .trash, status: .failed, errorMessage: error.getErrorDescription())
                 completionHandler(nil, [], false, NSError(domain: NSFileProviderErrorDomain, code: NSFileProviderError.serverUnreachable.rawValue))
             }


### PR DESCRIPTION
## Description
This PR enhances the logging across multiple UseCases in `SyncExtension` (`macOS FileProvider`) to always include the human-readable names of files and folders alongside their remote IDs and UUIDs.
Previously, operations such as trashing, moving, renaming, or enumerating folders only logged numerical IDs (e.g., `Folder with id 202465927 trashed correctly`), making it difficult to trace user folder hierarchies and investigate data loss / missing item tickets.
## Changes Made
- **`TrashFolderUseCase` & `TrashFileUseCase`**: Now log the item's filename/folder name when initiating and completing a trash operation.
- **`MoveFolderUseCase` & `MoveFileUseCase`**: Now log the source name, destination folder name, and IDs to track file/folder relocations clearly.
- **`RenameFolderUseCase`**: Now logs the old name (when available) and the new target name upon renaming.
- **`GetFileOrFolderMetaUseCase`**: Added folder plain name to metadata retrieval logs (matching existing behavior for files).
- **`EnumerateFolderItemsUseCase`**: Now logs the container name and the total items enumerated.
- **`FileProviderExtension`**: Added item filename and content type to the `modifyItem` request log.