### PR TITLE
prevent trashed and deleted items from reappearing in Finder on folder updates

### DIFF
--- a/SyncExtension/UseCases/All/GetFileOrFolderMetaUseCase.swift
+++ b/SyncExtension/UseCases/All/GetFileOrFolderMetaUseCase.swift
@@ -41,8 +41,8 @@ struct GetFileOrFolderMetaUseCase {
                     // File
                     self.logger.info("Trying to get metadata for item \(identifierRaw) as a file")
                     if let fileMeta = await self.getFileMetaOrNil(maybeFileUuid: identifierRaw) {
-                        if fileMeta.status != "EXISTS" || fileMeta.deleted == true || fileMeta.removed == true  {
-                            self.logger.info("❌ File \(fileMeta.plainName ?? fileMeta.name) (id: \(identifierRaw)) is \(fileMeta.status) / deleted, returning nonExistentItem")
+                        if fileMeta.status != "EXISTS" {
+                            self.logger.info("❌ File \(fileMeta.plainName ?? fileMeta.name) (id: \(identifierRaw)) is \(fileMeta.status), returning nonExistentItem")
                             completionHandler(nil, NSError.fileProviderErrorForNonExistentItem(withIdentifier: self.identifier))
                             return
                         }

--- a/SyncExtension/UseCases/All/GetFileOrFolderMetaUseCase.swift
+++ b/SyncExtension/UseCases/All/GetFileOrFolderMetaUseCase.swift
@@ -41,6 +41,12 @@ struct GetFileOrFolderMetaUseCase {
                     // File
                     self.logger.info("Trying to get metadata for item \(identifierRaw) as a file")
                     if let fileMeta = await self.getFileMetaOrNil(maybeFileUuid: identifierRaw) {
+                        if fileMeta.status != "EXISTS" || fileMeta.deleted == true || fileMeta.removed == true  {
+                            self.logger.info("❌ File \(fileMeta.plainName ?? fileMeta.name) (id: \(identifierRaw)) is \(fileMeta.status) / deleted, returning nonExistentItem")
+                            completionHandler(nil, NSError.fileProviderErrorForNonExistentItem(withIdentifier: self.identifier))
+                            return
+                        }
+
                         let parentFolderId = String(fileMeta.folderId)
                         
                         self.logger.info("Parent ID is \(parentFolderId) for file with id \(fileMeta.id)")
@@ -86,8 +92,9 @@ struct GetFileOrFolderMetaUseCase {
                     self.logger.info("Trying to get metadata for item \(identifierRaw) as a folder")
                     if let folderMeta = await self.getFolderMetaOrNil(maybeFolderId: identifierRaw) {
 
-                        
-                        if folderMeta.deleted == true {
+                        if folderMeta.deleted == true || folderMeta.removed == true {
+                            let itemDisplayName = folderMeta.plainName ?? folderMeta.name ?? identifierRaw
+                            self.logger.info("❌ Folder (id: \(identifierRaw), name: '\(itemDisplayName)') is deleted/removed, returning nonExistentItem")
                             completionHandler(nil, NSError.fileProviderErrorForNonExistentItem(withIdentifier: self.identifier))
                             return
                         }

--- a/SyncExtension/UseCases/All/Workspaces/GetFileOrFolderMetaWorkspaceUseCase.swift
+++ b/SyncExtension/UseCases/All/Workspaces/GetFileOrFolderMetaWorkspaceUseCase.swift
@@ -41,6 +41,11 @@ struct GetFileOrFolderMetaWorkspaceUseCase {
                 let rootFolderUuid = workspace[0].workspaceUser.rootFolderId
                
                 if let fileMeta = await self.getFileMetaOrNil(maybeFileUuid: self.identifier.rawValue) {
+                    if fileMeta.status != "EXISTS" || fileMeta.deleted == true || fileMeta.removed == true  {
+                        self.logger.info("❌ Workspace File (id: \(self.identifier.rawValue)) is \(fileMeta.status) / deleted, returning nonExistentItem")
+                        completionHandler(nil, NSError.fileProviderErrorForNonExistentItem(withIdentifier: self.identifier))
+                        return
+                    }
                     
                     guard let folderUuid = fileMeta.folderUuid else {
                         
@@ -84,6 +89,13 @@ struct GetFileOrFolderMetaWorkspaceUseCase {
                 
                 self.logger.info("Trying to get metadata for item \(self.identifier.rawValue) as a folder")
                 if let folderMeta = await self.getFolderMetaOrNil(maybeFolderId: self.identifier.rawValue) {
+                    if folderMeta.deleted == true || folderMeta.removed == true  {
+                        let itemDisplayName = folderMeta.plainName ?? folderMeta.name ?? self.identifier.rawValue
+                        self.logger.info("❌ Workspace Folder (id: \(self.identifier.rawValue), name: '\(itemDisplayName)') is deleted/removed, returning nonExistentItem")
+                        completionHandler(nil, NSError.fileProviderErrorForNonExistentItem(withIdentifier: self.identifier))
+                        return
+                    }
+
                     guard let createdAt = Time.dateFromISOString(folderMeta.createdAt) else {
                         self.logger.error("Cannot create createdAt date for folder \(folderMeta.id) with value \(folderMeta.createdAt)")
                         throw GetFileOrFolderMetaUseCaseError.InvalidCreatedAt
@@ -120,6 +132,9 @@ struct GetFileOrFolderMetaWorkspaceUseCase {
                 if (itemFound == true){ return }
                 // If we reached this, there was no way to found the file/folder
                 throw GetFileOrFolderMetaUseCaseError.FileOrFolderMetaNotFound
+            } catch GetFileOrFolderMetaUseCaseError.FileOrFolderMetaNotFound {
+                self.logger.info("Item \(identifier.rawValue) was not found on the server, signaling nonExistentItem to stop retries")
+                completionHandler(nil, NSError.fileProviderErrorForNonExistentItem(withIdentifier: identifier))
             } catch {
                 error.reportToSentry()
                 self.logger.error("❌ Failed to get folder meta for \(identifier.rawValue): \(error.getErrorDescription())")

--- a/SyncExtension/UseCases/All/Workspaces/GetFileOrFolderMetaWorkspaceUseCase.swift
+++ b/SyncExtension/UseCases/All/Workspaces/GetFileOrFolderMetaWorkspaceUseCase.swift
@@ -41,8 +41,8 @@ struct GetFileOrFolderMetaWorkspaceUseCase {
                 let rootFolderUuid = workspace[0].workspaceUser.rootFolderId
                
                 if let fileMeta = await self.getFileMetaOrNil(maybeFileUuid: self.identifier.rawValue) {
-                    if fileMeta.status != "EXISTS" || fileMeta.deleted == true || fileMeta.removed == true  {
-                        self.logger.info("❌ Workspace File (id: \(self.identifier.rawValue)) is \(fileMeta.status) / deleted, returning nonExistentItem")
+                    if fileMeta.status != "EXISTS" {
+                        self.logger.info("❌ Workspace File (id: \(self.identifier.rawValue)) is \(fileMeta.status), returning nonExistentItem")
                         completionHandler(nil, NSError.fileProviderErrorForNonExistentItem(withIdentifier: self.identifier))
                         return
                     }


### PR DESCRIPTION
This PR fixes an issue where files previously deleted/trashed (e.g. from the Web app) would reappear in Finder after creating or uploading a new file into the same folder from the macOS desktop app.

When a new file is uploaded or created, macOS FileProvider reconciles the parent directory and queries metadata for known container items via `item(for:request:completionHandler:)`. 
`GetFileOrFolderMetaUseCase` queried the backend endpoint (`getFileMetaByUuidV2`), which still returns the record with `status: "TRASHED"`. Because `GetFileOrFolderMetaUseCase` did not validate `fileMeta.status` or deletion flags, it constructed and returned an active `FileProviderItem` to macOS instead of signaling `fileProviderErrorForNonExistentItem`. Consequently, macOS restored the trashed items into the Finder view.

