### PR TITLE
report backup download errors, show friendly errors and relative paths

### DIFF
--- a/InternxtDesktop/Views/Issues/IssueRowView.swift
+++ b/InternxtDesktop/Views/Issues/IssueRowView.swift
@@ -31,14 +31,23 @@ struct IssueRowView: View {
                         .font(.SMMedium)
                         .foregroundColor(.Gray100)
                         .lineLimit(1)
-                        .help(issue.filename)
+                        .help(issue.fullHelpText)
+
+                    if let path = issue.relativePath, !path.isEmpty, path != issue.filename {
+                        Text(verbatim: path)
+                            .font(.XXSRegular)
+                            .foregroundColor(.Gray50)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                            .help(path)
+                    }
 
                     HStack(spacing: 4) {
                         AppText(issue.operation.localizedLabel)
                             .font(.XSRegular)
                             .foregroundColor(.Gray50)
 
-                        if let desc = issue.errorDescription {
+                        if let desc = issue.userFriendlyErrorDescription {
                             Text("·")
                                 .font(.XSRegular)
                                 .foregroundColor(.Gray40)
@@ -46,7 +55,7 @@ struct IssueRowView: View {
                                 .font(.XSRegular)
                                 .foregroundColor(.Gray50)
                                 .lineLimit(1)
-                                .help(desc)
+                                .help(issue.fullHelpText)
                         }
                     }
                 }

--- a/Shared/Extensions/Error.swift
+++ b/Shared/Extensions/Error.swift
@@ -115,6 +115,114 @@ extension Error {
             return NSError(domain: NSFileProviderErrorDomain, code: NSFileProviderError.serverUnreachable.rawValue)
         }
     }
+
+    func getUserFriendlyDescription() -> String {
+        return ErrorFormatter.userFriendlyDescription(from: self.getErrorDescription()) ?? NSLocalizedString("ISSUE_ERROR_NETWORK", comment: "")
+    }
+}
+
+public struct ErrorFormatter {
+    public static func userFriendlyDescription(from message: String?) -> String? {
+        guard let message = message, !message.isEmpty else {
+            return nil
+        }
+
+        let lower = message.lowercased()
+
+        // 1. Storage Full (420)
+        if message.contains("420") || lower.contains("storage is full") || lower.contains("storage full") {
+            return NSLocalizedString("ISSUE_ERROR_STORAGE_FULL", comment: "")
+        }
+
+        // 2. Authentication / Session (401)
+        if message.contains("401") || lower.contains("unauthorized") || lower.contains("session expired") {
+            return NSLocalizedString("ISSUE_ERROR_SESSION_EXPIRED", comment: "")
+        }
+
+        // 3. Payment / Plan limit (402)
+        if message.contains("402") || lower.contains("payment required") {
+            return NSLocalizedString("ISSUE_ERROR_PLAN_LIMIT", comment: "")
+        }
+
+        // 4. Not Found (404)
+        if message.contains("404") || lower.contains("not found") {
+            return NSLocalizedString("ISSUE_ERROR_NOT_FOUND", comment: "")
+        }
+
+        // 5. Conflict / Exists (409)
+        if message.contains("409") || lower.contains("conflict") || lower.contains("already exists") {
+            return NSLocalizedString("ISSUE_ERROR_ALREADY_EXISTS", comment: "")
+        }
+
+        // 6. Server Errors (500-599)
+        if message.contains("500") || message.contains("502") || message.contains("503") || message.contains("504") || lower.contains("server error") {
+            return NSLocalizedString("ISSUE_ERROR_SERVER", comment: "")
+        }
+
+        // 7. Enriched Error Codes
+        // Upload
+        if message.contains("UPL-001") {
+            return NSLocalizedString("ISSUE_ERROR_NETWORK", comment: "")
+        }
+        if message.contains("UPL-002") {
+            return NSLocalizedString("ISSUE_ERROR_TIMEOUT", comment: "")
+        }
+        if message.contains("UPL-003") || message.contains("UPL-004") {
+            return NSLocalizedString("ISSUE_ERROR_GENERIC_UPLOAD", comment: "")
+        }
+        if message.contains("UPL-005") || message.contains("ENC-") {
+            return NSLocalizedString("ISSUE_ERROR_ENCRYPTION", comment: "")
+        }
+        if message.contains("UPL-006") || lower.contains("size mismatch") {
+            return NSLocalizedString("ISSUE_ERROR_SIZE_MISMATCH", comment: "")
+        }
+        if message.contains("UPL-") {
+            return NSLocalizedString("ISSUE_ERROR_GENERIC_UPLOAD", comment: "")
+        }
+
+        // Download
+        if message.contains("DWN-002") || message.contains("DEC-") {
+            return NSLocalizedString("ISSUE_ERROR_DECRYPTION", comment: "")
+        }
+        if message.contains("DWN-003") || lower.contains("hash mismatch") {
+            return NSLocalizedString("ISSUE_ERROR_INTEGRITY", comment: "")
+        }
+        if message.contains("DWN-") {
+            return NSLocalizedString("ISSUE_ERROR_GENERIC_DOWNLOAD", comment: "")
+        }
+
+        // Network
+        if message.contains("NET-001") || lower.contains("timed out") || message.contains("-1001") {
+            return NSLocalizedString("ISSUE_ERROR_TIMEOUT", comment: "")
+        }
+        if message.contains("NET-002") || message.contains("-1009") || lower.contains("not connected to the internet") || lower.contains("offline") {
+            return NSLocalizedString("ISSUE_ERROR_NO_INTERNET", comment: "")
+        }
+        if message.contains("NET-003") || message.contains("-1005") || lower.contains("connection was lost") {
+            return NSLocalizedString("ISSUE_ERROR_CONNECTION_LOST", comment: "")
+        }
+        if message.contains("NET-004") || message.contains("-1004") || lower.contains("cannot connect") || lower.contains("websocket") {
+            return NSLocalizedString("ISSUE_ERROR_NETWORK", comment: "")
+        }
+
+        // Catch-all for step messages
+        if message.contains("Step: upload") {
+            return NSLocalizedString("ISSUE_ERROR_GENERIC_UPLOAD", comment: "")
+        }
+        if message.contains("Step: download") {
+            return NSLocalizedString("ISSUE_ERROR_GENERIC_DOWNLOAD", comment: "")
+        }
+        if message.contains("APIClientError") {
+            return NSLocalizedString("ISSUE_ERROR_SERVER", comment: "")
+        }
+
+        // If it's a short, user-friendly message already (no technical brackets or pipes)
+        if !message.contains("[") && !message.contains("|") && !message.contains("Error:") && message.count <= 60 {
+            return message
+        }
+
+        return NSLocalizedString("ISSUE_ERROR_NETWORK", comment: "")
+    }
 }
 
 extension Notification.Name {

--- a/Shared/Models/Issue.swift
+++ b/Shared/Models/Issue.swift
@@ -48,6 +48,7 @@ struct Issue: Identifiable, Equatable {
     let id: UUID
     let category: IssueCategory
     let filename: String
+    let relativePath: String?
     let operation: IssueOperation
     let errorDescription: String?
     let date: Date
@@ -56,6 +57,7 @@ struct Issue: Identifiable, Equatable {
         id: UUID = UUID(),
         category: IssueCategory,
         filename: String,
+        relativePath: String? = nil,
         operation: IssueOperation,
         errorDescription: String? = nil,
         date: Date = Date()
@@ -63,9 +65,27 @@ struct Issue: Identifiable, Equatable {
         self.id = id
         self.category = category
         self.filename = filename
+        self.relativePath = relativePath
         self.operation = operation
         self.errorDescription = errorDescription
         self.date = date
+    }
+
+    var userFriendlyErrorDescription: String? {
+        return ErrorFormatter.userFriendlyDescription(from: errorDescription)
+    }
+
+    var fullHelpText: String {
+        var parts: [String] = []
+        if let path = relativePath, !path.isEmpty {
+            parts.append(path)
+        } else {
+            parts.append(filename)
+        }
+        if let technical = errorDescription, !technical.isEmpty {
+            parts.append(technical)
+        }
+        return parts.joined(separator: "\n")
     }
 
     static func == (lhs: Issue, rhs: Issue) -> Bool {
@@ -103,6 +123,7 @@ extension Issue {
             id: stableID,
             category: (entry.kind == .backupDownload || entry.kind == .backupUpload) ? .backups : .sync,
             filename: entry.filename,
+            relativePath: entry.relativePath,
             operation: operation,
             errorDescription: entry.errorMessage,
             date: entry.createdAt

--- a/Shared/Services/ActivityManager.swift
+++ b/Shared/Services/ActivityManager.swift
@@ -63,7 +63,8 @@ class ActivityManager: ObservableObject {
         filename: String,
         kind: ActivityEntryOperationKind,
         status: ActivityEntryStatus,
-        errorMessage: String? = nil
+        errorMessage: String? = nil,
+        relativePath: String? = nil
     ) {
         guard let realm = getRealm() else { return }
         if let existing = realm.object(ofType: ActivityEntry.self, forPrimaryKey: id) {
@@ -72,12 +73,13 @@ class ActivityManager: ObservableObject {
                     existing.filename = filename
                     existing.status = status
                     if let msg = errorMessage { existing.errorMessage = msg }
+                    if let path = relativePath { existing.relativePath = path }
                 }
             } catch {
                 error.reportToSentry()
             }
         } else {
-            saveActivityEntry(entry: ActivityEntry(_id: id, filename: filename, kind: kind, status: status, errorMessage: errorMessage))
+            saveActivityEntry(entry: ActivityEntry(_id: id, filename: filename, kind: kind, status: status, errorMessage: errorMessage, relativePath: relativePath))
         }
     }
 
@@ -138,13 +140,15 @@ class ActivityEntry: Object {
     @Persisted var kind: ActivityEntryOperationKind
     @Persisted var status: ActivityEntryStatus
     @Persisted var errorMessage: String?
+    @Persisted var relativePath: String?
 
     convenience init(
         _id: ObjectId? = nil,
         filename: String,
         kind: ActivityEntryOperationKind,
         status: ActivityEntryStatus,
-        errorMessage: String? = nil
+        errorMessage: String? = nil,
+        relativePath: String? = nil
     ) {
         self.init()
         self._id = _id ?? ObjectId.generate()
@@ -153,6 +157,7 @@ class ActivityEntry: Object {
         self.kind = kind
         self.status = status
         self.errorMessage = errorMessage
+        self.relativePath = relativePath
     }
 }
 

--- a/Shared/Services/Backups/BackupErrorFileQueue.swift
+++ b/Shared/Services/Backups/BackupErrorFileQueue.swift
@@ -25,8 +25,12 @@ final class BackupErrorFileQueue {
         try? FileManager.default.removeItem(at: fileURL)
     }
 
-    func append(filename: String, errorMessage: String) {
-        guard let data = "{\"filename\":\(jsonEscape(filename)),\"error\":\(jsonEscape(errorMessage))}\n".data(using: .utf8) else { return }
+    func append(filename: String, errorMessage: String, relativePath: String? = nil) {
+        var dict: [String: String] = ["filename": filename, "error": errorMessage]
+        if let path = relativePath { dict["relativePath"] = path }
+        guard let data = try? JSONSerialization.data(withJSONObject: dict),
+              let jsonString = String(data: data, encoding: .utf8),
+              let lineData = (jsonString + "\n").data(using: .utf8) else { return }
         
         writeLock.lock()
         defer { writeLock.unlock() }
@@ -34,16 +38,16 @@ final class BackupErrorFileQueue {
         if FileManager.default.fileExists(atPath: fileURL.path) {
             if let handle = try? FileHandle(forWritingTo: fileURL) {
                 handle.seekToEndOfFile()
-                handle.write(data)
+                handle.write(lineData)
                 handle.closeFile()
             }
         } else {
-            try? data.write(to: fileURL)
+            try? lineData.write(to: fileURL)
         }
     }
 
 
-    func readAndClear() -> [(filename: String, error: String)] {
+    func readAndClear() -> [(filename: String, error: String, relativePath: String?)] {
         writeLock.lock()
         defer {
             try? FileManager.default.removeItem(at: fileURL)
@@ -54,12 +58,12 @@ final class BackupErrorFileQueue {
         
         return content
             .split(separator: "\n", omittingEmptySubsequences: true)
-            .compactMap { line -> (String, String)? in
+            .compactMap { line -> (String, String, String?)? in
                 guard let data = line.data(using: .utf8),
                       let json = try? JSONSerialization.jsonObject(with: data) as? [String: String],
                       let filename = json["filename"],
                       let error = json["error"] else { return nil }
-                return (filename, error)
+                return (filename, error, json["relativePath"])
             }
     }
 

--- a/Shared/Services/Backups/BackupsService.swift
+++ b/Shared/Services/Backups/BackupsService.swift
@@ -426,7 +426,8 @@ class BackupsService: ObservableObject {
                     filename: fileError.filename,
                     kind: .backupDownload,
                     status: .failed,
-                    errorMessage: fileError.error
+                    errorMessage: fileError.error,
+                    relativePath: fileError.relativePath
                 )
             }
             activityManager.saveActivityEntries(entries: entries)

--- a/Shared/Services/Backups/BackupsService.swift
+++ b/Shared/Services/Backups/BackupsService.swift
@@ -417,6 +417,41 @@ class BackupsService: ObservableObject {
         }
     }
 
+    private func propagateDownloadErrors(fallbackFilename: String, error: String?, onSuccess: (() -> Void)? = nil) {
+        let individualErrors = BackupErrorFileQueue.shared.readAndClear()
+
+        if !individualErrors.isEmpty {
+            let entries = individualErrors.map { fileError in
+                ActivityEntry(
+                    filename: fileError.filename,
+                    kind: .backupDownload,
+                    status: .failed,
+                    errorMessage: fileError.error
+                )
+            }
+            activityManager.saveActivityEntries(entries: entries)
+            DispatchQueue.main.async { [weak self] in
+                self?.backupDownloadStatus = .Failed
+            }
+        } else if let error = error {
+            let entry = ActivityEntry(
+                filename: fallbackFilename,
+                kind: .backupDownload,
+                status: .failed,
+                errorMessage: error
+            )
+            activityManager.saveActivityEntry(entry: entry)
+            DispatchQueue.main.async { [weak self] in
+                self?.backupDownloadStatus = .Failed
+            }
+        } else {
+            DispatchQueue.main.async { [weak self] in
+                self?.backupDownloadStatus = .Done
+            }
+            onSuccess?()
+        }
+    }
+
     private func propagateUploadSuccess() {
         logger.info("Device backed up successfully, tracking backup success event")
         UserDefaults.standard.set(Date(), forKey: LAST_BACKUP_TIME_KEY)
@@ -549,15 +584,14 @@ class BackupsService: ObservableObject {
             deviceUuid:device.uuid,
             bucketId: deviceBucketId,
             with: {result, error in
-                if error == nil {
-                    DispatchQueue.main.async {
-                        self.backupDownloadStatus = .Done
+                self.backupDownloadProgressTimer?.cancel()
+                self.propagateDownloadErrors(
+                    fallbackFilename: device.plainName ?? "Backup",
+                    error: error,
+                    onSuccess: {
+                        self.completeBackupDownload()
                     }
-                    
-                    self.completeBackupDownload()
-                } else {
-                    self.backupDownloadStatus = .Failed
-                }
+                )
                 self.logger.info(["Received backup download response", result, error])
             }
         )
@@ -612,15 +646,18 @@ class BackupsService: ObservableObject {
             folderId:folderId,
             bucketId: deviceBucketId, folderName: folderName ?? "",
             with: {result, error in
-                if error == nil {
-                    DispatchQueue.main.async {
-                        self.removeItem(item: itemBackup)
-                        self.backupDownloadStatus = .Done
-                    }
-                    self.logger.info("Backup Folder downloaded✅")
-                } else {
+                self.backupDownloadProgressTimer?.cancel()
+                DispatchQueue.main.async {
                     self.removeItem(item: itemBackup)
                 }
+                let fallback = (folderName?.isEmpty == false) ? folderName! : (device.plainName ?? "Backup Folder")
+                self.propagateDownloadErrors(
+                    fallbackFilename: fallback,
+                    error: error,
+                    onSuccess: {
+                        self.logger.info("Backup Folder downloaded✅")
+                    }
+                )
                 self.logger.info(["Received backup download response", result, error])
             }
         )
@@ -671,17 +708,16 @@ class BackupsService: ObservableObject {
             fileId:fileId,
             bucketId: deviceBucketId,
             with: {result, error in
-                if error == nil {
-                    DispatchQueue.main.async {
-                        self.removeItem(item: itemBackup)
-                        
-                    }
-                    self.logger.info("Backup file downloaded✅")
-                    
-                } else {
+                DispatchQueue.main.async {
                     self.removeItem(item: itemBackup)
-                    self.logger.info("Error to download file \(error ?? "Unknown Error")")
                 }
+                self.propagateDownloadErrors(
+                    fallbackFilename: downloadAt.lastPathComponent,
+                    error: error,
+                    onSuccess: {
+                        self.logger.info("Backup file downloaded✅")
+                    }
+                )
             }
         )
     }
@@ -779,11 +815,6 @@ class BackupsService: ObservableObject {
             
             if(backupDownloadStatus.status == .Done || backupDownloadStatus.status == .Failed) {
                 self.backupDownloadProgressTimer?.cancel()
-                if backupDownloadStatus.status == .Failed {
-                    let deviceName = self.deviceDownloading?.plainName ?? "Backup"
-                    let entry = ActivityEntry(filename: deviceName, kind: .backupDownload, status: .failed, errorMessage: "Backup download failed")
-                    self.activityManager.saveActivityEntry(entry: entry)
-                }
             }
         }
     }

--- a/Shared/en.lproj/Localizable.strings
+++ b/Shared/en.lproj/Localizable.strings
@@ -49,6 +49,24 @@
 "ISSUE_OP_CREATE"   = "Create failed";
 "ISSUE_OP_TRASH"    = "Trash failed";
 
+// Issues — friendly error descriptions
+"ISSUE_ERROR_NETWORK"         = "Network connectivity error";
+"ISSUE_ERROR_NO_INTERNET"     = "No internet connection";
+"ISSUE_ERROR_CONNECTION_LOST" = "Connection lost";
+"ISSUE_ERROR_TIMEOUT"         = "Connection timed out";
+"ISSUE_ERROR_STORAGE_FULL"    = "Storage limit reached";
+"ISSUE_ERROR_SESSION_EXPIRED" = "Session expired";
+"ISSUE_ERROR_PLAN_LIMIT"      = "Storage plan limit reached";
+"ISSUE_ERROR_NOT_FOUND"       = "Item not found";
+"ISSUE_ERROR_ALREADY_EXISTS"  = "Item already exists";
+"ISSUE_ERROR_SERVER"          = "Server error";
+"ISSUE_ERROR_ENCRYPTION"      = "Encryption error";
+"ISSUE_ERROR_DECRYPTION"      = "Decryption error";
+"ISSUE_ERROR_INTEGRITY"       = "File integrity check failed";
+"ISSUE_ERROR_SIZE_MISMATCH"   = "File size mismatch";
+"ISSUE_ERROR_GENERIC_UPLOAD"  = "Upload error";
+"ISSUE_ERROR_GENERIC_DOWNLOAD"= "Download error";
+
 
 // Widget sync status
 "SYNC_STATUS_UP_TO_DATE" = "Everything is up to date";

--- a/Shared/es.lproj/Localizable.strings
+++ b/Shared/es.lproj/Localizable.strings
@@ -49,6 +49,24 @@
 "ISSUE_OP_CREATE"   = "Error al crear";
 "ISSUE_OP_TRASH"    = "Error al mover a la papelera";
 
+// Issues — friendly error descriptions
+"ISSUE_ERROR_NETWORK"         = "Error de conexión de red";
+"ISSUE_ERROR_NO_INTERNET"     = "Sin conexión a internet";
+"ISSUE_ERROR_CONNECTION_LOST" = "Conexión perdida";
+"ISSUE_ERROR_TIMEOUT"         = "Tiempo de espera agotado";
+"ISSUE_ERROR_STORAGE_FULL"    = "Límite de almacenamiento alcanzado";
+"ISSUE_ERROR_SESSION_EXPIRED" = "Sesión expirada";
+"ISSUE_ERROR_PLAN_LIMIT"      = "Límite del plan de almacenamiento alcanzado";
+"ISSUE_ERROR_NOT_FOUND"       = "Elemento no encontrado";
+"ISSUE_ERROR_ALREADY_EXISTS"  = "El elemento ya existe";
+"ISSUE_ERROR_SERVER"          = "Error del servidor";
+"ISSUE_ERROR_ENCRYPTION"      = "Error de cifrado";
+"ISSUE_ERROR_DECRYPTION"      = "Error de descifrado";
+"ISSUE_ERROR_INTEGRITY"       = "Error de integridad del archivo";
+"ISSUE_ERROR_SIZE_MISMATCH"   = "El tamaño del archivo no coincide";
+"ISSUE_ERROR_GENERIC_UPLOAD"  = "Error al subir";
+"ISSUE_ERROR_GENERIC_DOWNLOAD"= "Error al descargar";
+
 
 // Widget sync status
 "SYNC_STATUS_UP_TO_DATE" = "Todo está actualizado";

--- a/Shared/fr.lproj/Localizable.strings
+++ b/Shared/fr.lproj/Localizable.strings
@@ -49,6 +49,24 @@
 "ISSUE_OP_CREATE"   = "Échec de la création";
 "ISSUE_OP_TRASH"    = "Échec du déplacement vers la corbeille";
 
+// Issues — friendly error descriptions
+"ISSUE_ERROR_NETWORK"         = "Erreur de connexion réseau";
+"ISSUE_ERROR_NO_INTERNET"     = "Pas de connexion internet";
+"ISSUE_ERROR_CONNECTION_LOST" = "Connexion perdue";
+"ISSUE_ERROR_TIMEOUT"         = "Délai de connexion dépassé";
+"ISSUE_ERROR_STORAGE_FULL"    = "Limite de stockage atteinte";
+"ISSUE_ERROR_SESSION_EXPIRED" = "Session expirée";
+"ISSUE_ERROR_PLAN_LIMIT"      = "Limite du forfait atteinte";
+"ISSUE_ERROR_NOT_FOUND"       = "Élément introuvable";
+"ISSUE_ERROR_ALREADY_EXISTS"  = "L'élément existe déjà";
+"ISSUE_ERROR_SERVER"          = "Erreur du serveur";
+"ISSUE_ERROR_ENCRYPTION"      = "Erreur de chiffrement";
+"ISSUE_ERROR_DECRYPTION"      = "Erreur de déchiffrement";
+"ISSUE_ERROR_INTEGRITY"       = "Échec de vérification du fichier";
+"ISSUE_ERROR_SIZE_MISMATCH"   = "Taille du fichier non concordante";
+"ISSUE_ERROR_GENERIC_UPLOAD"  = "Erreur de téléversement";
+"ISSUE_ERROR_GENERIC_DOWNLOAD"= "Erreur de téléchargement";
+
 
 // Widget sync status
 "SYNC_STATUS_UP_TO_DATE" = "Tout est à jour";

--- a/SyncExtension/FileProviderExtension.swift
+++ b/SyncExtension/FileProviderExtension.swift
@@ -487,6 +487,7 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension, NSFile
                         }
                     }
 
+                    let relativePath = await self.resolveRelativePath(for: modifiedFilename, parentIdentifier: itemTemplate.parentItemIdentifier)
                     let useCaseProgress: Progress
 
                     if self.isWorkspaceDomain() {
@@ -519,7 +520,8 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension, NSFile
                             encryptedThumbnailFileDestination: encryptedThumbnailFileDestination,
                             completionHandler: completionHandlerInternal,
                             workspace: self.workspace,
-                            workspaceCredentials: credentials
+                            workspaceCredentials: credentials,
+                            relativePath: relativePath
                         )
 
                         useCaseProgress = useCase.run()
@@ -542,7 +544,8 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension, NSFile
                             thumbnailFileDestination: thumbnailFileDestination,
                             encryptedThumbnailFileDestination: encryptedThumbnailFileDestination,
                             completionHandler: completionHandlerInternal,
-                            parentUuid: parentUuid
+                            parentUuid: parentUuid,
+                            relativePath: relativePath
                         )
 
                         useCaseProgress = useCase.run()
@@ -880,6 +883,35 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension, NSFile
         }
     }
 
-            
+    private func resolveRelativePath(for itemFilename: String, parentIdentifier: NSFileProviderItemIdentifier) async -> String {
+        let rootDriveName = "InternxtDrive"
+        if parentIdentifier == .rootContainer {
+            return "\(rootDriveName)/\(itemFilename)"
+        }
+
+        do {
+            let parentURL = try await self.manager.getUserVisibleURL(for: parentIdentifier)
+            let rootURL = try await self.manager.getUserVisibleURL(for: .rootContainer)
+            let parentPath = parentURL.path
+            let rootPath = rootURL.path
+            if parentPath.hasPrefix(rootPath) {
+                let subPath = String(parentPath.dropFirst(rootPath.count)).trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+                if !subPath.isEmpty {
+                    return "\(rootDriveName)/\(subPath)/\(itemFilename)"
+                }
+            }
+        } catch {
+            logger.warning("Could not get visible URL for parentIdentifier: \(error.getErrorDescription())")
+        }
+
+        let parentId = parentIdentifier.rawValue
+        if let folderMeta = try? await self.driveNewAPI.getFolderMetaById(id: parentId, debug: false),
+           let plainName = folderMeta.plainName, !plainName.isEmpty {
+            return "\(rootDriveName)/\(plainName)/\(itemFilename)"
+        }
+
+        return "\(rootDriveName)/\(itemFilename)"
+    }
+
 }
 

--- a/SyncExtension/UseCases/Files/DownloadFileUseCase.swift
+++ b/SyncExtension/UseCases/Files/DownloadFileUseCase.swift
@@ -138,6 +138,7 @@ struct DownloadFileUseCase {
             let uuidString = itemIdentifier.rawValue.replacingOccurrences(of: "-", with: "").prefix(24)
             let trackingObjectId = try? ObjectId(string: String(uuidString))
             
+            var resolvedFilename: String = itemIdentifier.rawValue
             var driveFile: DriveFile? = nil
             do {
                 
@@ -154,6 +155,7 @@ struct DownloadFileUseCase {
             
                     let folder = try await driveNewAPI.getFolderMetaById(id: idString)
                     let folderName = folder.plainName ?? folder.name ?? ""
+                    resolvedFilename = folderName
                     
                     if let trackingObjectId = trackingObjectId {
                         activityManager.updateActivityEntryStatus(id: trackingObjectId, filename: folderName, kind: .download, status: .inProgress)
@@ -195,6 +197,7 @@ struct DownloadFileUseCase {
                 }
                 
                 let currentFilename = FileProviderItem.getFilename(name: file.plainName ?? file.name, itemExtension: file.type)
+                resolvedFilename = currentFilename
                 if let trackingObjectId = trackingObjectId {
                     activityManager.updateActivityEntryStatus(id: trackingObjectId, filename: currentFilename, kind: .download, status: .inProgress)
                 }
@@ -285,7 +288,7 @@ struct DownloadFileUseCase {
                 self.logger.error("❌ Failed to fetch file content for file with identifier \(itemIdentifier.rawValue): \(error.getErrorDescription())")
                 
                 if let trackingObjectId = trackingObjectId {
-                    activityManager.updateActivityEntryStatus(id: trackingObjectId, filename: itemIdentifier.rawValue, kind: .download, status: .failed, errorMessage: error.getErrorDescription())
+                    activityManager.updateActivityEntryStatus(id: trackingObjectId, filename: resolvedFilename, kind: .download, status: .failed, errorMessage: error.getErrorDescription())
                 }
                 completionHandler(nil, nil, NSError(domain: NSFileProviderErrorDomain, code: NSFileProviderError.cannotSynchronize.rawValue))
             }

--- a/SyncExtension/UseCases/Files/UploadFileOrUpdateContentUseCase.swift
+++ b/SyncExtension/UseCases/Files/UploadFileOrUpdateContentUseCase.swift
@@ -28,6 +28,7 @@ struct UploadFileOrUpdateContentUseCase {
     private let activityManager: ActivityManager
     private let trackId = UUID().uuidString
     private let parentUUID: String
+    private let relativePath: String?
     init(
         networkFacade: NetworkFacade,
         user: DriveUser,
@@ -38,7 +39,8 @@ struct UploadFileOrUpdateContentUseCase {
         thumbnailFileDestination:URL,
         encryptedThumbnailFileDestination: URL,
         completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void,
-        parentUuid: String
+        parentUuid: String,
+        relativePath: String? = nil
     ) {
         self.item = item
         self.activityManager = activityManager
@@ -50,6 +52,7 @@ struct UploadFileOrUpdateContentUseCase {
         self.networkFacade = networkFacade
         self.user = user
         self.parentUUID = parentUuid
+        self.relativePath = relativePath
     }
     
     private func fileAlreadyExistsByName() async -> GetExistenceFileInFolderResponse? {
@@ -87,7 +90,8 @@ struct UploadFileOrUpdateContentUseCase {
                     encryptedThumbnailFileDestination: self.encryptedThumbnailFileDestination,
                     completionHandler: self.completionHandler,
                     progress: progress,
-                    parentUuid: parentUUID
+                    parentUuid: parentUUID,
+                    relativePath: self.relativePath
                 ).run()
             }
             

--- a/SyncExtension/UseCases/Files/UploadFileUseCase.swift
+++ b/SyncExtension/UseCases/Files/UploadFileUseCase.swift
@@ -37,6 +37,7 @@ struct UploadFileUseCase {
     private let trackId = UUID().uuidString
     private let progress: Progress
     private let parentUUID: String
+    private let relativePath: String?
     init(
         networkFacade: NetworkFacade,
         user: DriveUser,
@@ -48,7 +49,8 @@ struct UploadFileUseCase {
         encryptedThumbnailFileDestination: URL,
         completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void,
         progress: Progress,
-        parentUuid: String
+        parentUuid: String,
+        relativePath: String? = nil
     ) {
         self.item = item
         self.activityManager = activityManager
@@ -61,6 +63,7 @@ struct UploadFileUseCase {
         self.user = user
         self.progress = progress
         self.parentUUID = parentUuid
+        self.relativePath = relativePath
     }
     
    
@@ -85,7 +88,7 @@ struct UploadFileUseCase {
         Task {
           
             let inProgressId = ObjectId.generate()
-            activityManager.saveActivityEntry(entry: ActivityEntry(_id: inProgressId, filename: item.filename, kind: .upload, status: .inProgress))
+            activityManager.saveActivityEntry(entry: ActivityEntry(_id: inProgressId, filename: item.filename, kind: .upload, status: .inProgress, relativePath: self.relativePath))
             
             do {
                 var isPackage = FileProviderItem.isPackage(filename: item.filename)
@@ -149,7 +152,7 @@ struct UploadFileUseCase {
                         size: 0
                     )
                     completionHandler(fileProviderItem, [], false, nil)
-                    activityManager.updateActivityEntryStatus(id: inProgressId, filename: item.filename, kind: .upload, status: .finished)
+                    activityManager.updateActivityEntryStatus(id: inProgressId, filename: item.filename, kind: .upload, status: .finished, relativePath: self.relativePath)
                     return
                 }
 
@@ -246,12 +249,12 @@ struct UploadFileUseCase {
                 )
                 
                 completionHandler(fileProviderItem, [], false, nil )
-                activityManager.updateActivityEntryStatus(id: inProgressId, filename: FileProviderItem.getFilename(name: createdFile.plain_name, itemExtension: createdFile.type), kind: .upload, status: .finished)
+                activityManager.updateActivityEntryStatus(id: inProgressId, filename: FileProviderItem.getFilename(name: createdFile.plain_name, itemExtension: createdFile.type), kind: .upload, status: .finished, relativePath: self.relativePath)
 
                 
             } catch {
                 error.reportToSentry()
-                activityManager.updateActivityEntryStatus(id: inProgressId, filename: item.filename, kind: .upload, status: .failed, errorMessage: error.getErrorDescription())
+                activityManager.updateActivityEntryStatus(id: inProgressId, filename: item.filename, kind: .upload, status: .failed, errorMessage: error.getErrorDescription(), relativePath: self.relativePath)
                 self.logger.error("❌ Failed to create file \(item.filename) : \(error.getErrorDescription())")
                 completionHandler(nil, [], false, error.toFileProviderError())
             }

--- a/SyncExtension/UseCases/Files/Workspaces/UploadFileOrUpdateContentWorkspaceUseCase.swift
+++ b/SyncExtension/UseCases/Files/Workspaces/UploadFileOrUpdateContentWorkspaceUseCase.swift
@@ -26,6 +26,7 @@ struct UploadFileOrUpdateContentWorkspaceUseCase {
     private let activityManager: ActivityManager
     private let workspace: [AvailableWorkspace]
     private let workspaceCredentials: WorkspaceCredentialsResponse
+    private let relativePath: String?
     init(
         networkFacade: NetworkFacade,
         user: DriveUser,
@@ -37,7 +38,8 @@ struct UploadFileOrUpdateContentWorkspaceUseCase {
         encryptedThumbnailFileDestination: URL,
         completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void,
         workspace: [AvailableWorkspace],
-        workspaceCredentials: WorkspaceCredentialsResponse
+        workspaceCredentials: WorkspaceCredentialsResponse,
+        relativePath: String? = nil
     ) {
         self.item = item
         self.activityManager = activityManager
@@ -50,6 +52,7 @@ struct UploadFileOrUpdateContentWorkspaceUseCase {
         self.user = user
         self.workspace = workspace
         self.workspaceCredentials = workspaceCredentials
+        self.relativePath = relativePath
     }
     
     private func fileAlreadyExistsByName() async -> GetExistenceFileInFolderResponse? {
@@ -94,7 +97,8 @@ struct UploadFileOrUpdateContentWorkspaceUseCase {
                     thumbnailFileDestination: self.thumbnailFileDestination,
                     encryptedThumbnailFileDestination: self.encryptedThumbnailFileDestination,
                     completionHandler: self.completionHandler,
-                    progress: progress, workspace: self.workspace, workspaceCredentials: workspaceCredentials
+                    progress: progress, workspace: self.workspace, workspaceCredentials: workspaceCredentials,
+                    relativePath: self.relativePath
                 ).run()
             }
             

--- a/SyncExtension/UseCases/Files/Workspaces/UploadFileWorkspaceUseCase.swift
+++ b/SyncExtension/UseCases/Files/Workspaces/UploadFileWorkspaceUseCase.swift
@@ -31,6 +31,7 @@ struct UploadFileWorkspaceUseCase {
     private let progress: Progress
     private let workspace: [AvailableWorkspace]
     private let workspaceCredentials: WorkspaceCredentialsResponse
+    private let relativePath: String?
     init(
         networkFacade: NetworkFacade,
         user: DriveUser,
@@ -43,8 +44,8 @@ struct UploadFileWorkspaceUseCase {
         completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void,
         progress: Progress,
         workspace: [AvailableWorkspace],
-        workspaceCredentials: WorkspaceCredentialsResponse
-        
+        workspaceCredentials: WorkspaceCredentialsResponse,
+        relativePath: String? = nil
     ) {
         self.item = item
         self.activityManager = activityManager
@@ -58,6 +59,7 @@ struct UploadFileWorkspaceUseCase {
         self.progress = progress
         self.workspace = workspace
         self.workspaceCredentials = workspaceCredentials
+        self.relativePath = relativePath
     }
     
    
@@ -123,7 +125,7 @@ struct UploadFileWorkspaceUseCase {
         Task {
            
             let inProgressId = ObjectId.generate()
-            activityManager.saveActivityEntry(entry: ActivityEntry(_id: inProgressId, filename: item.filename, kind: .upload, status: .inProgress))
+            activityManager.saveActivityEntry(entry: ActivityEntry(_id: inProgressId, filename: item.filename, kind: .upload, status: .inProgress, relativePath: self.relativePath))
             
             do {
                 let parentIdIsRootFolder = FileProviderItem.parentIdIsRootFolder(identifier: item.parentItemIdentifier)
@@ -228,12 +230,12 @@ struct UploadFileWorkspaceUseCase {
                 }
                 
                 completionHandler(fileProviderItem, [], false, nil )
-                activityManager.updateActivityEntryStatus(id: inProgressId, filename: FileProviderItem.getFilename(name: createdFile.plain_name, itemExtension: createdFile.type), kind: .upload, status: .finished)
+                activityManager.updateActivityEntryStatus(id: inProgressId, filename: FileProviderItem.getFilename(name: createdFile.plain_name, itemExtension: createdFile.type), kind: .upload, status: .finished, relativePath: self.relativePath)
                 
             } catch {
                 self.trackError(processIdentifier: trackId, error: error)
                 error.reportToSentry()
-                activityManager.updateActivityEntryStatus(id: inProgressId, filename: item.filename, kind: .upload, status: .failed)
+                activityManager.updateActivityEntryStatus(id: inProgressId, filename: item.filename, kind: .upload, status: .failed, errorMessage: error.getErrorDescription(), relativePath: self.relativePath)
                 self.logger.error("❌ Failed to create file: \(error.getErrorDescription())")
                 completionHandler(nil, [], false, error.toFileProviderError())
             }

--- a/XPCBackupService/Entities/BackupDownloadItemOperation.swift
+++ b/XPCBackupService/Entities/BackupDownloadItemOperation.swift
@@ -28,10 +28,15 @@ class BackupDownloadItemOperation: AsyncOperation, @unchecked Sendable {
     
     
     override func performAsyncTask() async throws -> Void {
+        let encryptedFileURL = self.encryptedContentURL.appendingPathComponent(UUID().uuidString)
+        defer {
+            logger.info("🧹 Cleaning up encrypted file...")
+            try? FileManager.default.removeItem(at: encryptedFileURL)
+        }
+
         do {
             self.downloadAttempts += 1
             logger.info("⬇️ Downloading file at \(downloadAt.path) with fileID \(fileId)")
-            let encryptedFileURL = self.encryptedContentURL.appendingPathComponent(UUID().uuidString)
            
             let _ = try await networkFacade.downloadFile(
                 bucketId: bucketId,
@@ -43,16 +48,14 @@ class BackupDownloadItemOperation: AsyncOperation, @unchecked Sendable {
             )
             
             backupDownloadProgress.completedUnitCount += 1
-            
-            defer {
-                logger.info("🧹 Cleaning up encrypted file...")
-                try? FileManager.default.removeItem(at: encryptedContentURL)
-            }
-            
             logger.info("✅ File downloaded at \(downloadAt.path)")
         } catch {
-            if downloadAttempts == MAX_DOWNLOAD_ATTEMPTS {
-                logger.error("❌ Failed to download file at \(downloadAt.path)")
+            if downloadAttempts >= MAX_DOWNLOAD_ATTEMPTS {
+                logger.error("❌ Failed to download file at \(downloadAt.path): \(error.getErrorDescription())")
+                BackupErrorFileQueue.shared.append(
+                    filename: downloadAt.lastPathComponent,
+                    errorMessage: error.getErrorDescription()
+                )
             } else {
                 logger.error("🔄 Retrying file download, attempt #\(downloadAttempts) for file at \(downloadAt.path)")
                 try? await self.performAsyncTask()

--- a/XPCBackupService/Entities/BackupDownloadItemOperation.swift
+++ b/XPCBackupService/Entities/BackupDownloadItemOperation.swift
@@ -52,9 +52,12 @@ class BackupDownloadItemOperation: AsyncOperation, @unchecked Sendable {
         } catch {
             if downloadAttempts >= MAX_DOWNLOAD_ATTEMPTS {
                 logger.error("❌ Failed to download file at \(downloadAt.path): \(error.getErrorDescription())")
+                let parentFolderName = downloadAt.deletingLastPathComponent().lastPathComponent
+                let relativePath = parentFolderName.isEmpty ? downloadAt.lastPathComponent : "\(parentFolderName)/\(downloadAt.lastPathComponent)"
                 BackupErrorFileQueue.shared.append(
                     filename: downloadAt.lastPathComponent,
-                    errorMessage: error.getErrorDescription()
+                    errorMessage: error.getErrorDescription(),
+                    relativePath: relativePath
                 )
             } else {
                 logger.error("🔄 Retrying file download, attempt #\(downloadAttempts) for file at \(downloadAt.path)")

--- a/XPCBackupService/XPCBackupService.swift
+++ b/XPCBackupService/XPCBackupService.swift
@@ -223,6 +223,7 @@ public class XPCBackupService: NSObject, XPCBackupServiceProtocol {
         bucketId: String,
         with reply: @escaping (_ result: String?, _ error: String?) -> Void
     ) {
+        BackupErrorFileQueue.shared.startNewSession()
         self.backupDownloadStatus = .InProgress
         self.backupDownloadProgress = Progress()
         let downloadAtURL = URL(fileURLWithPath: downloadAtURL)
@@ -274,7 +275,7 @@ public class XPCBackupService: NSObject, XPCBackupServiceProtocol {
         folderName: String,
         with reply: @escaping (_ result: String?, _ error: String?) -> Void
     ) {
-        
+        BackupErrorFileQueue.shared.startNewSession()
         self.backupDownloadStatus = .InProgress
         self.backupDownloadProgress = Progress()
         let downloadAtURL = URL(fileURLWithPath: downloadAtURL)
@@ -348,8 +349,7 @@ public class XPCBackupService: NSObject, XPCBackupServiceProtocol {
     }
     
     @objc func downloadFileBackup(downloadAt downloadAtURL: String, networkAuth: String, fileId: String, bucketId: String, with reply: @escaping (String?, String?) -> Void) {
-        
-
+        BackupErrorFileQueue.shared.startNewSession()
         let downloadAtURL = URL(fileURLWithPath: downloadAtURL)
         
         let configManager = BackupConfigurationManager(groupName: INTERNXT_GROUP_NAME, clientName: CLIENT_NAME)
@@ -377,7 +377,6 @@ public class XPCBackupService: NSObject, XPCBackupServiceProtocol {
                 logger.info("Download operations completed")
                 reply(nil, nil)
             }
-            reply(nil,nil)
         }
     }
     


### PR DESCRIPTION
This PR fixes backup download error reporting and improves the Issues View UX on macOS to match Windows:
- **Backup Download Errors**: Captures download failures via `BackupErrorFileQueue` and propagates them to Realm (`ActivityEntry`), ensuring they appear in the Backups tab of Issues View.
- **User-Friendly Error Messages**: Replaces raw debug logs (`[UPL-001]`, `API-420`, etc.) with clean localized descriptions (e.g. *"Network connectivity error"*, *"Storage limit reached"*).
- **Relative File Paths**: Resolves and displays the relative file path under the filename in `IssueRowView` (e.g. `InternxtDrive/Documents/file.pdf`).
- **Preserved Debug Info**: Raw technical errors and paths remain visible via hover tooltip (`.help`) for debugging.
- **Localizations**: Added localized strings in EN, ES, and FR.