### PR TITLE
fix: retry folder creation with exponential backoff on parent folder 404

### DIFF
--- a/XPCBackupService/Services/BackupUploadService.swift
+++ b/XPCBackupService/Services/BackupUploadService.swift
@@ -162,7 +162,7 @@ class BackupUploadService:  BackupUploadServiceProtocol, ObservableObject {
     
 
 
-    private func syncNodeFolder(node: BackupTreeNode) async -> Result<BackupTreeNodeSyncResult, Error> {
+    private func syncNodeFolder(node: BackupTreeNode, retryCount: Int = 0) async -> Result<BackupTreeNodeSyncResult, Error> {
         self.logger.info("Creating folder")
 
         guard let nodeURL = node.url else {
@@ -228,7 +228,21 @@ class BackupUploadService:  BackupUploadServiceProtocol, ObservableObject {
             self.logger.error("❌ Failed to create folder: \(error.getErrorDescription())")
 
             if let apiClientError = error as? APIClientError, apiClientError.statusCode == 404 {
-                self.logger.error("❌ Folder parent \(safeRemoteParentId) not found in server . Deleting local reference from Realm")
+                if retryCount < 3 && self.canDoBackup && !Task.isCancelled {
+                    let delaySeconds = pow(2.0, Double(retryCount)) * 0.5
+                    self.logger.warning("⏳ Folder parent \(safeRemoteParentId) not found yet (404), retrying in \(delaySeconds)s (attempt \(retryCount + 1)/3)...")
+                    do {
+                        try await Task.sleep(nanoseconds: UInt64(delaySeconds * 1_000_000_000))
+                    } catch {
+                        return .failure(BackupUploadError.BackupStoppedManually)
+                    }
+                    guard self.canDoBackup && !Task.isCancelled else {
+                        return .failure(BackupUploadError.BackupStoppedManually)
+                    }
+                    return await self.syncNodeFolder(node: node, retryCount: retryCount + 1)
+                }
+
+                self.logger.error("❌ Folder parent \(safeRemoteParentId) not found in server after \(retryCount) retries. Deleting local reference from Realm")
                 try? await SyncedNodeRepository.shared.deleteSyncedNodeByRemoteIdAsync(remoteId: safeRemoteParentId)
                 return .failure(BackupUploadError.MissingParentFolder)
             }


### PR DESCRIPTION
## Description
During backups of directory trees with multiple levels, child folders are dispatched for creation immediately (~13–50 ms) after their parent folder is created. Due to eventual consistency and replication lag across server API nodes, the server intermittently returns:
`404 Parent folder does not exist`
Log analysis confirms that the parent folder **was indeed valid and created on the server**: just milliseconds later, other subfolders and files inside that exact same parent folder were created successfully (200 OK). However, because the client treated the initial 404 as an unrecoverable fatal error, it immediately deleted the parent reference from Realm and aborted the failed folder branch, causing hundreds of descendant files and folders to never be backed up.
This PR introduces an exponential backoff retry mechanism (up to 3 retries: 0.5s, 1s, 2s) in `syncNodeFolder` when receiving an `APIClientError` with `statusCode == 404`. Only if all retries are exhausted does it delete the Realm reference and mark the folder as permanently failed.
## Changes Made
- **`BackupUploadService.swift`**:
  - Added `retryCount: Int = 0` parameter to `syncNodeFolder`.
  - Added exponential backoff retry logic (0.5s, 1s, 2s) when catching `APIClientError` with `statusCode == 404`.
  - Added task cancellation and backup status check (`canDoBackup`) between retries.
  - Deferred local Realm deletion of the parent until all retries are exhausted.